### PR TITLE
Equinox cli as .net tool package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,8 @@
     <PackageLicenseUrl>https://github.com/jet/equinox/blob/master/LICENSE</PackageLicenseUrl>
     <Copyright>Copyright © 2016-8</Copyright>
 
+    <RepoDir>$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory)"))</RepoDir>
+
     <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
 
     <!-- SourceLink related properties https://github.com/dotnet/SourceLink#using-sourcelink -->

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
       VersionSuffix: '$(VersionSuffix)'
   - task: PublishBuildArtifacts@1
     inputs:
-      pathtoPublish: 'bin'
+      pathtoPublish: 'bin/nupkg'
       artifactName: 'nupkgs'
   - task: NuGetCommand@2
     inputs:
@@ -39,7 +39,7 @@ jobs:
       publishFeedCredentials: 'Jet-MyGet'
       versioningScheme: byEnvVar
       versionEnvVar: Version
-      packagesToPush: 'bin/*.nupkg;bin/*.symbols.nupkg'
+      packagesToPush: 'bin/nupkg/*.nupkg'
 
 - job: Linux
   pool:

--- a/build.proj
+++ b/build.proj
@@ -6,7 +6,7 @@
     <Cfg>--configuration Release</Cfg>
 
     <ThisDirAbsolute>$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory)"))</ThisDirAbsolute>
-    <PackOptions>-o $(ThisDirAbsolute)bin --version-suffix "$(VersionSuffix)"</PackOptions>
+    <PackOptions>-o $(ThisDirAbsolute)bin/nupkg --version-suffix "$(VersionSuffix)"</PackOptions>
 
     <TestOptions>--logger:trx</TestOptions>
     <!-- disable known test failures on mono -->

--- a/build.proj
+++ b/build.proj
@@ -14,7 +14,8 @@
   </PropertyGroup>
 
   <Target Name="Pack">
-    <Exec Command="dotnet pack cli/Equinox.Cli $(Cfg) $(PackOptions)" />
+    <Exec Command='dotnet publish cli/Equinox.Cli $(Cfg) -f net461 -o "$(RepoDir)/bin/equinox-cli/net461" ' />
+    <Exec Command="dotnet pack cli/Equinox.Cli $(Cfg) $(PackOptions) /p:PackAsTool=true" />
     <Exec Command="dotnet pack src/Equinox $(Cfg) $(PackOptions)" />
     <Exec Command="dotnet pack src/Equinox.Codec $(Cfg) $(PackOptions)" />
     <Exec Command="dotnet pack src/Equinox.EventStore $(Cfg) $(PackOptions)" />

--- a/cli/Equinox.Cli/Equinox.Cli.fsproj
+++ b/cli/Equinox.Cli/Equinox.Cli.fsproj
@@ -9,6 +9,8 @@
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
 
+    <AssemblyName>eqx</AssemblyName>
+
     <!-- workaround for not being able to make Backend and Domain as inlined in a complete way https://github.com/nuget/home/issues/3891#issuecomment-377319939 -->
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>

--- a/cli/Equinox.Cli/Equinox.Cli.fsproj
+++ b/cli/Equinox.Cli/Equinox.Cli.fsproj
@@ -46,6 +46,20 @@
     <PackageReference Include="System.Reactive" Version="4.0.0" />
   </ItemGroup>
 
+  <!-- bundle the net461 exe inside the .net core tool package -->
+  <PropertyGroup Condition=" '$(PackAsTool)' == 'true' ">
+    <TargetFrameworks></TargetFrameworks>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(PackAsTool)' == 'true' ">
+    <Content Include="$(RepoDir)/bin/equinox-cli/net461/*">
+      <Pack>true</Pack>
+      <PackagePath>tools\net461\any\%(Filename)%(Extension)</PackagePath>
+      <Visible>true</Visible>
+    </Content>
+  </ItemGroup>
+
   <!-- workaround for not being able to make Backend and Domain as inlined in a complete way https://github.com/nuget/home/issues/3891#issuecomment-377319939 -->
   <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">
     <ItemGroup>


### PR DESCRIPTION
fix https://github.com/jet/equinox/issues/64

- pack `Equinox.Cli` as .NET Tool
- bundle the `net461` executable in the package, in the dir `tools/net461/any`

## .net core tool

To test is locally, after `dotnet pack build.proj`

```
dotnet tool install --add-source "bin\nupkg" --tool-path bin2 --version 0.0.1 Equinox.Cli
```

and

```
bin2\eqx --help
```

use `-g` instead of `--tool-path` to install globally

## .net executable

it's inside the nupkg, in the `tools/net461/any` directory