### PR TITLE
Add JObject capture support for UnionConverter

### DIFF
--- a/src/Foldunk.Serialization/Serialization.fs
+++ b/src/Foldunk.Serialization/Serialization.fs
@@ -137,14 +137,29 @@ module Converters =
                 else FSharpValue.MakeUnion(cases.[1], [|value|])
 
     let typeHasJsonConverterAttribute = memoize (fun (t : Type) -> t.IsDefined(typeof<JsonConverterAttribute>))
+    let propTypeRequiresConstruction (propertyType : Type) =
+        not (Union.isInlinedIntoUnionItem propertyType)
+        && not (typeHasJsonConverterAttribute propertyType)
 
-    (* Serializes a discriminated union case with a single field that is a record by flattening the
-       record fields to the same level as the discriminator *)
+    /// Prepare arguments for the Case class ctor based on the kind of case and how F# maps that to a Type
+    /// and/or whether we need to let json.net step in to convert argument types
+    let mapTargetCaseArgs (inputJObject : JObject) jsonSerializer : PropertyInfo[] -> obj [] = function
+        | [| singleCaseArg |] when propTypeRequiresConstruction singleCaseArg.PropertyType ->
+            [| inputJObject.ToObject(singleCaseArg.PropertyType, jsonSerializer) |]
+        | multipleFieldsInCustomCaseType ->
+            [| for fi in multipleFieldsInCustomCaseType ->
+                match inputJObject.[fi.Name] with
+                | null -> null
+                | itemValue -> itemValue.ToObject(fi.PropertyType, jsonSerializer) |]
+
+    /// Serializes a discriminated union case with a single field that is a
+    /// record by flattening the record fields to the same level as the discriminator
     type UnionConverter private (discriminator : string, ?catchAllCase) =
         inherit JsonConverter()
 
         new(discriminator: string, catchAllCase: string) = UnionConverter(discriminator, ?catchAllCase=Option.ofObj catchAllCase)
         new() = UnionConverter("case")
+
         override __.CanConvert (t: Type) = Union.isUnion t
 
         override __.WriteJson(writer: JsonWriter, value: obj, jsonSerializer: JsonSerializer) =
@@ -183,49 +198,27 @@ module Converters =
             writer.WriteEndObject()
 
         override __.ReadJson(reader: JsonReader, t: Type, _: obj, jsonSerializer: JsonSerializer) =
-            let union = Union.getUnion t
-            let cases = union.cases
-
             let token = JToken.ReadFrom reader
-            if token.Type <> JTokenType.Object then raise <| new FormatException(sprintf "Expected object reading JSON, got %O" token.Type)
-            let obj = token :?> JObject
+            if token.Type <> JTokenType.Object then raise (FormatException(sprintf "Expected object token, got %O" token.Type))
+            let inputJObject = token :?> JObject
 
-            let caseName = obj.[discriminator] |> string
-            let foundTag = cases |> Array.tryFindIndex (fun case -> case.Name = caseName)
-            let tag =
-                match foundTag, catchAllCase with
-                | Some tag, _ -> tag
+            let union = Union.getUnion t
+            let targetCaseIndex =
+                let inputCaseNameValue = inputJObject.[discriminator] |> string
+                let findCaseNamed x = union.cases |> Array.tryFindIndex (fun case -> case.Name = x)
+                match findCaseNamed inputCaseNameValue, catchAllCase  with
+                | None, None ->
+                    sprintf "No case defined for '%s', and no catchAllCase nominated for '%s' on type '%s'"
+                        inputCaseNameValue typeof<UnionConverter>.Name t.FullName |> invalidOp
+                | Some foundIndex, _ -> foundIndex
                 | None, Some catchAllCaseName ->
-                    match cases |> Array.tryFindIndex (fun case -> case.Name = catchAllCaseName) with
-                    | None -> invalidOp (sprintf "No case defined for '%s', nominated catchAllCase: '%s' not found in type '%s'" caseName catchAllCaseName t.FullName)
-                    | Some tag -> tag
-                | None, None -> invalidOp (sprintf "No case defined for '%s', and no catchAllCase nominated for '%s' on type '%s'" caseName typeof<UnionConverter>.Name t.FullName)
-            let case = cases.[tag]
-            let fieldInfos = case.GetFields()
-
-            let fieldValues =
-                if fieldInfos.Length = 1
-                    && not (Union.isInlinedIntoUnionItem fieldInfos.[0].PropertyType)
-                    && not (typeHasJsonConverterAttribute fieldInfos.[0].PropertyType) then
-                    let fieldInfo = fieldInfos.[0]
-                    // strip out the discriminator property as we're preparing args for a constructor
-                    let obj' =
-                        obj.Children()
-                        |> Seq.filter (function
-                            | :? JProperty as prop when prop.Name = discriminator -> false
-                            | _ -> true
-                        )
-                        |> Array.ofSeq
-                        |> JObject
-                    [| obj'.ToObject(fieldInfo.PropertyType, jsonSerializer) |]
-                else
-                    let simpleFieldValue (fieldInfo: PropertyInfo) =
-                        let itemValue = obj.[fieldInfo.Name]
-                        if itemValue = null then null
-                        else itemValue.ToObject(fieldInfo.PropertyType, jsonSerializer)
-                    fieldInfos |> Array.map simpleFieldValue
-
-            union.caseConstructor.[tag] fieldValues
+                    match findCaseNamed catchAllCaseName with
+                    | None ->
+                        sprintf "No case defined for '%s', nominated catchAllCase: '%s' not found in type '%s'"
+                            inputCaseNameValue catchAllCaseName t.FullName |> invalidOp
+                    | Some foundIndex -> foundIndex
+            let targetCaseFields, targetCaseCtor = union.cases.[targetCaseIndex].GetFields(), union.caseConstructor.[targetCaseIndex]
+            targetCaseCtor (mapTargetCaseArgs inputJObject jsonSerializer targetCaseFields)
 
 type Settings private () =
     /// <summary>


### PR DESCRIPTION
This, addresssing #22 provides an affordance in the `UnionConverter` that allows one to trap an unknown Union case as a `JObject` in order to do things such as:
- providing warnings when dropping events
- post-processing when doing multiple runs across a stream bearing cases from two disjunct unions

As a side-effect, this also clean up how we match inputs with union case inputs