### PR TITLE
Make minver a private asset

### DIFF
--- a/src/Equinox.Codec/Equinox.Codec.fsproj
+++ b/src/Equinox.Codec/Equinox.Codec.fsproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
-    <PackageReference Include="MinVer" Version="1.0.0-beta.2" />
+    <PackageReference Include="MinVer" Version="1.0.0-beta.2" PrivateAssets="All" />
 
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />

--- a/src/Equinox.Cosmos/Equinox.Cosmos.fsproj
+++ b/src/Equinox.Cosmos/Equinox.Cosmos.fsproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
-    <PackageReference Include="MinVer" Version="1.0.0-beta.2" />
+    <PackageReference Include="MinVer" Version="1.0.0-beta.2" PrivateAssets="All" />
 
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' != 'netstandard2.0' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />

--- a/src/Equinox.EventStore/Equinox.EventStore.fsproj
+++ b/src/Equinox.EventStore/Equinox.EventStore.fsproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
-    <PackageReference Include="MinVer" Version="1.0.0-beta.2" />
+    <PackageReference Include="MinVer" Version="1.0.0-beta.2" PrivateAssets="All" />
 
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' != 'netstandard2.0' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />

--- a/src/Equinox.MemoryStore/Equinox.MemoryStore.fsproj
+++ b/src/Equinox.MemoryStore/Equinox.MemoryStore.fsproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
-    <PackageReference Include="MinVer" Version="1.0.0-beta.2" />
+    <PackageReference Include="MinVer" Version="1.0.0-beta.2" PrivateAssets="All" />
 
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />

--- a/src/Equinox/Equinox.fsproj
+++ b/src/Equinox/Equinox.fsproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
-    <PackageReference Include="MinVer" Version="1.0.0-beta.2" />
+    <PackageReference Include="MinVer" Version="1.0.0-beta.2" PrivateAssets="All" />
 
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />

--- a/tools/Equinox.Tool/Equinox.Tool.fsproj
+++ b/tools/Equinox.Tool/Equinox.Tool.fsproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="1.0.0-beta.2" />
+    <PackageReference Include="MinVer" Version="1.0.0-beta.2" PrivateAssets="All" />
 
     <PackageReference Include="Argu" Version="5.1.0" />
     <!--Handle TypeShape-restriction; would otherwise use 3.1.2.5-->


### PR DESCRIPTION
Minver is currently leaking as a dependency in the eqx libraries, causing compile time errors when referenced from libraries that are using the old project system.