### PR TITLE
Use MinVer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project ToolsVersion="15.0">
   <PropertyGroup>
-    <VersionPrefix>0.0.1</VersionPrefix>
     <Authors>@jet @bartelink @eiriktsarpalis and contributors</Authors>
     <Company>Jet.com</Company>
     <Description>Composable high performance event sourcing componentry</Description>
@@ -21,7 +20,8 @@
     <EnableSourceLink Condition=" '$(OS)' != 'Windows_NT' AND '$(MSBuildRuntimeType)' != 'Core' ">false</EnableSourceLink>
 
     <!-- suppress false positive warning FS2003 about invalid version of AssemblyInformationalVersionAttribute -->
-    <NoWarn>FS2003</NoWarn>
+    <!-- Supress NU5105 triggerd by MinVer height e.g.: pr43-rc1.2: The package version '<X>' uses SemVer 2.0.0 or components of SemVer 1.0.0 that are not supported on legacy clients. Change the package version to a SemVer 1.0.0 string. If the version contains a release label it must start with a letter. This message can be ignored if the package is not intended for older clients. -->
+    <NoWarn>$(NoWarn);FS2003;NU5105</NoWarn>
   </PropertyGroup>
 
   <!-- Workaround for https://github.com/xunit/xunit/issues/1357 -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,4 +3,18 @@
   <Target Name="VSTestIfTestProject">
     <CallTarget Targets="VSTest" Condition="'$(IsTestProject)' == 'true'" />
   </Target>
+  <Target Name="ComputePackageVersion" AfterTargets="MinVer" Condition="'$(BUILD_PR)' != ''" >
+    <PropertyGroup>
+      <PackageVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)-pr.$(BUILD_PR)</PackageVersion>
+      <PackageVersion Condition="'$(MinVerPreRelease)' != ''">$(PackageVersion).$(MinVerPreRelease)</PackageVersion>
+      <PackageVersion Condition="'$(MinVerBuildMetadata)' != ''">$(PackageVersion)+$(MinVerBuildMetadata)</PackageVersion>
+      <Version>$(PackageVersion)</Version>
+    </PropertyGroup>
+  </Target>
+  <Target Name="ComputeFileVersion" AfterTargets="MinVer">
+    <PropertyGroup>
+      <BUILD_ID Condition="'$(BUILD_ID)' == ''">0</BUILD_ID>
+      <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(BUILD_ID)</FileVersion>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ The Equinox components within this repository are delivered as a series of multi
 - `samples/TodoBackend` (in this repo): Standard https://todobackend.com compliant backend
 - `Equinox.Tool` (Nuget: `dotnet tool install Equinox.Tool -g`): Tool incorporating a benchmark scenario runner, facilitating running representative load tests composed of transactions in `samples/Store` and `samples/TodoBackend` against any nominated store; this allows perf tuning and measurement in terms of both latency and transaction charge aspects.
 
+## Versioning
+
+## About Versioning
+
+The repo is versioned based on [SemVer 2.0](https://semver.org/spec/v2.0.0.html) using the tiny-but-mighty [MinVer](https://github.com/adamralph/minver) from @adamralph. [See here](https://github.com/adamralph/minver#how-it-works) for more information on how it works.
+
 ## CONTRIBUTING
 
 Please raise GitHub issues for any questions so others can benefit from the discussion.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,16 +4,6 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps:
-  - powershell: |
-      $buildId = $env:BUILD_BUILDNUMBER.PadLeft(7, '0');
-      $versionSuffixPR = "ci-$buildId-pr$($env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)";
-      $branchName = "$env:BUILD_SOURCEBRANCHNAME".Replace("_","");
-      $versionSuffixBRANCH = "$branchName-$buildId";
-      $isTag = "$env:BUILD_SOURCEBRANCH".StartsWith('refs/tags/');
-      $isPR = "$env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER" -ne ""
-      $versionSuffix = if ($isTag) { "" } else { if ($isPR) { $versionSuffixPR } else { $versionSuffixBRANCH } };
-      Write-Host "##vso[task.setvariable variable=VersionSuffix]$versionSuffix";
-    displayName: compute VersionSuffix
   - script: dotnet test build.proj -v n
     displayName: dotnet test build.proj
     env:
@@ -27,7 +17,8 @@ jobs:
   - script: dotnet pack build.proj
     displayName: dotnet pack build.proj
     env:
-      VersionSuffix: '$(VersionSuffix)'
+      BUILD_PR: $(SYSTEM.PULLREQUEST.PULLREQUESTNUMBER)
+      BUILD_ID: $(BUILD.BUILDNUMBER) 
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: 'bin/nupkg'
@@ -58,7 +49,10 @@ jobs:
       testResultsFiles: 'tests/**/*.trx'
     condition: succeededOrFailed()
   - script: dotnet pack build.proj
-    displayName: dotnet pack build.proj
+    displayName: dotnet pack
+    env:
+      BUILD_PR: $(SYSTEM.PULLREQUEST.PULLREQUESTNUMBER)
+      BUILD_ID: $(BUILD.BUILDNUMBER) 
 
 - job: MacOS
   pool:
@@ -77,4 +71,7 @@ jobs:
       testResultsFiles: 'tests/**/*.trx'
     condition: succeededOrFailed()
   - script: dotnet pack build.proj
-    displayName: dotnet pack build.proj
+    displayName: dotnet pack
+    env:
+      BUILD_PR: $(SYSTEM.PULLREQUEST.PULLREQUESTNUMBER)
+      BUILD_ID: $(BUILD.BUILDNUMBER) 

--- a/build.proj
+++ b/build.proj
@@ -6,7 +6,7 @@
     <Cfg>--configuration Release</Cfg>
 
     <ThisDirAbsolute>$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory)"))</ThisDirAbsolute>
-    <PackOptions>-o $(ThisDirAbsolute)bin/nupkg --version-suffix "$(VersionSuffix)"</PackOptions>
+    <PackOptions>/p:BUILD_ID=$(BUILD_ID) /p:BUILD_PR=$(BUILD_PR) -o $(ThisDirAbsolute)bin/nupkg</PackOptions>
 
     <TestOptions>--logger:trx</TestOptions>
     <!-- disable known test failures on mono -->

--- a/src/Equinox.Codec/Equinox.Codec.fsproj
+++ b/src/Equinox.Codec/Equinox.Codec.fsproj
@@ -15,6 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="1.0.0-beta.2" />
+
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/src/Equinox.EventStore/Equinox.EventStore.fsproj
+++ b/src/Equinox.EventStore/Equinox.EventStore.fsproj
@@ -22,6 +22,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="1.0.0-beta.2" />
+
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' != 'netstandard2.0' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
     <PackageReference Include="EventStore.ClientAPI.NetCore" Version="4.1.1-rc" Condition=" '$(TargetFramework)' == 'netstandard2.0'" />

--- a/src/Equinox.MemoryStore/Equinox.MemoryStore.fsproj
+++ b/src/Equinox.MemoryStore/Equinox.MemoryStore.fsproj
@@ -19,6 +19,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="1.0.0-beta.2" />
+
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
   </ItemGroup>

--- a/src/Equinox/Equinox.fsproj
+++ b/src/Equinox/Equinox.fsproj
@@ -17,6 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="1.0.0-beta.2" />
+
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
     <PackageReference Include="Serilog" Version="2.7.1" />

--- a/tools/Equinox.Tool/Equinox.Tool.fsproj
+++ b/tools/Equinox.Tool/Equinox.Tool.fsproj
@@ -38,6 +38,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MinVer" Version="1.0.0-beta.2" />
+
     <PackageReference Include="Argu" Version="5.1.0" />
     <!--Handle TypeShape-restriction; would otherwise use 3.1.2.5-->
     <PackageReference Include="FSharp.Core" Version="4.0.0.1" Condition=" '$(TargetFramework)' == 'net461' " />


### PR DESCRIPTION
This PR, a rerun of #71, integrates [MinVer](https://github.com/adamralph/minver) 

HT: this is based on https://github.com/justeat/JustSaying/pull/465, which @adamralph kindly sent me a link to

To test locally (the Azure Pipelines effectively invokes it this way): `dotnet pack /p:build_pr=46 /p:build_id=1000 build.proj`

TODO
- [ ] simplify the wiring in the `azure-pipelines.yml` to pass `BUILD_ID` and `BUILD_PR`
- [ ] not seeing VERSIONINFO on the dlls