### PR TITLE
Tidy ES rolling snapshots and builder

### DIFF
--- a/cli/Equinox.Cli/Equinox.Cli.fsproj
+++ b/cli/Equinox.Cli/Equinox.Cli.fsproj
@@ -8,6 +8,9 @@
     <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
+
+    <!-- workaround for not being able to make Backend and Domain as inlined in a complete way https://github.com/nuget/home/issues/3891#issuecomment-377319939 -->
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,11 +24,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- workaround for not being able to make Backend and Domain as inlined in a complete way https://github.com/nuget/home/issues/3891#issuecomment-377319939 -->
     <ProjectReference Include="..\..\src\Equinox.MemoryStore\Equinox.MemoryStore.fsproj" PrivateAssets="all" />
     <ProjectReference Include="..\..\samples\Store\Backend\Backend.fsproj" PrivateAssets="all" />
     <ProjectReference Include="..\..\samples\Store\Domain\Domain.fsproj" PrivateAssets="all" />
     <ProjectReference Include="..\..\src\Equinox.EventStore\Equinox.EventStore.fsproj" />
-    <ProjectReference Include="..\..\src\Equinox.Codec\Equinox.Codec.fsproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -44,14 +47,9 @@
   </ItemGroup>
 
   <!-- workaround for not being able to make Backend and Domain as inlined in a complete way https://github.com/nuget/home/issues/3891#issuecomment-377319939 -->
-  <PropertyGroup>
-    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeNonPackagedDlls</TargetsForTfmSpecificBuildOutput>
-  </PropertyGroup>
-  <Target Name="IncludeNonPackagedDlls">
+  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">
     <ItemGroup>
-      <BuildOutputInPackage Include="$(MSBuildProjectDirectory)/$(OutputPath)Backend.dll" />
-      <BuildOutputInPackage Include="$(MSBuildProjectDirectory)/$(OutputPath)Domain.dll" />
-      <BuildOutputInPackage Include="$(MSBuildProjectDirectory)/$(OutputPath)Equinox.MemoryStore.dll" />
+      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
     </ItemGroup>
   </Target>
 

--- a/samples/Store/Domain/Favorites.fs
+++ b/samples/Store/Domain/Favorites.fs
@@ -5,12 +5,10 @@ module Events =
     type Favorited =                            { date: System.DateTimeOffset; skuId: SkuId }
     type Unfavorited =                          { skuId: SkuId }
     module Compaction =
-        let [<Literal>] EventType = "compacted/1"
         type Compacted =                        { net: Favorited[] }
 
     type Event =
-        | [<System.Runtime.Serialization.DataMember(Name = Compaction.EventType)>]
-          Compacted                             of Compaction.Compacted
+        | Compacted                             of Compaction.Compacted
         | Favorited                             of Favorited
         | Unfavorited                           of Unfavorited
         interface TypeShape.UnionContract.IUnionContract
@@ -37,7 +35,8 @@ module Folds =
         let s = InternalState state
         for e in events do evolve s e
         s.AsState()
-    let compact = Events.Compaction.EventType, fun state -> Events.Compacted { net = state }
+    let isOrigin = function Events.Compacted _ -> true | _ -> false
+    let snapshot = isOrigin, fun state -> Events.Compacted { net = state }
 
 type Command =
     | Favorite      of date : System.DateTimeOffset * skuIds : SkuId list

--- a/samples/Store/Integration/FavoritesIntegration.fs
+++ b/samples/Store/Integration/FavoritesIntegration.fs
@@ -6,7 +6,7 @@ open Swensen.Unquote
 
 #nowarn "1182" // From hereon in, we may have some 'unused' privates (the tests)
 
-let fold, initial, compact = Domain.Favorites.Folds.fold, Domain.Favorites.Folds.initial, Domain.Favorites.Folds.compact
+let fold, initial, snapshot = Domain.Favorites.Folds.fold, Domain.Favorites.Folds.initial, Domain.Favorites.Folds.snapshot
 
 let createMemoryStore () =
     new VolatileStore()
@@ -15,7 +15,8 @@ let createServiceMem log store =
 
 let codec = genCodec<Domain.Favorites.Events.Event>()
 let createServiceGes gateway log =
-    Backend.Favorites.Service(log, GesStreamBuilder(gateway, codec, fold, initial, Equinox.EventStore.AccessStrategy.RollingSnapshots compact).Create)
+    let resolveStream = GesStreamBuilder(gateway, codec, fold, initial, AccessStrategy.RollingSnapshots snapshot).Create
+    Backend.Favorites.Service(log, resolveStream)
 
 type Tests(testOutputHelper) =
     let testOutput = TestOutputAdapter testOutputHelper

--- a/src/Equinox.MemoryStore/MemoryStore.fs
+++ b/src/Equinox.MemoryStore/MemoryStore.fs
@@ -79,7 +79,7 @@ type MemoryCategory<'event, 'state>(store : VolatileStore, fold, initial) =
             match store.TryLoad<'event> streamName log with
             | None -> return Token.ofEmpty streamName initial
             | Some events -> return Token.ofEventArray streamName fold initial events }
-        member __.TrySync (log : ILogger) (Token.Unpack token, state) (events : 'event list, _state': 'state) = async {
+        member __.TrySync (log : ILogger) (Token.Unpack token, state) (events : 'event list) = async {
             let trySyncValue currentValue =
                 if Array.length currentValue <> token.streamVersion + 1 then ConcurrentDictionarySyncResult.Conflict (token.streamVersion)
                 else ConcurrentDictionarySyncResult.Written (Seq.append currentValue events)


### PR DESCRIPTION
This is a cherry-pick from #42, which finesses the way in which one defines rolling snapshots when using `Equinox.EventStore` in order to unify to the maximum degree possible with how one will specify the equivalent rules in `Equinox.Cosmos` (see `unfolds` in #50)