### PR TITLE
Update Projection to use `Confluent.Kafka.1.0.0-beta2`

### DIFF
--- a/src/Equinox.Projection.Kafka/Equinox.Projection.Kafka.fsproj
+++ b/src/Equinox.Projection.Kafka/Equinox.Projection.Kafka.fsproj
@@ -22,12 +22,7 @@
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
 
     <PackageReference Include="Confluent.Kafka" Version="1.0.0-beta2" />
-    <!-- TODO remove special casing
-         While the general policy is to use 11.0.2 across the board for consistency (11.0.2 being the first version that cleanly supports netstandard2.0),
-         in this case we're relaxing the constraint for net461 so as to not trigger a set of transitive dependency updates at the present time
-         should also be able to remove [<Trait("KnownFailOn","Mono")>] in JsonConverterTests when this special casing goes away -->
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" Condition=" '$(TargetFramework)' != 'netstandard2.0' " />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 

--- a/src/Equinox.Projection.Kafka/Equinox.Projection.Kafka.fsproj
+++ b/src/Equinox.Projection.Kafka/Equinox.Projection.Kafka.fsproj
@@ -21,7 +21,7 @@
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' != 'netstandard2.0' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
 
-    <PackageReference Include="Confluent.Kafka" Version="0.11.4" />
+    <PackageReference Include="Confluent.Kafka" Version="1.0.0-beta2" />
     <!-- TODO remove special casing
          While the general policy is to use 11.0.2 across the board for consistency (11.0.2 being the first version that cleanly supports netstandard2.0),
          in this case we're relaxing the constraint for net461 so as to not trigger a set of transitive dependency updates at the present time

--- a/src/Equinox.Projection.Kafka/Kafka.fs
+++ b/src/Equinox.Projection.Kafka/Kafka.fs
@@ -246,13 +246,6 @@ type KafkaProducer private (log: ILogger, producer : Producer<string, string>, t
 
             c.Close()
 
-            //let _ = Async.StartAsTask(async { poll() }, cancellationToken = cts.Token)
-            //{ new IDisposable with 
-            //    member __.Dispose() = 
-            //        log.Information("Consumer:{name} Run poll disposing", c.Name)
-                    
-            //        cts.Dispose() }
-
         member c.WithLogging(log: ILogger) =
             let d1 = c.OnLog.Subscribe(fun m ->
                 log.Information("consumer_info|{message} level={level} name={name} facility={facility}", m.Message, m.Level, m.Name, m.Facility))

--- a/src/Equinox.Projection.Kafka/Kafka.fs
+++ b/src/Equinox.Projection.Kafka/Kafka.fs
@@ -271,8 +271,8 @@ type KafkaProducer private (log: ILogger, producer : Producer<string, string>, t
 
     let mkConsumer (kvps : seq<KeyValuePair<string,string>>, topics : string seq)  =
         let consumer = new Consumer<'Key, 'Value>(kvps)
-        //let _ = consumer.OnPartitionsAssigned.Subscribe(fun m -> consumer.Assign m)
-        //let _ = consumer.OnPartitionsRevoked.Subscribe(fun _ -> consumer.Unassign())
+        let _ = consumer.OnPartitionsAssigned.Subscribe(fun m -> consumer.Assign m)
+        let _ = consumer.OnPartitionsRevoked.Subscribe(fun _ -> consumer.Unassign())
         consumer.Subscribe topics
         consumer
 

--- a/src/Equinox.Projection.Kafka/Kafka.fs
+++ b/src/Equinox.Projection.Kafka/Kafka.fs
@@ -232,12 +232,9 @@ type KafkaProducer private (log: ILogger, producer : Producer<string, string>, t
             c.StoreOffsets[| TopicPartitionOffset(tpo.Topic, tpo.Partition, Offset(let o = tpo.Offset in o.Value + 1L)) |]
 
         member c.RunPoll(log : ILogger, counter : InFlightMessageCounter, cancellationToken: CancellationToken , onMessage: ConsumeResult<'Key,'Value> -> unit) =
-            //let poll() = 
             while not cancellationToken.IsCancellationRequested do
                 counter.AwaitThreshold()
-                //log.Information("Consumer:{name} Entering consume", c.Name)
                 try let message = c.Consume(cancellationToken) // NB don't use TimeSpan overload unless you want GPFs on1.0.0-beta2
-                    //log.Information("Consumer:{name} Exiting consume", c.Name)
                     if message <> null then
                         onMessage message
                 with 

--- a/tests/Equinox.Projection.Kafka.Integration/KafkaIntegration.fs
+++ b/tests/Equinox.Projection.Kafka.Integration/KafkaIntegration.fs
@@ -58,7 +58,7 @@ module Helpers =
 
     type TestMessage = { producerId : int ; messageId : int }
     [<NoComparison; NoEquality>]
-    type ConsumedTestMessage = { consumerId : int ; message : KafkaConsumerMessage ; payload : TestMessage }
+    type ConsumedTestMessage = { consumerId : int ; message : KafkaMessage ; payload : TestMessage }
     type ConsumerCallback = KafkaConsumer -> ConsumedTestMessage [] -> Async<unit>
 
     let runProducers log (broker : Uri) (topic : string) (numProducers : int) (messagesPerProducer : int) = async {
@@ -84,7 +84,7 @@ module Helpers =
 
     let runConsumers log (config : KafkaConsumerConfig) (numConsumers : int) (timeout : TimeSpan option) (handler : ConsumerCallback) = async {
         let mkConsumer (consumerId : int) = async {
-            let deserialize (msg : KafkaConsumerMessage) = { consumerId = consumerId ; message = msg ; payload = JsonConvert.DeserializeObject<_> msg.Value }
+            let deserialize (msg : KafkaMessage) = { consumerId = consumerId ; message = msg ; payload = JsonConvert.DeserializeObject<_> msg.Value }
 
             // need to pass the consumer instance to the handler callback
             // do a bit of cyclic dependency fixups
@@ -137,7 +137,7 @@ type T1(testOutputHelper) =
         let config = KafkaConsumerConfig.Create("panther", broker, [topic], groupId)
         let consumers = runConsumers log config numConsumers None consumerCallback
 
-        do! [ producers; consumers ]
+        do! [ producers ; consumers ]
             |> Async.Parallel
             |> Async.Ignore
 

--- a/tests/Equinox.Projection.Kafka.Integration/KafkaIntegration.fs
+++ b/tests/Equinox.Projection.Kafka.Integration/KafkaIntegration.fs
@@ -116,7 +116,7 @@ type T1(testOutputHelper) =
 
     let [<FactIfBroker>] ``ConfluentKafka producer-consumer basic roundtrip`` () = async {
         let numProducers = 10
-        let numConsumers = 4
+        let numConsumers = 10
         let messagesPerProducer = 1000
 
         let topic = newId() // dev kafka topics are created and truncated automatically
@@ -128,7 +128,7 @@ type T1(testOutputHelper) =
             let messageCount = consumedBatches |> Seq.sumBy Array.length
             // signal cancellation if consumed items reaches expected size
             if messageCount >= numProducers * messagesPerProducer then
-                do! consumer.Stop()
+                consumer.Stop()
         }
 
         // Section: run the test
@@ -187,6 +187,9 @@ type T2(testOutputHelper) =
         let config = KafkaConsumerConfig.Create("panther", broker, [topic], groupId)
         
         let! r = Async.Catch <| runConsumers log config 1 None (fun _ _ -> raise <|IndexOutOfRangeException())
+        match r with
+        | Choice1Of2 a -> ()
+        | Choice2Of2 b -> ()
         test <@ match r with Choice2Of2 (:? IndexOutOfRangeException) -> true | x -> failwithf "%A" x @>
     }
 

--- a/tests/Equinox.Projection.Kafka.Integration/KafkaIntegration.fs
+++ b/tests/Equinox.Projection.Kafka.Integration/KafkaIntegration.fs
@@ -169,7 +169,7 @@ type T1(testOutputHelper) =
             allMessages
             |> Array.groupBy (fun msg -> msg.payload.producerId)
             |> Array.map (fun (_, gp) -> gp |> Array.distinctBy (fun msg -> msg.payload.messageId))
-            |> Array.forall (fun gp -> true)//gp.Length = messagesPerProducer)
+            |> Array.forall (fun gp -> gp.Length = messagesPerProducer)
 
         test <@ ``should have consumed all expected messages`` @> // "should have consumed all expected messages"
     }
@@ -187,9 +187,6 @@ type T2(testOutputHelper) =
         let config = KafkaConsumerConfig.Create("panther", broker, [topic], groupId)
         
         let! r = Async.Catch <| runConsumers log config 1 None (fun _ _ -> raise <|IndexOutOfRangeException())
-        match r with
-        | Choice1Of2 a -> ()
-        | Choice2Of2 b -> ()
         test <@ match r with Choice2Of2 (:? IndexOutOfRangeException) -> true | x -> failwithf "%A" x @>
     }
 

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -322,7 +322,7 @@ let main argv =
                 let producer, disposeProducer =
                     match broker,topic with
                     | Some b,Some t ->
-                        let cfg = KafkaProducerConfig.Create("equinox-tool", Uri b, maxInFlight = 1, compression = Config.Producer.LZ4)
+                        let cfg = KafkaProducerConfig.Create("equinox-tool", Uri b, maxInFlight = 1, compression = Config.LZ4)
                         let p = KafkaProducer.Create(log, cfg, t)
                         Some p, (p :> IDisposable).Dispose
                     | _ -> None, id


### PR DESCRIPTION
This PR updates the `Confluent.Kafka` reference from 0.11.4 to the above.

The core of the changes here are based on [the examples](https://github.com/confluentinc/confluent-kafka-dotnet/tree/master/examples)

Reduction in number of config settings is from a mix of spotting redundancy based on [the docs](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) and in reading the xmldoc for the ConsumerConfig/ClientConfig/ProducerConfig classes in the `Confluent.Kafka` library

_It should be noted that moving to 0.11.5 or 0.11.6 also necessitate similar changes to the shutdown logic (which sometimes can be reduced by changing the number of consumers to 1 in the happy path test)_.