### PR TITLE
Clean up Identity Types

### DIFF
--- a/samples/Store/Backend/Cart.fs
+++ b/samples/Store/Backend/Cart.fs
@@ -3,7 +3,7 @@
 open Domain
 
 type Service(log, resolveStream) =
-    let (|AggregateId|) (id: CartId) = Equinox.AggregateId ("Cart", id.Value)
+    let (|AggregateId|) (id: CartId) = Equinox.AggregateId ("Cart", CartId.toStringN id)
     let (|Stream|) (AggregateId id) = Cart.Handler(log, resolveStream id)
 
     member __.FlowAsync (Stream stream, flow, ?prepare) =

--- a/samples/Store/Backend/Favorites.fs
+++ b/samples/Store/Backend/Favorites.fs
@@ -5,7 +5,7 @@ open Domain.Favorites
 open System
 
 type Service(log, resolveStream) =
-    let (|AggregateId|) (id: ClientId) = Equinox.AggregateId("Favorites", id.Value)
+    let (|AggregateId|) (id: ClientId) = Equinox.AggregateId("Favorites", ClientId.toStringN id)
     let (|Stream|) (AggregateId id) = Handler(log, resolveStream id)
 
     member __.Execute(Stream stream, command) =

--- a/samples/Store/Backend/SavedForLater.fs
+++ b/samples/Store/Backend/SavedForLater.fs
@@ -7,7 +7,7 @@ open System
 
 type Service(handlerLog, resolveStream, maxSavedItems : int, maxAttempts) =
     do if maxSavedItems < 0 then invalidArg "maxSavedItems" "must be non-negative value."
-    let (|AggregateId|) (id: ClientId) = Equinox.AggregateId("SavedForLater", id.Value)
+    let (|AggregateId|) (id: ClientId) = Equinox.AggregateId("SavedForLater", ClientId.toStringN id)
     let (|Stream|) (AggregateId id) = Handler(handlerLog, resolveStream id, maxSavedItems, maxAttempts)
 
     member __.MaxSavedItems = maxSavedItems

--- a/samples/Store/Domain.Tests/FavoritesTests.fs
+++ b/samples/Store/Domain.Tests/FavoritesTests.fs
@@ -7,7 +7,7 @@ open Domain.Favorites.Folds
 open Swensen.Unquote
 open System
 
-let mkFavorite skuId    = Favorited { Favorited.date = DateTimeOffset.UtcNow; skuId = skuId }
+let mkFavorite skuId    = Favorited { date = DateTimeOffset.UtcNow; skuId = skuId }
 let mkUnfavorite skuId  = Unfavorited { skuId = skuId }
 
 /// Put the aggregate into the state where the command should trigger an event; verify correct events are yielded

--- a/samples/Store/Domain.Tests/Infrastructure.fs
+++ b/samples/Store/Domain.Tests/Infrastructure.fs
@@ -37,7 +37,8 @@ module IdTypes =
     [<Fact>]
     let ``ClientId has structural equality semantics`` () =
         let x = Guid.NewGuid()
-        test <@ ClientId x = ClientId x @>
+        let (x1 : ClientId, x2 : ClientId) = %x, %x
+        test <@ x1 = x2 @>
 
     [<Fact>]
     let ``RequestId has structural equality semantics`` () =

--- a/samples/Store/Domain.Tests/Infrastructure.fs
+++ b/samples/Store/Domain.Tests/Infrastructure.fs
@@ -43,7 +43,8 @@ module IdTypes =
     [<Fact>]
     let ``RequestId has structural equality semantics`` () =
         let x = Guid.NewGuid()
-        test <@ RequestId x = RequestId x @>
+        let (x1 : RequestId, x2 : RequestId) = RequestId %x, RequestId %x
+        test <@ x1 = x2 @>
 
     [<Fact>]
     let ``SkuId has structural equality semantics`` () =

--- a/samples/Store/Domain.Tests/Infrastructure.fs
+++ b/samples/Store/Domain.Tests/Infrastructure.fs
@@ -29,24 +29,29 @@ let knuthShuffle (array : 'a []) =
 
 module IdTypes =
     [<Fact>]
-    let ``CartId has structural equality semantics`` () =
-        let x = Guid.NewGuid()
+    let ``CartId has structural equality and Guid rendering semantics`` () =
+        let x = Guid.NewGuid() in let xs, xn = x.ToString(), x.ToString "N"
         let (x1 : CartId, x2 : CartId) = %x, %x
-        test <@ x1 = x2 @>
+        test <@ x1 = x2
+                && xn = CartId.toStringN x2
+                && string x1 = xs @>
 
     [<Fact>]
-    let ``ClientId has structural equality semantics`` () =
-        let x = Guid.NewGuid()
+    let ``ClientId has structural equality and Guid rendering semantics`` () =
+        let x = Guid.NewGuid() in let xs, xn = x.ToString(), x.ToString "N"
         let (x1 : ClientId, x2 : ClientId) = %x, %x
-        test <@ x1 = x2 @>
+        test <@ x1 = x2
+                && xn = ClientId.toStringN x2
+                && string x1 = xs @>
 
     [<Fact>]
-    let ``RequestId has structural equality semantics`` () =
-        let x = Guid.NewGuid()
+    let ``RequestId has structural equality and canonical rendering semantics`` () =
+        let x = Guid.NewGuid() in let xn = Guid.toStringN x
         let (x1 : RequestId, x2 : RequestId) = RequestId %x, RequestId %x
-        test <@ x1 = x2 @>
+        test <@ x1 = x2 && string x1 = xn @>
 
     [<Fact>]
-    let ``SkuId has structural equality semantics`` () =
-        let x = Guid.NewGuid()
-        test <@ SkuId x = SkuId x @> 
+    let ``SkuId has structural equality and canonical rendering semantics`` () =
+        let x = Guid.NewGuid() in let xn = Guid.toStringN x
+        let (x1 : SkuId, x2 : SkuId) = SkuId %x, SkuId %x
+        test <@ x1 = x2 && string x1 = xn @>

--- a/samples/Store/Domain.Tests/Infrastructure.fs
+++ b/samples/Store/Domain.Tests/Infrastructure.fs
@@ -2,6 +2,7 @@
 module Samples.Store.Domain.Tests.Infrastructure
 
 open Domain
+open FSharp.UMX
 open FsCheck
 open Swensen.Unquote
 open System
@@ -30,7 +31,8 @@ module IdTypes =
     [<Fact>]
     let ``CartId has structural equality semantics`` () =
         let x = Guid.NewGuid()
-        test <@ CartId x = CartId x @>
+        let (x1 : CartId, x2 : CartId) = %x, %x
+        test <@ x1 = x2 @>
 
     [<Fact>]
     let ``ClientId has structural equality semantics`` () =

--- a/samples/Store/Domain.Tests/Infrastructure.fs
+++ b/samples/Store/Domain.Tests/Infrastructure.fs
@@ -2,15 +2,14 @@
 module Samples.Store.Domain.Tests.Infrastructure
 
 open Domain
-open FSharp.UMX
 open FsCheck
+open FSharp.UMX
 open Swensen.Unquote
 open System
 open global.Xunit
 
 type FsCheckGenerators =
     static member SkuId = Arb.generate |> Gen.map SkuId |> Arb.fromGen
-    static member RequestId = Arb.generate |> Gen.map RequestId |> Arb.fromGen
 
 type DomainPropertyAttribute() =
     inherit FsCheck.Xunit.PropertyAttribute(QuietOnSuccess = true, Arbitrary=[| typeof<FsCheckGenerators> |])
@@ -47,11 +46,13 @@ module IdTypes =
     [<Fact>]
     let ``RequestId has structural equality and canonical rendering semantics`` () =
         let x = Guid.NewGuid() in let xn = Guid.toStringN x
-        let (x1 : RequestId, x2 : RequestId) = RequestId %x, RequestId %x
-        test <@ x1 = x2 && string x1 = xn @>
+        let (x1 : RequestId, x2 : RequestId) = RequestId.parse %x, RequestId.parse %x
+        test <@ x1 = x2
+                && string x1 = xn @>
 
     [<Fact>]
     let ``SkuId has structural equality and canonical rendering semantics`` () =
         let x = Guid.NewGuid() in let xn = Guid.toStringN x
-        let (x1 : SkuId, x2 : SkuId) = SkuId %x, SkuId %x
-        test <@ x1 = x2 && string x1 = xn @>
+        let (x1 : SkuId, x2 : SkuId) = SkuId.parse %x, SkuId.parse %x
+        test <@ x1 = x2
+                && string x1 = xn @>

--- a/samples/Store/Domain.Tests/SavedForLaterTests.fs
+++ b/samples/Store/Domain.Tests/SavedForLaterTests.fs
@@ -3,6 +3,7 @@
 open Domain
 open Domain.SavedForLater
 open Domain.SavedForLater.Folds
+open FSharp.UMX
 open Swensen.Unquote.Assertions
 open System
 open System.Collections.Generic
@@ -25,7 +26,7 @@ let run (commands : Commands.Command list) : State * Events.Event list =
 let contains sku (state : State) = state |> Array.exists (fun s -> s.skuId = sku)
 let find sku (state : State) = state |> Array.find (fun s -> s.skuId = sku)
 
-let genSku () = SkuId(Guid.NewGuid())
+let genSku () = % Guid.NewGuid() |> SkuId.parse
 
 [<Fact>]
 let ``Adding one item to mysaves should appear in aggregate`` () =
@@ -96,7 +97,7 @@ let ``Event aggregation should carry set semantics`` (commands : Commands.Comman
 let ``State should produce a stable output for skus with the same saved date`` (skuIds : Guid []) =
     let now = DateTimeOffset.Now
 
-    let skus = Array.map SkuId skuIds
+    let skus = skuIds |> Array.map (UMX.tag >> SkuId.parse) 
     let shuffledSkus =
         let rnd = new Random()
         skus |> Array.sortBy (fun _ -> rnd.Next())

--- a/samples/Store/Domain/Domain.fsproj
+++ b/samples/Store/Domain/Domain.fsproj
@@ -26,6 +26,7 @@
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
     <PackageReference Include="Jet.JsonNet.Converters" Version="0.2.2" />
+    <PackageReference Include="FSharp.UMX" Version="1.0.0-preview-001" />
   </ItemGroup>
 
 </Project>

--- a/samples/Store/Domain/Infrastructure.fs
+++ b/samples/Store/Domain/Infrastructure.fs
@@ -77,12 +77,17 @@ and private RequestIdJsonConverter() =
     /// Input must be a `Guid.Parse`able value
     override __.UnPickle input = Guid.Parse input |> RequestId
 
-/// CartId strongly typed id; not used for storage so rendering is not significatn
+/// CartId strongly typed id; not used for storage so rendering is not significant
 type CartId = Guid<cartId>
 and [<Measure>] cartId
 module CartId = let toStringN (value : CartId) : string = Guid.toStringN %value
 
-/// ClientId strongly typed id
+/// CartId strongly typed id; not used for storage so rendering is not significant
 type ClientId = Guid<clientId>
 and [<Measure>] clientId
 module ClientId = let toStringN (value : ClientId) : string = Guid.toStringN %value
+
+/// InventoryItemId strongly typed id
+type InventoryItemId = Guid<inventoryItemId>
+and [<Measure>] inventoryItemId
+module InventoryItemId = let toStringN (value : InventoryItemId) : string = Guid.toStringN %value

--- a/samples/Store/Domain/Infrastructure.fs
+++ b/samples/Store/Domain/Infrastructure.fs
@@ -73,42 +73,14 @@ and private RequestIdJsonConverter() =
     /// Input must be a Guid.Parseable value
     override __.UnPickle input = RequestId.Parse input
 
-[<Measure>] type cartId
 /// CartId strongly typed id
 type CartId = Guid<cartId>
+and [<Measure>] cartId
 module CartId =
-    let toStringN (value : CartId) : string = let g : Guid = %value in g.ToString("N") 
+    let toStringN (value : CartId) : string = let g : Guid = %value in g.ToString "N"
 
 /// ClientId strongly typed id
-[<Sealed; JsonConverter(typeof<ClientIdJsonConverter>); AutoSerializable(false); StructuredFormatDisplay("{Value}")>]
-// To support model binding using aspnetcore 2 FromHeader
-[<System.ComponentModel.TypeConverter(typeof<ClientIdStringConverter>)>]
-// (Internally a string for most efficient copying semantics)
-type ClientId private (id : string) =
-    inherit Comparable<ClientId, string>(id)
-    [<IgnoreDataMember>] // Prevent swashbuckle inferring there's a "value" field
-    member __.Value = id
-    override __.ToString () = id
-    // NB tests lean on having a ctor of this shape
-    new (guid: Guid) = ClientId (guid.ToString("N"))
-    // NB for validation [and XSS] purposes we must prove it translatable to a Guid
-    static member Parse(input: string) = ClientId (Guid.Parse input)
-/// Represent as a Guid.ToString("N") output externally
-and private ClientIdJsonConverter() =
-    inherit JsonIsomorphism<ClientId, string>()
-    /// Renders as per Guid.ToString("N")
-    override __.Pickle value = value.Value
-    /// Input must be a Guid.Parseable value
-    override __.UnPickle input = ClientId.Parse input
-and private ClientIdStringConverter() =
-    inherit System.ComponentModel.TypeConverter()
-    override __.CanConvertFrom(context, sourceType) =
-        sourceType = typedefof<string> || base.CanConvertFrom(context,sourceType)
-    override __.ConvertFrom(context, culture, value) =
-        match value with
-        | :? string as s -> s |> ClientId.Parse |> box
-        | _ -> base.ConvertFrom(context, culture, value)
-    override __.ConvertTo(context, culture, value, destinationType) =
-        match value with
-        | :? ClientId as value when destinationType = typedefof<string> -> value.Value :> _
-        | _ -> base.ConvertTo(context, culture, value, destinationType)
+type ClientId = Guid<clientId>
+and [<Measure>] clientId
+module ClientId =
+    let toStringN (value : ClientId) : string = let g : Guid = %value in g.ToString "N"

--- a/samples/Store/Domain/Infrastructure.fs
+++ b/samples/Store/Domain/Infrastructure.fs
@@ -22,7 +22,7 @@ module Seq =
 /// Endows any type that inherits this class with standard .NET comparison semantics using a supplied token identifier
 [<AbstractClass>]
 type Comparable<'TComp, 'Token when 'TComp :> Comparable<'TComp, 'Token> and 'Token : comparison>(token : 'Token) =
-    member private __.Token = token // I can haz protected?
+    member private __.Token = token
     override x.Equals y = match y with :? Comparable<'TComp, 'Token> as y -> x.Token = y.Token | _ -> false
     override __.GetHashCode() = hash token
     interface IComparable with
@@ -30,6 +30,13 @@ type Comparable<'TComp, 'Token when 'TComp :> Comparable<'TComp, 'Token> and 'To
             match y with
             | :? Comparable<'TComp, 'Token> as y -> compare x.Token y.Token
             | _ -> invalidArg "y" "invalid comparand"
+
+/// Endows any type that inherits this class with standard .NET comparison semantics using a supplied token identifier
+/// + treats the token as the canonical rendition for `ToString()` purposes
+[<AbstractClass>]
+type StringId<'TComp when 'TComp :> Comparable<'TComp, string>>(token : string) =
+    inherit Comparable<'TComp,string>(token)
+    override __.ToString() = token
 
 /// SkuId strongly typed id
 [<Sealed; JsonConverter(typeof<SkuIdJsonConverter>); AutoSerializable(false); StructuredFormatDisplay("{Value}")>]
@@ -52,35 +59,32 @@ and private SkuIdJsonConverter() =
     /// Input must be a Guid.Parseable value
     override __.UnPickle input = SkuId.Parse input
 
+module Guid =
+    let toStringN (x : Guid) = x.ToString "N"
+
 /// RequestId strongly typed id
-[<Sealed; JsonConverter(typeof<RequestIdJsonConverter>); AutoSerializable(false); StructuredFormatDisplay("{Value}")>]
-// (Internally a string for most efficient copying semantics)
+/// - Implements comparison/equality and default ctor to enable tests to leverage structural equality and empty
+/// - Guarantees canonical rendering in Guid.ToString("N") format without dashes via ToString and Newtonsoft.Json
+/// - Guards against XSS by only permitting initialization based on Guid.Parse
+[<Sealed; JsonConverter(typeof<RequestIdJsonConverter>); AutoSerializable(false)>]
 type RequestId private (id : string) =
-    inherit Comparable<RequestId, string>(id)
-    [<IgnoreDataMember>] // Prevent swashbuckle inferring there's a "value" field
-    member __.Value = id
-    override __.ToString () = id
-    new (guid: Guid) = RequestId (guid.ToString("N"))
-    // NB tests (specifically, empty) lean on having a ctor of this shape
+    inherit StringId<RequestId>(id)
+    new(id : Guid) = RequestId(Guid.toStringN id)
     new() = RequestId(Guid.NewGuid())
-    // NB for validation [and XSS] purposes we prove it translatable to a Guid
-    static member Parse(input: string) = RequestId (Guid.Parse input)
 /// Represent as a Guid.ToString("N") output externally
 and private RequestIdJsonConverter() =
     inherit JsonIsomorphism<RequestId, string>()
-    /// Renders as per Guid.ToString("N")
-    override __.Pickle value = value.Value
-    /// Input must be a Guid.Parseable value
-    override __.UnPickle input = RequestId.Parse input
+    /// Renders as per `Guid.ToString("N")`
+    override __.Pickle value = string value
+    /// Input must be a `Guid.Parse`able value
+    override __.UnPickle input = Guid.Parse input |> RequestId
 
 /// CartId strongly typed id
 type CartId = Guid<cartId>
 and [<Measure>] cartId
-module CartId =
-    let toStringN (value : CartId) : string = let g : Guid = %value in g.ToString "N"
+module CartId = let toStringN (value : CartId) : string = Guid.toStringN %value
 
 /// ClientId strongly typed id
 type ClientId = Guid<clientId>
 and [<Measure>] clientId
-module ClientId =
-    let toStringN (value : ClientId) : string = let g : Guid = %value in g.ToString "N"
+module ClientId = let toStringN (value : ClientId) : string = Guid.toStringN %value

--- a/samples/Store/Domain/Infrastructure.fs
+++ b/samples/Store/Domain/Infrastructure.fs
@@ -1,6 +1,7 @@
 ﻿[<AutoOpen>]
 module Domain.Infrastructure
 
+open FSharp.UMX
 open Newtonsoft.Json
 open Newtonsoft.Json.Converters.FSharp
 open System
@@ -72,25 +73,11 @@ and private RequestIdJsonConverter() =
     /// Input must be a Guid.Parseable value
     override __.UnPickle input = RequestId.Parse input
 
+[<Measure>] type cartId
 /// CartId strongly typed id
-[<Sealed; JsonConverter(typeof<CartIdJsonConverter>); AutoSerializable(false); StructuredFormatDisplay("{Value}")>]
-// (Internally a string for most efficient copying semantics)
-type CartId private (id : string) =
-    inherit Comparable<CartId, string>(id)
-    [<IgnoreDataMember>] // Prevent swashbuckle inferring there's a "value" field
-    member __.Value = id
-    override __.ToString () = id
-    // NB tests lean on having a ctor of this shape
-    new (guid: Guid) = CartId (guid.ToString("N"))
-    // NB for validation [and XSS] purposes we must prove it translatable to a Guid
-    static member Parse(input: string) = CartId (Guid.Parse input)
-/// Represent as a Guid.ToString("N") output externally
-and private CartIdJsonConverter() =
-    inherit JsonIsomorphism<CartId, string>()
-    /// Renders as per Guid.ToString("N")
-    override __.Pickle value = value.Value
-    /// Input must be a Guid.Parseable value
-    override __.UnPickle input = CartId.Parse input
+type CartId = Guid<cartId>
+module CartId =
+    let toStringN (value : CartId) : string = let g : Guid = %value in g.ToString("N") 
 
 /// ClientId strongly typed id
 [<Sealed; JsonConverter(typeof<ClientIdJsonConverter>); AutoSerializable(false); StructuredFormatDisplay("{Value}")>]

--- a/samples/Store/Domain/InventoryItem.fs
+++ b/samples/Store/Domain/InventoryItem.fs
@@ -64,10 +64,8 @@ type Handler(log, stream, ?maxAttempts) =
     member __.Read : Async<Folds.State> =
         inner.Query id
 
-type InventoryItemId = InventoryItemId of Guid
-
 type Service(log, resolveStream) =
-    let (|AggregateId|) (InventoryItemId id) = Equinox.AggregateId ("InventoryItem", id.ToString("N"))
+    let (|AggregateId|) (id : InventoryItemId) = Equinox.AggregateId ("InventoryItem", InventoryItemId.toStringN id)
     let (|Stream|) (AggregateId id) = Handler(log, resolveStream id)
 
     member __.Execute (Stream handler) command =

--- a/samples/Store/Integration/CodecIntegration.fs
+++ b/samples/Store/Integration/CodecIntegration.fs
@@ -2,9 +2,9 @@
 module Samples.Store.Integration.CodecIntegration
 
 open Domain
+open FSharp.UMX
 open Swensen.Unquote
 open TypeShape.UnionContract
-open Xunit
 
 let serializationSettings =
     Newtonsoft.Json.Converters.FSharp.Settings.CreateCorrect(converters=
@@ -14,7 +14,7 @@ let serializationSettings =
 let genCodec<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>() =
     Equinox.UnionCodec.JsonUtf8.Create<'Union>(serializationSettings)
 
-type EventWithId = { id : SkuId }
+type EventWithId = { id : Guid<skuId> }
 
 type EventWithOption = { age : int option }
 

--- a/samples/Store/Integration/Infrastructure.fs
+++ b/samples/Store/Integration/Infrastructure.fs
@@ -6,7 +6,6 @@ open FsCheck
 open System
 
 type FsCheckGenerators =
-    static member CartId = Arb.generate |> Gen.map CartId |> Arb.fromGen
     static member SkuId = Arb.generate |> Gen.map SkuId |> Arb.fromGen
     static member RequestId = Arb.generate |> Gen.map RequestId |> Arb.fromGen
     static member ContactPreferencesId =

--- a/samples/Store/Integration/Infrastructure.fs
+++ b/samples/Store/Integration/Infrastructure.fs
@@ -7,7 +7,6 @@ open System
 
 type FsCheckGenerators =
     static member SkuId = Arb.generate |> Gen.map SkuId |> Arb.fromGen
-    static member RequestId = Arb.generate |> Gen.map RequestId |> Arb.fromGen
     static member ContactPreferencesId =
         Arb.generate<Guid>
         |> Gen.map (fun x -> sprintf "%s@test.com" (x.ToString("N")))

--- a/samples/Store/Integration/Integration.fsproj
+++ b/samples/Store/Integration/Integration.fsproj
@@ -30,13 +30,13 @@
   <ItemGroup>
     <PackageReference Include="FsCheck.xUnit" Version="2.12.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
     <PackageReference Include="unquote" Version="4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/Store/Integration/LogIntegration.fs
+++ b/samples/Store/Integration/LogIntegration.fs
@@ -1,8 +1,8 @@
 ﻿module Samples.Store.Integration.LogIntegration
 
-open Domain
 open Equinox.Cosmos.Integration
 open Equinox.Store
+open FSharp.UMX
 open Swensen.Unquote
 open System
 open System.Collections.Concurrent
@@ -113,7 +113,7 @@ type Tests() =
         let gateway = createGesGateway conn batchSize
         let service = Backend.Cart.Service(log, CartIntegration.resolveGesStreamWithRollingSnapshots gateway)
         let itemCount = batchSize / 2 + 1
-        let cartId = Guid.NewGuid() |> CartId
+        let cartId = % Guid.NewGuid()
         do! act buffer service itemCount context cartId skuId "ReadStreamEventsBackwardAsync-Duration"
     }
 
@@ -126,6 +126,6 @@ type Tests() =
         let gateway = createEqxStore conn batchSize
         let service = Backend.Cart.Service(log, CartIntegration.resolveEqxStreamWithProjection gateway)
         let itemCount = batchSize / 2 + 1
-        let cartId = Guid.NewGuid() |> CartId
+        let cartId = % Guid.NewGuid()
         do! act buffer service itemCount context cartId skuId "EqxCosmos Tip " // one is a 404, one is a 200
     }

--- a/samples/TodoBackend/Todo.fs
+++ b/samples/TodoBackend/Todo.fs
@@ -56,7 +56,8 @@ type Handler(log, stream, ?maxAttempts) =
 type Service(handlerLog, resolve) =
     // The TodoBackend spec does not dictate having multiple lists, tentants or clients
     // Here, we implement such a discriminator in order to allow each virtual client to maintain independent state
-    let (|Stream|) (clientId: ClientId) = Handler(handlerLog, resolve (Equinox.AggregateId("Todos", if obj.ReferenceEquals(clientId,null) then "1" else clientId.Value)))
+    let (|AggregateId|) (id : ClientId) = Equinox.AggregateId("Todos", ClientId.toStringN id)
+    let (|Stream|) (AggregateId id) = Handler(handlerLog, resolve id)
 
     member __.List(Stream stream) : Async<Todo seq> =
         stream.Query (fun s -> s.items |> Seq.ofList)

--- a/tests/Equinox.Cosmos.Integration/CosmosFixturesInfrastructure.fs
+++ b/tests/Equinox.Cosmos.Integration/CosmosFixturesInfrastructure.fs
@@ -9,7 +9,6 @@ open Serilog.Core
 
 type FsCheckGenerators =
     static member SkuId = Arb.generate |> Gen.map SkuId |> Arb.fromGen
-    static member RequestId = Arb.generate |> Gen.map RequestId |> Arb.fromGen
     static member ContactPreferencesId =
         Arb.generate<Guid>
         |> Gen.map (fun x -> sprintf "%s@test.com" (x.ToString("N")))

--- a/tests/Equinox.Cosmos.Integration/CosmosIntegration.fs
+++ b/tests/Equinox.Cosmos.Integration/CosmosIntegration.fs
@@ -3,6 +3,7 @@
 open Domain
 open Equinox.Cosmos
 open Equinox.Cosmos.Integration.Infrastructure
+open FSharp.UMX
 open Swensen.Unquote
 open System.Threading
 open System
@@ -75,7 +76,7 @@ type Tests(testOutputHelper) =
         let service = Cart.createServiceWithoutOptimizationAndMaxItems conn maxItemsPerRequest maxEventsPerBatch log
         capture.Clear() // for re-runs of the test
 
-        let cartId = Guid.NewGuid() |> CartId
+        let cartId = % Guid.NewGuid()
         // The command processing should trigger only a single read and a single write call
         let addRemoveCount = 2
         let eventsPerAction = addRemoveCount * 2 - 1
@@ -110,7 +111,7 @@ type Tests(testOutputHelper) =
         let batchSize = 3
 
         let context, (sku11, sku12, sku21, sku22) = ctx
-        let cartId = Guid.NewGuid() |> CartId
+        let cartId = % Guid.NewGuid()
 
         // establish base stream state
         let service1 =
@@ -222,7 +223,7 @@ type Tests(testOutputHelper) =
         capture.Clear()
 
         // Trigger 10 events, then reload
-        let cartId = Guid.NewGuid() |> CartId
+        let cartId = % Guid.NewGuid()
         do! addAndThenRemoveItemsManyTimes context cartId skuId service1 5
         let! _ = service2.Read cartId
 
@@ -250,7 +251,7 @@ type Tests(testOutputHelper) =
         capture.Clear()
 
         // Trigger 10 events, then reload
-        let cartId = Guid.NewGuid() |> CartId
+        let cartId = % Guid.NewGuid()
         do! addAndThenRemoveItemsManyTimes context cartId skuId service1 5
         let! _ = service2.Read cartId
 

--- a/tests/Equinox.Cosmos.Integration/CosmosIntegration.fs
+++ b/tests/Equinox.Cosmos.Integration/CosmosIntegration.fs
@@ -4,11 +4,12 @@ open Domain
 open Equinox.Cosmos
 open Equinox.Cosmos.Integration.Infrastructure
 open FSharp.UMX
+open Newtonsoft.Json
 open Swensen.Unquote
 open System.Threading
 open System
 
-let serializationSettings = Newtonsoft.Json.Converters.FSharp.Settings.CreateCorrect()
+let serializationSettings = JsonSerializerSettings()
 let genCodec<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>() =
     Equinox.UnionCodec.JsonUtf8.Create<'Union>(serializationSettings)
 

--- a/tests/Equinox.EventStore.Integration/EventStoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/EventStoreIntegration.fs
@@ -2,6 +2,7 @@
 
 open Equinox.EventStore
 open Equinox.Integration.Infrastructure
+open Newtonsoft.Json
 open Serilog
 open Swensen.Unquote
 open System.Threading
@@ -18,7 +19,7 @@ let connectToLocalEventStoreNode log =
 let defaultBatchSize = 500
 let createGesGateway connection batchSize = GesGateway(connection, GesBatchingPolicy(maxBatchSize = batchSize))
 
-let serializationSettings = Newtonsoft.Json.Converters.FSharp.Settings.CreateCorrect()
+let serializationSettings = JsonSerializerSettings()
 let genCodec<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>() =
     Equinox.UnionCodec.JsonUtf8.Create<'Union>(serializationSettings)
 

--- a/tests/Equinox.EventStore.Integration/Infrastructure.fs
+++ b/tests/Equinox.EventStore.Integration/Infrastructure.fs
@@ -7,7 +7,6 @@ open System
 
 type FsCheckGenerators =
     static member SkuId = Arb.generate |> Gen.map SkuId |> Arb.fromGen
-    static member RequestId = Arb.generate |> Gen.map RequestId |> Arb.fromGen
     static member ContactPreferencesId =
         Arb.generate<Guid>
         |> Gen.map (fun x -> sprintf "%s@test.com" (x.ToString("N")))

--- a/tests/Equinox.MemoryStore.Integration/Infrastructure.fs
+++ b/tests/Equinox.MemoryStore.Integration/Infrastructure.fs
@@ -9,7 +9,6 @@ open System
 
 type FsCheckGenerators =
     static member SkuId = Arb.generate |> Gen.map SkuId |> Arb.fromGen
-    static member RequestId = Arb.generate |> Gen.map RequestId |> Arb.fromGen
 
 type AutoDataAttribute() =
     inherit FsCheck.Xunit.PropertyAttribute(Arbitrary = [|typeof<FsCheckGenerators>|], MaxTest = 1, QuietOnSuccess = true)

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -3,6 +3,7 @@
 open Argu
 open Domain.Infrastructure
 open Equinox.Tool.Infrastructure
+open FSharp.UMX
 open Microsoft.Extensions.DependencyInjection
 open Samples.Infrastructure.Log
 open Samples.Infrastructure.Storage
@@ -157,7 +158,7 @@ module LoadTest =
             | [] -> TimeSpan.FromSeconds 10.|> Seq.singleton
             | intervals -> seq { for i in intervals -> TimeSpan.FromSeconds(float i) }
             |> fun intervals -> [| yield duration; yield! intervals |]
-        let clients = Array.init (testsPerSecond * 2) (fun _ -> Guid.NewGuid () |> ClientId)
+        let clients = Array.init (testsPerSecond * 2) (fun _ -> % Guid.NewGuid())
 
         log.Information( "Running {test} for {duration} @ {tps} hits/s across {clients} clients; Max errors: {errorCutOff}, reporting intervals: {ri}, report file: {report}",
             test, duration, testsPerSecond, clients.Length, errorCutoff, reportingIntervals, reportFilename)

--- a/tools/Equinox.Tool/StoreClient.fs
+++ b/tools/Equinox.Tool/StoreClient.fs
@@ -9,7 +9,7 @@ open System.Net.Http
 type Session(client: HttpClient, clientId: ClientId) =
 
     member __.Send(req : HttpRequestMessage) : Async<HttpResponseMessage> =
-        let req = req |> HttpReq.withHeader "COMPLETELY_INSECURE_CLIENT_ID" clientId.Value
+        let req = req |> HttpReq.withHeader "COMPLETELY_INSECURE_CLIENT_ID" (ClientId.toStringN clientId)
         client.Send(req)
 
 type Favorited = { date: System.DateTimeOffset; skuId: SkuId }

--- a/tools/Equinox.Tool/TodoClient.fs
+++ b/tools/Equinox.Tool/TodoClient.fs
@@ -11,7 +11,7 @@ type Todo = { id: int; url: string; order: int; title: string; completed: bool }
 type Session(client: HttpClient, clientId: ClientId) =
 
     member __.Send(req : HttpRequestMessage) : Async<HttpResponseMessage> =
-        let req = req |> HttpReq.withHeader "COMPLETELY_INSECURE_CLIENT_ID" clientId.Value
+        let req = req |> HttpReq.withHeader "COMPLETELY_INSECURE_CLIENT_ID" (ClientId.toStringN clientId)
         client.Send(req)
 
 type TodosClient(session: Session) =


### PR DESCRIPTION
This PR cleans up the Id Types per #83 using https://github.com/fsprojects/FSharp.UMX

- [x] For CartId + ClientId, use a tagged Guid (not stored or indexed, but used as binding target in Todo sample)
- [x] For SkuId, retain string encoding (but need to uphold other constraints)
- [x] ClientId, RequestId etc.
- [x] I'm leaving some unfinished work wrt completely getting rid of the concrete SkuId - see https://github.com/jet/equinox/tree/idtypes-extra