### PR TITLE
Unify Tip vs Batch formats

### DIFF
--- a/tests/Equinox.Cosmos.Integration/CosmosCoreIntegration.fs
+++ b/tests/Equinox.Cosmos.Integration/CosmosCoreIntegration.fs
@@ -176,7 +176,7 @@ type Tests(testOutputHelper) =
         let! res = Events.append ctx streamName 0L expected
         test <@ AppendResult.Ok 1L = res @>
         test <@ [EqxAct.Append] = capture.ExternalCalls @>
-        verifyRequestChargesMax 12 // was 10, observed 10.57
+        verifyRequestChargesMax 14 // observed 12.73 // was 10
         capture.Clear()
 
         // Try overwriting it (a competing consumer would see the same)

--- a/tests/Equinox.Cosmos.Integration/JsonConverterTests.fs
+++ b/tests/Equinox.Cosmos.Integration/JsonConverterTests.fs
@@ -21,12 +21,9 @@ type VerbatimUtf8Tests() =
     [<Fact>]
     let ``encodes correctly`` () =
         let encoded = mkUnionEncoder().Encode(A { embed = "\"" })
-        let e : Store.Event =
-            {   p = "streamName"; id = string 0; i = 0L; _etag=null
-                c = DateTimeOffset.MinValue
-                t = encoded.caseName
-                d = encoded.payload
-                m = null }
+        let e : Store.Batch =
+            {   p = "streamName"; id = string 0; i = 0L; _i = 0L; _etag = null
+                e = [| { t = DateTimeOffset.MinValue; c = encoded.caseName; d = encoded.payload; m = null } |] }
         let res = JsonConvert.SerializeObject(e)
         test <@ res.Contains """"d":{"embed":"\""}""" @>
 
@@ -38,7 +35,7 @@ type Base64ZipUtf8Tests() =
         let encoded = unionEncoder.Encode(A { embed = String('x',5000) })
         let e : Store.Unfold =
             {   i = 42L
-                t = encoded.caseName
+                c = encoded.caseName
                 d = encoded.payload
                 m = null }
         let res = JsonConvert.SerializeObject e
@@ -55,12 +52,12 @@ type Base64ZipUtf8Tests() =
         let encoded = unionEncoder.Encode value
         let e : Store.Unfold =
             {   i = 42L
-                t = encoded.caseName
+                c = encoded.caseName
                 d = encoded.payload
                 m = null }
         let ser = JsonConvert.SerializeObject(e)
         test <@ ser.Contains("\"d\":\"") @>
         let des = JsonConvert.DeserializeObject<Store.Unfold>(ser)
-        let d : Equinox.UnionCodec.EncodedUnion<_> = { caseName = des.t; payload = des.d }
+        let d : Equinox.UnionCodec.EncodedUnion<_> = { caseName = des.c; payload = des.d }
         let decoded = unionEncoder.Decode d
         test <@ value = decoded @>


### PR DESCRIPTION
This consists of two elements, as described in #50:
- Move all events into `e` arrays
- take advantage of the reduction of clashing names to apply the following renames:
    - `c`ompaction events -> `u`nfolds
   - `c`reation date/time -> `t`
   - unfold/domain event union case/event type (was `et`, presently `t`): `t` -> `c`(ase)

There is some ugliness that drops off in #48 if we adopt this too