### PR TITLE
Fix UnionEncoder Null handling

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -26,4 +26,4 @@ nuget TypeShape
 group build
     source https://api.nuget.org/v3/index.json
 
-    nuget FAKE prerelease
+    nuget FAKE

--- a/paket.lock
+++ b/paket.lock
@@ -48,4 +48,4 @@ NUGET
 GROUP build
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    FAKE (5.1)
+    FAKE (5.3)

--- a/tests/Foldunk.LoadTests/Foldunk.LoadTests.fsproj
+++ b/tests/Foldunk.LoadTests/Foldunk.LoadTests.fsproj
@@ -78,10 +78,6 @@
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Samples\Store\Backend\Backend.fsproj">

--- a/tests/Foldunk.Serialization.Tests/Foldunk.Serialization.Tests.fsproj
+++ b/tests/Foldunk.Serialization.Tests/Foldunk.Serialization.Tests.fsproj
@@ -9,7 +9,7 @@
     <ProjectGuid>1d9d5e23-683d-497f-bfa2-fbb43bb81205</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>Foldunk.Serialization.Tests</RootNamespace>
-    <AssemblyName>Foldunk.EventSum.Tests</AssemblyName>
+    <AssemblyName>Foldunk.Serialization.Tests</AssemblyName>
     <UseStandardResourceNames>true</UseStandardResourceNames>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.4.1.0</TargetFSharpCoreVersion>
@@ -86,6 +86,28 @@
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="FsCheck">
+          <HintPath>..\..\packages\FsCheck\lib\net452\FsCheck.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="FsCheck.Xunit">
+          <HintPath>..\..\packages\FsCheck.Xunit\lib\net452\FsCheck.Xunit.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.6.1')">
       <ItemGroup>

--- a/tests/Foldunk.Serialization.Tests/SerializationTests.fs
+++ b/tests/Foldunk.Serialization.Tests/SerializationTests.fs
@@ -3,6 +3,7 @@
 open Foldunk.Serialization
 open Newtonsoft.Json
 open Swensen.Unquote.Assertions
+open System
 open System.IO
 open System.Text.RegularExpressions
 open Xunit
@@ -43,104 +44,134 @@ let ``UnionConverter produces expected output`` () =
     let a = CaseA {test = "hi"}
     let aJson = JsonConvert.SerializeObject(a, settings)
 
-    test <@ "{\"case\":\"CaseA\",\"test\":\"hi\"}" = aJson @>
+    test <@ """{"case":"CaseA","test":"hi"}""" = aJson @>
 
     let b = CaseB
     let bJson = JsonConvert.SerializeObject(b, settings)
 
-    test <@ "{\"case\":\"CaseB\"}" = bJson @>
+    test <@ """{"case":"CaseB"}""" = bJson @>
 
     let c = CaseC "hi"
     let cJson = JsonConvert.SerializeObject(c, settings)
 
-    test <@ "{\"case\":\"CaseC\",\"Item\":\"hi\"}" = cJson @>
+    test <@ """{"case":"CaseC","Item":"hi"}""" = cJson @>
 
     let d = CaseD "hi"
     let dJson = JsonConvert.SerializeObject(d, settings)
 
-    test <@ "{\"case\":\"CaseD\",\"a\":\"hi\"}" = dJson @>
+    test <@ """{"case":"CaseD","a":"hi"}""" = dJson @>
 
     let e = CaseE ("hi", 0)
     let eJson = JsonConvert.SerializeObject(e, settings)
 
-    test <@ "{\"case\":\"CaseE\",\"Item1\":\"hi\",\"Item2\":0}" = eJson @>
+    test <@ """{"case":"CaseE","Item1":"hi","Item2":0}""" = eJson @>
 
     let f = CaseF ("hi", 0)
     let fJson = JsonConvert.SerializeObject(f, settings)
 
-    test <@ "{\"case\":\"CaseF\",\"a\":\"hi\",\"b\":0}" = fJson @>
+    test <@ """{"case":"CaseF","a":"hi","b":0}""" = fJson @>
 
     let g = CaseG {Item = "hi"}
     let gJson = JsonConvert.SerializeObject(g, settings)
 
-    test <@ "{\"case\":\"CaseG\",\"Item\":\"hi\"}" = gJson @>
+    test <@ """{"case":"CaseG","Item":"hi"}""" = gJson @>
 
     // this may not be expected, but I don't itend changing it
     let h = CaseH {test = "hi"}
     let hJson = JsonConvert.SerializeObject(h, settings)
 
-    test <@ "{\"case\":\"CaseH\",\"test\":\"hi\"}" = hJson @>
+    test <@ """{"case":"CaseH","test":"hi"}""" = hJson @>
 
     let i = CaseI ({test = "hi"}, "bye")
     let iJson = JsonConvert.SerializeObject(i, settings)
 
-    test <@ "{\"case\":\"CaseI\",\"a\":{\"test\":\"hi\"},\"b\":\"bye\"}" = iJson @>
+    test <@ """{"case":"CaseI","a":{"test":"hi"},"b":"bye"}""" = iJson @>
 
 [<Fact>]
 let ``UnionConverter deserializes properly`` () =
-    let aJson = "{\"case\":\"CaseA\",\"test\":\"hi\"}"
+    let aJson = """{"case":"CaseA","test":"hi"}"""
     let a = JsonConvert.DeserializeObject<TestDU>(aJson, settings)
 
     test <@ CaseA {test = "hi"} = a @>
 
-    let bJson = "{\"case\":\"CaseB\"}"
+    let bJson = """{"case":"CaseB"}"""
     let b = JsonConvert.DeserializeObject<TestDU>(bJson, settings)
 
     test <@ CaseB = b @>
 
-    let cJson = "{\"case\":\"CaseC\",\"Item\":\"hi\"}"
+    let cJson = """{"case":"CaseC","Item":"hi"}"""
     let c = JsonConvert.DeserializeObject<TestDU>(cJson, settings)
 
     test <@ CaseC "hi" = c @>
 
-    let dJson = "{\"case\":\"CaseD\",\"a\":\"hi\"}"
+    let dJson = """{"case":"CaseD","a":"hi"}"""
     let d = JsonConvert.DeserializeObject<TestDU>(dJson, settings)
 
     test <@ CaseD "hi" = d @>
 
-    let eJson = "{\"case\":\"CaseE\",\"Item1\":\"hi\",\"Item2\":0}"
+    let eJson = """{"case":"CaseE","Item1":"hi","Item2":0}"""
     let e = JsonConvert.DeserializeObject<TestDU>(eJson, settings)
 
     test <@ CaseE ("hi", 0) = e @>
 
-    let fJson = "{\"case\":\"CaseF\",\"a\":\"hi\",\"b\":0}"
+    let fJson = """{"case":"CaseF","a":"hi","b":0}"""
     let f = JsonConvert.DeserializeObject<TestDU>(fJson, settings)
 
     test <@ CaseF ("hi", 0) = f @>
 
-    let gJson = "{\"case\":\"CaseG\",\"Item\":\"hi\"}"
+    let gJson = """{"case":"CaseG","Item":"hi"}"""
     let g = JsonConvert.DeserializeObject<TestDU>(gJson, settings)
 
     test <@ CaseG {Item = "hi"} = g @>
 
-    let hJson = "{\"case\":\"CaseH\",\"test\":\"hi\"}"
+    let hJson = """{"case":"CaseH","test":"hi"}"""
     let h = JsonConvert.DeserializeObject<TestDU>(hJson, settings)
 
     test <@ CaseH {test = "hi"} = h @>
 
-    let iJson = "{\"case\":\"CaseI\",\"a\":{\"test\":\"hi\"},\"b\":\"bye\"}"
+    let iJson = """{"case":"CaseI","a":{"test":"hi"},"b":"bye"}"""
     let i = JsonConvert.DeserializeObject<TestDU>(iJson, settings)
 
     test <@ CaseI ({test = "hi"}, "bye") = i @>
 
+
+let (|Q|) (s : string) = Newtonsoft.Json.JsonConvert.SerializeObject s
+
+let render = function
+    | CaseA { test = null } -> """{"case":"CaseA"}"""
+    | CaseA { test = Q x} -> sprintf """{"case":"CaseA","test":%s}""" x
+    | CaseB -> """{"case":"CaseB"}"""
+    | CaseC null -> """{"case":"CaseC"}"""
+    | CaseC (Q s) -> sprintf """{"case":"CaseC","Item":%s}""" s
+    | CaseD null -> """{"case":"CaseD"}"""
+    | CaseD (Q s) -> sprintf """{"case":"CaseD","a":%s}""" s
+    | CaseE (null,y) -> sprintf """{"case":"CaseE","Item2":%d}""" y
+    | CaseE (Q x,y) -> sprintf """{"case":"CaseE","Item1":%s,"Item2":%d}""" x y
+    | CaseF (null,y) -> sprintf """{"case":"CaseF","b":%d}""" y
+    | CaseF (Q x,y) -> sprintf """{"case":"CaseF","a":%s,"b":%d}""" x y
+    | CaseG {Item = null} -> """{"case":"CaseG"}"""
+    | CaseG {Item = Q s} -> sprintf """{"case":"CaseG","Item":%s}""" s
+    | CaseH {test = null} -> """{"case":"CaseH"}"""
+    | CaseH {test = Q s} -> sprintf """{"case":"CaseH","test":%s}""" s
+    | CaseI ({test = null}, null) -> """{"case":"CaseI","a":{}}"""
+    | CaseI ({test = null}, Q s) -> sprintf """{"case":"CaseI","a":{},"b":%s}""" s
+    | CaseI ({test = Q s}, null) -> sprintf """{"case":"CaseI","a":{"test":%s}}""" s
+    | CaseI ({test = Q s}, Q b) -> sprintf """{"case":"CaseI","a":{"test":%s},"b":%s}""" s b
+
+[<FsCheck.Xunit.Property(MaxTest=1000)>]
+let ``UnionConverter roundtrip property test`` (x: TestDU) =
+    let serialized = JsonConvert.SerializeObject(x, settings)
+    render x =! serialized
+    let deserialized = JsonConvert.DeserializeObject<_>(serialized, settings)
+    deserialized =! x
+
 [<Fact>]
 let ``UnionConverter's exception catch doesn't make the model invalid`` () =
-
     let s = JsonSerializer.CreateDefault()
     let mutable gotError = false
     s.Error.Add(fun _ -> gotError <- true)
 
-    let dJson = "{\"case\":\"CaseD\",\"a\":\"hi\"}"
+    let dJson = """{"case":"CaseD","a":"hi"}"""
     use dReader = new StringReader(dJson)
     use dJsonReader = new JsonTextReader(dReader)
     let d = s.Deserialize<TestDU>(dJsonReader)
@@ -150,7 +181,7 @@ let ``UnionConverter's exception catch doesn't make the model invalid`` () =
 
 [<Fact>]
 let ``UnionConverter by default throws on unknown cases`` () =
-    let aJson = "{\"case\":\"CaseUnknown\"}"
+    let aJson = """{"case":"CaseUnknown"}"""
     let act () = JsonConvert.DeserializeObject<TestDU>(aJson, settings)
 
     fun (e : System.InvalidOperationException) -> <@ -1 <> e.Message.IndexOf "No case defined for 'CaseUnknown', and no catchAllCase nominated" @>
@@ -163,7 +194,7 @@ type DuWithCatchAll =
 
 [<Fact>]
 let ``UnionConverter supports a nominated catchall`` () =
-    let aJson = "{\"case\":\"CaseUnknown\"}"
+    let aJson = """{"case":"CaseUnknown"}"""
     let a = JsonConvert.DeserializeObject<DuWithCatchAll>(aJson, settings)
 
     test <@ Catchall = a @>
@@ -174,8 +205,8 @@ type DuWithMissingCatchAll =
 
 [<Fact>]
 let ``UnionConverter explains if nominated catchAll not found`` () =
-    let aJson = "{\"case\":\"CaseUnknown\"}"
+    let aJson = """{"case":"CaseUnknown"}"""
     let act () = JsonConvert.DeserializeObject<DuWithMissingCatchAll>(aJson, settings)
 
     fun (e : System.InvalidOperationException) -> <@ -1 <> e.Message.IndexOf "nominated catchAllCase: 'CatchAllThatCantBeFound' not found" @>
-    |> raisesWith <@ act() @> 
+    |> raisesWith <@ act() @>

--- a/tests/Foldunk.Serialization.Tests/paket.references
+++ b/tests/Foldunk.Serialization.Tests/paket.references
@@ -1,4 +1,5 @@
-﻿nuget FSharp.Core redirects: force
+﻿nuget FsCheck.Xunit
+nuget FSharp.Core redirects: force
 nuget Newtonsoft.json
 nuget Serilog
 nuget TypeShape


### PR DESCRIPTION
Prequel to #29 with a property-based test for sample cases - leading to more thorough `null` handling