### PR TITLE
Handle Nullary cases in Cosmos

### DIFF
--- a/samples/Store/Integration/CodecIntegration.fs
+++ b/samples/Store/Integration/CodecIntegration.fs
@@ -30,6 +30,9 @@ type SimpleDu =
     | EventA of EventWithId
     | EventB of EventWithOption
     | EventC of EventWithUnion
+    | EventD
+    | EventE of int
+    | EventF of string
     interface IUnionContract
 
 let render = function
@@ -39,12 +42,15 @@ let render = function
     | EventC { value = I { i = i } } -> sprintf """{"value":{"case":"I","i":%d}}""" i
     | EventC { value = S { maybeI = None } } -> sprintf """{"value":{"case":"S"}}"""
     | EventC { value = S { maybeI = Some i } } -> sprintf """{"value":{"case":"S","maybeI":%d}}""" i
+    | EventD -> null
+    | EventE i -> string i
+    | EventF s ->  Newtonsoft.Json.JsonConvert.SerializeObject s
 
 let codec = genCodec<SimpleDu>()
 
 [<AutoData(MaxTest=100)>]
 let ``Can roundtrip, rendering correctly`` (x: SimpleDu) =
     let serialized = codec.Encode x
-    render x =! System.Text.Encoding.UTF8.GetString(serialized.payload)
+    render x =! if serialized.payload = null then null else System.Text.Encoding.UTF8.GetString(serialized.payload)
     let deserialized = codec.TryDecode serialized |> Option.get
     deserialized =! x

--- a/samples/Tutorial/Todo.fsx
+++ b/samples/Tutorial/Todo.fsx
@@ -28,7 +28,9 @@ type Event =
 
 type State = { items : Todo list; nextId : int }
 let initial = { items = []; nextId = 0 }
-let evolve s = function
+let evolve s (e : Event) = 
+    printfn "%A" e
+    match e with
     | Added item -> { s with items = item :: s.items; nextId = s.nextId + 1 }
     | Updated value -> { s with items = s.items |> List.map (function { id = id } when id = value.id -> value | item -> item) }
     | Deleted id -> { s with items = s.items |> List.filter (fun x -> x.id <> id) }
@@ -116,7 +118,7 @@ module TodosCategory =
 
 let service = Service(log, TodosCategory.resolve)
 
-let client = "ClientB"
+let client = "ClientJ"
 let item = { id = 0; order = 0; title = "Feed cat"; completed = false }
 service.Create(client, item) |> Async.RunSynchronously
 //val it : Todo = {id = 0;
@@ -144,7 +146,22 @@ service.TryGet(client, 3) |> Async.RunSynchronously
 
 let itemH = { id = 1; order = 0; title = "Feed horse"; completed = false }
 service.Patch(client, itemH) |> Async.RunSynchronously
+//[05:49:33 INF] EqxCosmos Tip 302 116ms rc=1
+//Updated {id = 1;
+//         order = 0;
+//         title = "Feed horse";
+//         completed = false;}Updated {id = 1;
+//         order = 0;
+//         title = "Feed horse";
+//         completed = false;}[05:49:33 INF] EqxCosmos Sync 1+1 534ms rc=14.1
 //val it : Todo = {id = 1;
 //                 order = 0;
 //                 title = "Feed horse";
-//                 completed = false;} 
+//                 completed = false;}
+service.Execute(client, Delete 1) |> Async.RunSynchronously 
+//[05:47:18 INF] EqxCosmos Tip 302 224ms rc=1
+//Deleted 1[05:47:19 INF] EqxCosmos Sync 1+1 230ms rc=13.91
+//val it : unit = ()
+service.List(client) |> Async.RunSynchronously
+//[05:47:22 INF] EqxCosmos Tip 302 119ms rc=1
+//val it : seq<Todo> = []

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -14,7 +14,8 @@ type [<NoEquality; NoComparison; JsonObject(ItemRequired=Required.Always)>]
 
         /// Event body, as UTF-8 encoded json ready to be injected into the Json being rendered for DocDb
         [<JsonConverter(typeof<Equinox.Cosmos.Internal.Json.VerbatimUtf8JsonConverter>)>]
-        d: byte[] // required
+        [<JsonProperty(Required=Required.AllowNull)>]
+        d: byte[] // Required, but can be null so Nullary cases can work
 
         /// Optional metadata, as UTF-8 encoded json, ready to emit directly (null, not written if missing)
         [<JsonConverter(typeof<Equinox.Cosmos.Internal.Json.VerbatimUtf8JsonConverter>)>]


### PR DESCRIPTION
- Adjusts rules re json rendering in Cosmos to facilitate cases without any elements (which json.net translates to a `null` value)
- Add json rendering integration test cases to illustrate that special casing for string union cases is a separate matter