### PR TITLE
Rename cli/Equinox.Cli to tools/Equinox.Tool

### DIFF
--- a/Equinox.sln
+++ b/Equinox.sln
@@ -44,7 +44,7 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Equinox.MemoryStore.Integra
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Equinox.Codec", "src\Equinox.Codec\Equinox.Codec.fsproj", "{F5491EB1-D072-4262-8184-2A908E1D6175}"
 EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Equinox.Cli", "cli\Equinox.Cli\Equinox.Cli.fsproj", "{C8992C1C-6DC5-42CD-A3D7-1C5663433FED}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Equinox.Tool", "tools\Equinox.Tool\Equinox.Tool.fsproj", "{C8992C1C-6DC5-42CD-A3D7-1C5663433FED}"
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "TodoBackend", "samples\TodoBackend\TodoBackend.fsproj", "{EC2EC658-3D85-44F3-AD2F-52AFCAFF8871}"
 EndProject

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The Equinox components within this repository are delivered as a series of multi
 - `Equinox.MemoryStore` (Nuget: `Equinox.MemoryStore`): In-memory store for integration testing/performance baselining/providing out-of-the-box zero dependency storage for examples.
 - `samples/Store` (in this repo): Example domain types reflecting examples of how one applies Equinox to a diverse set of stream-based models
 - `samples/TodoBackend` (in this repo): Standard https://todobackend.com compliant backend
-- `Equinox.Cli` (Nuget: `dotnet tool install Equinox.Cli -g`): Tool incorporating a benchmark scenario runner, facilitating running representative load tests composed of transactions in `samples/Store` and `samples/TodoBackend` against any nominated store; this allows perf tuning and measurement in terms of both latency and transaction charge aspects.
+- `Equinox.Tool` (Nuget: `dotnet tool install Equinox.Tool -g`): Tool incorporating a benchmark scenario runner, facilitating running representative load tests composed of transactions in `samples/Store` and `samples/TodoBackend` against any nominated store; this allows perf tuning and measurement in terms of both latency and transaction charge aspects.
 
 ## CONTRIBUTING
 
@@ -148,13 +148,13 @@ A key facility of this repo is being able to run load tests, either in process a
 This benchmark continually reads and writes very small events across multiple streams on .NET Full Framework
 
     dotnet pack -c Release .\build.proj
-    & .\cli\Equinox.Cli\bin\Release\net461\eqx.exe run -f 2500 -C es
+    & ./tools/Equinox.Tool/bin/Release/net461/eqx.exe run -f 2500 -C -U es
 
 ### Run EventStore benchmark on .NET Core (when provisioned)
 
 At present, .NET Core seems to show comparable perf under normal load, but becomes very unpredictable under load. The following benchmark should produce pretty consistent levels of reads and writes, and can be used as a baseline for investigation:
 
-    & dotnet run -c Release -f netcoreapp2.1 -p cli/equinox.cli -- run -t saveforlater -f 1000 -d 5 -C -U es
+    & dotnet run -c Release -f netcoreapp2.1 -p tools/Equinox.Tool -- run -t saveforlater -f 1000 -d 5 -C -U es
 
 ### run Web benchmark
 
@@ -166,7 +166,7 @@ The CLI can drive the Store and TodoBackend samples in the `samples/Web` ASP.NET
 
 #### in Window 2
 
-    dotnet tool install -g Equinox.Cli # only once
+    dotnet tool install -g Equinox.Tool # only once
     eqx run -t saveforlater -f 200 web
 
 ### run CosmosDb benchmark (when provisioned)
@@ -175,9 +175,9 @@ The CLI can drive the Store and TodoBackend samples in the `samples/Web` ASP.NET
     $env:EQUINOX_COSMOS_DATABASE="equinox-test"
     $env:EQUINOX_COSMOS_COLLECTION="equinox-test"
 
-    cli/Equinox.cli/bin/Release/net461/eqx run `
+    tools/Equinox.Tool/bin/Release/net461/eqx run `
       cosmos -s $env:EQUINOX_COSMOS_CONNECTION -d $env:EQUINOX_COSMOS_DATABASE -c $env:EQUINOX_COSMOS_COLLECTION `
-    dotnet run -f netcoreapp2.1 -p cli/equinox.cli -- run `
+    dotnet run -f netcoreapp2.1 -p tools/Equinox.Tool -- run `
       cosmos -s $env:EQUINOX_COSMOS_CONNECTION -d $env:EQUINOX_COSMOS_DATABASE -c $env:EQUINOX_COSMOS_COLLECTION `
 
 ## PROVISIONING
@@ -193,7 +193,7 @@ For EventStore, the tests assume a running local instance configured as follows 
 
 ### Provisioning CosmosDb (when not using -sc)
 
-    dotnet run -f netcoreapp2.1 -p cli/equinox.cli -- init -ru 1000 `
+    dotnet run -f netcoreapp2.1 -p tools/Equinox.Tool -- init -ru 1000 `
         cosmos -s $env:EQUINOX_COSMOS_CONNECTION -d $env:EQUINOX_COSMOS_DATABASE -c $env:EQUINOX_COSMOS_COLLECTION
 
 ## DEPROVISIONING

--- a/build.proj
+++ b/build.proj
@@ -14,12 +14,12 @@
   </PropertyGroup>
 
   <Target Name="Pack">
-    <Exec Command='dotnet publish cli/Equinox.Cli $(Cfg) -f net461 -o "$(RepoDir)/bin/equinox-cli/net461" ' />
-    <Exec Command="dotnet pack cli/Equinox.Cli $(Cfg) $(PackOptions) /p:PackAsTool=true" />
     <Exec Command="dotnet pack src/Equinox $(Cfg) $(PackOptions)" />
     <Exec Command="dotnet pack src/Equinox.Codec $(Cfg) $(PackOptions)" />
     <Exec Command="dotnet pack src/Equinox.EventStore $(Cfg) $(PackOptions)" />
     <Exec Command="dotnet pack src/Equinox.MemoryStore $(Cfg) $(PackOptions)" />
+    <Exec Command='dotnet publish tools/Equinox.Tool $(Cfg) -f net461 -o "$(RepoDir)/bin/equinox-tool/net461" ' />
+    <Exec Command="dotnet pack tools/Equinox.Tool $(Cfg) $(PackOptions) /p:PackAsTool=true" />
   </Target>
 
   <!-- tests hangs on osx -->

--- a/samples/Infrastructure/Storage.fs
+++ b/samples/Infrastructure/Storage.fs
@@ -50,7 +50,7 @@ module EventStore =
                 heartbeatTimeout=heartbeatTimeout, concurrentOperationsLimit = col,
                 log=(if log.IsEnabled(Serilog.Events.LogEventLevel.Debug) then Logger.SerilogVerbose log else Logger.SerilogNormal log),
                 tags=["M", Environment.MachineName; "I", Guid.NewGuid() |> string])
-            .Establish("equinox-cli", Discovery.GossipDns dnsQuery, ConnectionStrategy.ClusterTwinPreferSlaveReads)
+            .Establish("equinox-tool", Discovery.GossipDns dnsQuery, ConnectionStrategy.ClusterTwinPreferSlaveReads)
     let private createGateway connection batchSize = GesGateway(connection, GesBatchingPolicy(maxBatchSize = batchSize))
     let config (log: ILogger, storeLog) (cache, unfolds) (sargs : ParseResults<EsArguments>) =
         let host = sargs.GetResult(Host,"localhost")

--- a/tools/Equinox.Tool/Equinox.Tool.fsproj
+++ b/tools/Equinox.Tool/Equinox.Tool.fsproj
@@ -9,7 +9,7 @@
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
 
-    <PackageId>Equinox.Cli</PackageId>
+    <PackageId>Equinox.Tool</PackageId>
     <AssemblyName>eqx</AssemblyName>
 
     <!-- workaround for not being able to make Backend and Domain as inlined in a complete way https://github.com/nuget/home/issues/3891#issuecomment-377319939 -->
@@ -55,7 +55,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(PackAsTool)' == 'true' ">
-    <Content Include="$(RepoDir)/bin/equinox-cli/net461/*">
+    <Content Include="$(RepoDir)/bin/equinox-tool/net461/*">
       <Pack>true</Pack>
       <PackagePath>tools\net461\any\%(Filename)%(Extension)</PackagePath>
       <Visible>true</Visible>

--- a/tools/Equinox.Tool/Infrastructure/Aggregate.fs
+++ b/tools/Equinox.Tool/Infrastructure/Aggregate.fs
@@ -1,5 +1,5 @@
 ﻿[<AutoOpen>]
-module Equinox.Cli.Infrastructure.Aggregate
+module Equinox.Tool.Infrastructure.Aggregate
 
 open MathNet.Numerics.Statistics
 open Serilog

--- a/tools/Equinox.Tool/Infrastructure/HttpHelpers.fs
+++ b/tools/Equinox.Tool/Infrastructure/HttpHelpers.fs
@@ -1,4 +1,4 @@
-﻿module Equinox.Cli.Infrastructure.HttpHelpers
+﻿module Equinox.Tool.Infrastructure.HttpHelpers
 
 open System
 open System.Net

--- a/tools/Equinox.Tool/Infrastructure/Infrastructure.fs
+++ b/tools/Equinox.Tool/Infrastructure/Infrastructure.fs
@@ -1,5 +1,5 @@
 ﻿[<AutoOpen>]
-module Equinox.Cli.Infrastructure.Prelude
+module Equinox.Tool.Infrastructure.Prelude
 
 open System
 open System.Diagnostics

--- a/tools/Equinox.Tool/Infrastructure/LoadTestRunner.fs
+++ b/tools/Equinox.Tool/Infrastructure/LoadTestRunner.fs
@@ -1,4 +1,4 @@
-﻿namespace Equinox.Cli.Infrastructure
+﻿namespace Equinox.Tool.Infrastructure
 
 open System
 open System.Threading

--- a/tools/Equinox.Tool/Infrastructure/LocalLoadTestRunner.fs
+++ b/tools/Equinox.Tool/Infrastructure/LocalLoadTestRunner.fs
@@ -1,4 +1,4 @@
-﻿namespace Equinox.Cli.Infrastructure
+﻿namespace Equinox.Tool.Infrastructure
 
 open Serilog
 open System

--- a/tools/Equinox.Tool/Infrastructure/Types.fs
+++ b/tools/Equinox.Tool/Infrastructure/Types.fs
@@ -1,4 +1,4 @@
-﻿namespace Equinox.Cli.Infrastructure
+﻿namespace Equinox.Tool.Infrastructure
 
 open System
 open System.Net

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -1,8 +1,8 @@
-﻿module Equinox.Cli.Program
+﻿module Equinox.Tool.Program
 
 open Argu
 open Domain.Infrastructure
-open Equinox.Cli.Infrastructure
+open Equinox.Tool.Infrastructure
 open Microsoft.Extensions.DependencyInjection
 open Samples.Infrastructure.Storage
 open Serilog

--- a/tools/Equinox.Tool/StoreClient.fs
+++ b/tools/Equinox.Tool/StoreClient.fs
@@ -1,7 +1,7 @@
-﻿module Equinox.Cli.StoreClient
+﻿module Equinox.Tool.StoreClient
 
 open Domain
-open Equinox.Cli.Infrastructure
+open Equinox.Tool.Infrastructure
 open System
 open System.Net
 open System.Net.Http

--- a/tools/Equinox.Tool/Tests.fs
+++ b/tools/Equinox.Tool/Tests.fs
@@ -1,4 +1,4 @@
-﻿module Equinox.Cli.Tests
+﻿module Equinox.Tool.Tests
 
 open Domain
 open Infrastructure

--- a/tools/Equinox.Tool/TodoClient.fs
+++ b/tools/Equinox.Tool/TodoClient.fs
@@ -1,7 +1,7 @@
-﻿module Equinox.Cli.TodoClient
+﻿module Equinox.Tool.TodoClient
 
 open Domain
-open Equinox.Cli.Infrastructure
+open Equinox.Tool.Infrastructure
 open System.Net
 open System.Net.Http
 open System


### PR DESCRIPTION
This naming fits a teeny bit better alongside `Equinox.Templates`, and allows us to add other tools ... like Projectors ;)