### PR TITLE
Correct connection options and documentation for gossip

### DIFF
--- a/Samples/Store/Integration/Infrastructure.fs
+++ b/Samples/Store/Integration/Infrastructure.fs
@@ -58,6 +58,5 @@ open Foldunk.EventStore
 
 let cfg = GesConnectionBuilder(operationTimeout = TimeSpan.FromSeconds 1., operationRetryLimit = 3, requireMaster = true, log = GesLog.Debug)
 let connectToLocalEventStoreNode () = cfg.ConnectWithGossip("localhost", "admin", "changeit")
-//let connectToLocalEventStoreNode () = cfg.ConnectLoopback("admin", "changeit")
 let defaultBatchSize = 500
 let createGesGateway connection batchSize = GesGateway(connection, GesBatchingPolicy(maxBatchSize = batchSize))

--- a/tests/Foldunk.EventStore.Integration/EventStoreIntegration.fs
+++ b/tests/Foldunk.EventStore.Integration/EventStoreIntegration.fs
@@ -7,7 +7,6 @@ open System
 
 let cfg = GesConnectionBuilder(operationTimeout = TimeSpan.FromSeconds 1., operationRetryLimit = 3, requireMaster = true, log= GesLog.Debug)
 let connectToLocalEventStoreNode () = cfg.ConnectWithGossip("localhost", "admin", "changeit")
-//let connectToLocalEventStoreNode () = cfg.ConnectLoopback("admin", "changeit")
 let defaultBatchSize = 500
 let createGesGateway connection batchSize = GesGateway(connection, GesBatchingPolicy(maxBatchSize = batchSize))
 


### PR DESCRIPTION
~Turns out that the oss version has "manager nodes" built into the normal nodes, and they run their metadata endpoint on the default port `2113` (while the actual gossip protocol happens on `30778`)~

~For a production-ready version of this we need some kind of DNS, port resolution for connecting to manager nodes as they come up and down.~

---

This line seems to be at the crux of the difference between the OSS and CS versions:

> For database nodes to have this information available to them, the nodes gossip with other nodes in the cluster. Gossip runs over the internal (and optionally the external) HTTP interfaces of database nodes, and over both internal and external interfaces of manager nodes.
- https://eventstore.org/docs/server/cluster-with-manager-nodes/

With that in mind - should just make the OSS version run on `30778` to make everything simple
