### PR TITLE
Use MinVer to infer package versions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project ToolsVersion="15.0">
   <PropertyGroup>
-    <VersionPrefix>0.0.1</VersionPrefix>
     <Authors>@jet @bartelink @eiriktsarpalis and contributors</Authors>
     <Company>Jet.com</Company>
     <Description>Composable high performance event sourcing componentry</Description>
@@ -22,6 +21,9 @@
 
     <!-- suppress false positive warning FS2003 about invalid version of AssemblyInformationalVersionAttribute -->
     <NoWarn>FS2003</NoWarn>
+
+    <!-- Fit in with sibling project tagging scheme (MinVer trims this off the tag when inferring)-->
+    <MinVerTagPrefix>v</MinVerTagPrefix>
   </PropertyGroup>
 
   <!-- Workaround for https://github.com/xunit/xunit/issues/1357 -->

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Equinox provides a unified programming model for event sourced processing against diverse stream-based stores.
 
+[![Build Status](https://dev.azure.com/jet-opensource/opensource/_apis/build/status/jet.equinox?branchName=master)](https://dev.azure.com/jet-opensource/opensource/_build/latest?definitionId=4?branchName=master)
+
 Current supported backends are:
 
 - [EventStore](https://eventstore.org/) - this codebase itself has been in production since 2017 (commit history reflects usage), with elements dating back to 2016.

--- a/cli/Equinox.Cli/Equinox.Cli.fsproj
+++ b/cli/Equinox.Cli/Equinox.Cli.fsproj
@@ -38,6 +38,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MinVer" Version="1.0.0-beta.2+build.172" />
+
     <PackageReference Include="Argu" Version="5.1.0" />
     <!--Handle TypeShape-restriction; would otherwise use 3.1.2.5-->
     <PackageReference Include="FSharp.Core" Version="4.0.0.1" Condition=" '$(TargetFramework)' == 'net461' " />

--- a/src/Equinox.Codec/Equinox.Codec.fsproj
+++ b/src/Equinox.Codec/Equinox.Codec.fsproj
@@ -15,6 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="1.0.0-beta.2+build.172" />
+
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/src/Equinox.EventStore/Equinox.EventStore.fsproj
+++ b/src/Equinox.EventStore/Equinox.EventStore.fsproj
@@ -22,6 +22,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="1.0.0-beta.2+build.172" />
+
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' != 'netstandard2.0' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
     <PackageReference Include="EventStore.ClientAPI.NetCore" Version="4.1.1-rc" Condition=" '$(TargetFramework)' == 'netstandard2.0'" />

--- a/src/Equinox.MemoryStore/Equinox.MemoryStore.fsproj
+++ b/src/Equinox.MemoryStore/Equinox.MemoryStore.fsproj
@@ -19,6 +19,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="1.0.0-beta.2+build.172" />
+
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
   </ItemGroup>

--- a/src/Equinox/Equinox.fsproj
+++ b/src/Equinox/Equinox.fsproj
@@ -17,6 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="1.0.0-beta.2+build.172" />
+
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
     <PackageReference Include="Serilog" Version="2.7.1" />


### PR DESCRIPTION
This PR uses [MinVer](https://github.com/adamralph/minver) to compute assembly versions based on tags in the git history.

I've included a `v0.0.0-rc1` tag in here; I intend to squash merge to remove that from the history and then re-add it on the squashed commit

There's a `v0.0.1-rc1` at large, which is on the `cosmos` branch; will do the same squash merge and then apply on master dance when we merge that.

... I needed to push it with `git push origin v0.0.0-rc1` for MinVer to pick it up though

... but it seems to have been cached and hence not picked up. Merging to see if it gets picked up by next PR