### PR TITLE
Generalize Codec factory namespacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - Uses MinVer 1.0.0 [internally] to compute package versions (was `rc.1`, `beta.4` along the way)
 - Rename `Equinox.Projection.Codec` to `Equinox.Projection` (no code changes)
 - Remove `maxEventsPerSlice`/`maxTipEvents` pending [#109](https://github.com/jet/equinox/issues/109)
+- Renamespaced and separated `Equinox.Codec` to `Equinox.Codec.NewtonsoftJson` and `Equinox.Codec.Custom` (in preparation for [#113](https://github.com/jet/equinox/issues/113)) HT @szer
 
 ### Removed
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ The components within this repository are delivered as a series of multi-targete
 
 - `Equinox[.Stream]` [![NuGet](https://img.shields.io/nuget/v/Equinox.svg)](https://www.nuget.org/packages/Equinox/): Store-agnostic decision flow runner that manages the optimistic concurrency protocol. ([depends](https://www.fuget.org/packages/Equinox) on `Serilog` (but no specific Serilog sinks, i.e. you configure to emit to `NLog` etc))
 - `Equinox.Codec` [![Codec NuGet](https://img.shields.io/nuget/v/Equinox.Codec.svg)](https://www.nuget.org/packages/Equinox.Codec/): [a scheme for the serializing Events modelled as an F# Discriminated Union](https://eiriktsarpalis.wordpress.com/2018/10/30/a-contract-pattern-for-schemaless-datastores/) ([depends](https://www.fuget.org/packages/Equinox.Codec) on `TypeShape 6.*`, `Newtonsoft.Json >= 11.0.2` but can support any serializer) with the following capabilities:
-  - `Equinox.Codec.JsonNet.JsonUtf8`: allows tagging of F# Discriminated Union cases in a versionable manner with low-dependency `DataMember(Name=` tags using [TypeShape](https://github.com/eiriktsarpalis/TypeShape)'s [`UnionContractEncoder`](https://github.com/eiriktsarpalis/TypeShape/blob/master/tests/TypeShape.Tests/UnionContractTests.fs)
-  - `Equinox.Codec.JsonUtf8`: independent of any specific serializer; enables plugging in a serializer and/or Union Encoder of your choice
+  - `Equinox.Codec.NewtonsoftJson.Json`: allows tagging of F# Discriminated Union cases in a versionable manner with low-dependency `DataMember(Name=` tags using [TypeShape](https://github.com/eiriktsarpalis/TypeShape)'s [`UnionContractEncoder`](https://github.com/eiriktsarpalis/TypeShape/blob/master/tests/TypeShape.Tests/UnionContractTests.fs)
+  - `Equinox.Codec.Custom`: independent of any specific serializer; enables plugging in a serializer and/or Union Encoder of your choice
 
 ### Store libraries
 

--- a/samples/Infrastructure/Services.fs
+++ b/samples/Infrastructure/Services.fs
@@ -3,9 +3,6 @@
 open Microsoft.Extensions.DependencyInjection
 open System
 
-let serializationSettings = Newtonsoft.Json.Converters.FSharp.Settings.CreateCorrect()
-let genCodec<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>() = Equinox.Codec.JsonNet.JsonUtf8.Create<'Union>(serializationSettings)
-
 type StreamResolver(storage) =
     member __.Resolve
         (   codec : Equinox.Codec.IUnionEncoder<'event,byte[]>,
@@ -23,32 +20,40 @@ type StreamResolver(storage) =
             let accessStrategy = if unfolds then Equinox.Cosmos.AccessStrategy.Snapshot snapshot |> Some else None
             Equinox.Cosmos.CosmosResolver<'event,'state>(store, codec, fold, initial, caching, ?access = accessStrategy).Resolve
 
-type ServiceBuilder(storageConfig, handlerLog) =
+type ICodecGen =
+    abstract Generate<'Union when 'Union :> TypeShape.UnionContract.IUnionContract> : unit -> Equinox.Codec.IUnionEncoder<'Union,byte[]>
+
+type ServiceBuilder(storageConfig, handlerLog, codecGen : ICodecGen) =
      let resolver = StreamResolver(storageConfig)
 
      member __.CreateFavoritesService() =
-        let codec = genCodec<Domain.Favorites.Events.Event>()
+        let codec = codecGen.Generate<Domain.Favorites.Events.Event>()
         let fold, initial = Domain.Favorites.Folds.fold, Domain.Favorites.Folds.initial
         let snapshot = Domain.Favorites.Folds.isOrigin,Domain.Favorites.Folds.compact
         Backend.Favorites.Service(handlerLog, resolver.Resolve(codec,fold,initial,snapshot))
 
      member __.CreateSaveForLaterService() =
-        let codec = genCodec<Domain.SavedForLater.Events.Event>()
+        let codec = codecGen.Generate<Domain.SavedForLater.Events.Event>()
         let fold, initial = Domain.SavedForLater.Folds.fold, Domain.SavedForLater.Folds.initial
         let snapshot = Domain.SavedForLater.Folds.isOrigin,Domain.SavedForLater.Folds.compact
         Backend.SavedForLater.Service(handlerLog, resolver.Resolve(codec,fold,initial,snapshot), maxSavedItems=50)
 
      member __.CreateTodosService() =
-        let codec = genCodec<TodoBackend.Events.Event>()
+        let codec = codecGen.Generate<TodoBackend.Events.Event>()
         let fold, initial = TodoBackend.Folds.fold, TodoBackend.Folds.initial
         let snapshot = TodoBackend.Folds.isOrigin, TodoBackend.Folds.compact
         TodoBackend.Service(handlerLog, resolver.Resolve(codec,fold,initial,snapshot))
 
-let register (services : IServiceCollection, storageConfig, handlerLog) =
+let register (services : IServiceCollection, storageConfig, handlerLog, codecGen : ICodecGen) =
     let regF (factory : IServiceProvider -> 'T) = services.AddSingleton<'T>(fun (sp: IServiceProvider) -> factory sp) |> ignore
 
-    regF <| fun _sp -> ServiceBuilder(storageConfig, handlerLog)
+    regF <| fun _sp -> ServiceBuilder(storageConfig, handlerLog, codecGen)
 
     regF <| fun sp -> sp.GetService<ServiceBuilder>().CreateFavoritesService()
     regF <| fun sp -> sp.GetService<ServiceBuilder>().CreateSaveForLaterService()
     regF <| fun sp -> sp.GetService<ServiceBuilder>().CreateTodosService()
+
+let serializationSettings = Newtonsoft.Json.Converters.FSharp.Settings.CreateCorrect()
+type NewtonsoftJsonCodecGen() =
+    interface ICodecGen with
+        member __.Generate() = Equinox.Codec.NewtonsoftJson.Json.Create<'Union>(serializationSettings)

--- a/samples/Store/Integration/CodecIntegration.fs
+++ b/samples/Store/Integration/CodecIntegration.fs
@@ -12,7 +12,7 @@ let serializationSettings =
             Newtonsoft.Json.Converters.FSharp.OptionConverter() |])
 
 let genCodec<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>() =
-    Equinox.Codec.JsonNet.JsonUtf8.Create<'Union>(serializationSettings)
+    Equinox.Codec.NewtonsoftJson.Json.Create<'Union>(serializationSettings)
 
 type EventWithId = { id : CartId } // where CartId uses FSharp.UMX
 

--- a/samples/Store/Integration/EventStoreIntegration.fs
+++ b/samples/Store/Integration/EventStoreIntegration.fs
@@ -5,7 +5,7 @@ open Equinox.EventStore
 open System
 
 let serializationSettings = Newtonsoft.Json.Converters.FSharp.Settings.CreateCorrect()
-let genCodec<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>() = Equinox.Codec.JsonNet.JsonUtf8.Create<'Union>(serializationSettings)
+let genCodec<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>() = Equinox.Codec.NewtonsoftJson.Json.Create<'Union>(serializationSettings)
 
 /// Connect with Gossip based cluster discovery using the default Commercial edition Manager port config
 /// Such a config can be simulated on a single node with zero config via the EventStore OSS package:-

--- a/samples/Tutorial/Cosmos.fsx
+++ b/samples/Tutorial/Cosmos.fsx
@@ -90,7 +90,7 @@ module Store =
     let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
 
 module FavoritesCategory = 
-    let codec = Equinox.Codec.JsonNet.JsonUtf8.Create<Favorites.Event>(Newtonsoft.Json.JsonSerializerSettings())
+    let codec = Equinox.Codec.NewtonsoftJson.Json.Create<Favorites.Event>(Newtonsoft.Json.JsonSerializerSettings())
     let resolve = CosmosResolver(Store.store, codec, Favorites.fold, Favorites.initial, Store.cacheStrategy).Resolve
 
 let service = Favorites.Service(Log.log, FavoritesCategory.resolve)

--- a/samples/Tutorial/Todo.fsx
+++ b/samples/Tutorial/Todo.fsx
@@ -114,7 +114,7 @@ module Store =
     let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
 
 module TodosCategory = 
-    let codec = Equinox.Codec.JsonNet.JsonUtf8.Create<Event>(Newtonsoft.Json.JsonSerializerSettings())
+    let codec = Equinox.Codec.NewtonsoftJson.Json.Create<Event>(Newtonsoft.Json.JsonSerializerSettings())
     let access = Equinox.Cosmos.AccessStrategy.Snapshot (isOrigin,compact)
     let resolve = CosmosResolver(Store.store, codec, fold, initial, Store.cacheStrategy, access=access).Resolve
 
@@ -166,4 +166,4 @@ service.Execute(client, Delete 1) |> Async.RunSynchronously
 //val it : unit = ()
 service.List(client) |> Async.RunSynchronously
 //[05:47:22 INF] EqxCosmos Tip 302 119ms rc=1
-//val it : seq<Todo> = []
+//val it : seq<Todo> = [] 

--- a/samples/Web/Startup.fs
+++ b/samples/Web/Startup.fs
@@ -63,7 +63,8 @@ type Startup() =
             | _  | Some (Memory _) ->
                 log.Fatal("Web App is using Volatile Store; Storage options: {options:l}", options)
                 Storage.MemoryStore.config (), log
-        Services.register(services, storeConfig, storeLog)
+        let codecGen : Services.ICodecGen = Services.NewtonsoftJsonCodecGen() :> _
+        Services.register(services, storeConfig, storeLog, codecGen)
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
     static member Configure(app: IApplicationBuilder, env: IHostingEnvironment) : unit =

--- a/tests/Equinox.Cosmos.Integration/CosmosIntegration.fs
+++ b/tests/Equinox.Cosmos.Integration/CosmosIntegration.fs
@@ -11,7 +11,7 @@ open System
 
 let serializationSettings = JsonSerializerSettings()
 let genCodec<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>() =
-    Equinox.Codec.JsonNet.JsonUtf8.Create<'Union>(serializationSettings)
+    Equinox.Codec.NewtonsoftJson.Json.Create<'Union>(serializationSettings)
 
 module Cart =
     let fold, initial = Domain.Cart.Folds.fold, Domain.Cart.Folds.initial

--- a/tests/Equinox.Cosmos.Integration/JsonConverterTests.fs
+++ b/tests/Equinox.Cosmos.Integration/JsonConverterTests.fs
@@ -14,7 +14,7 @@ type Union =
     interface TypeShape.UnionContract.IUnionContract
 
 let defaultSettings = JsonSerializerSettings()
-let mkUnionEncoder () = Equinox.Codec.JsonNet.JsonUtf8.Create<Union>(defaultSettings)
+let mkUnionEncoder () = Equinox.Codec.NewtonsoftJson.Json.Create<Union>(defaultSettings)
 
 type EmbeddedString = { embed : string }
 type EmbeddedDate = { embed : DateTime }
@@ -47,7 +47,7 @@ type VerbatimUtf8Tests() =
         let res = JsonConvert.SerializeObject(e)
         test <@ res.Contains """"d":{"embed":"\""}""" @>
 
-    let uEncoder = Equinox.Codec.JsonNet.JsonUtf8.Create<U>(defaultSettings)
+    let uEncoder = Equinox.Codec.NewtonsoftJson.Json.Create<U>(defaultSettings)
 
     let [<Property(MaxTest=100)>] ``roundtrips diverse bodies correctly`` (x: U) =
         let encoded = uEncoder.Encode x
@@ -62,15 +62,15 @@ type VerbatimUtf8Tests() =
 
     // NB while this aspect works, we don't support it as it gets messy when you then use the VerbatimUtf8Converter
     // https://github.com/JamesNK/Newtonsoft.Json/issues/862 // doesnt apply to this case
-    let [<Fact>] ``Equinox.Codec.JsonNet.JsonUtf8 does not fall prey to Date-strings being mutilated`` () =
+    let [<Fact>] ``Equinox.Codec.NewtonsoftJson.Json does not fall prey to Date-strings being mutilated`` () =
         let x = ES { embed = "2016-03-31T07:02:00+07:00" }
         let encoded = uEncoder.Encode x
         let decoded = uEncoder.TryDecode encoded |> Option.get
         test <@ x = decoded @> 
 
     //// NB while this aspect works, we don't support it as it gets messy when you then use the VerbatimUtf8Converter
-    //let sEncoder = Equinox.Codec.JsonNet.JsonUtf8.Create<US>(defaultSettings)
-    //let [<Theory; InlineData ""; InlineData null>] ``Equinox.Codec.JsonNet.JsonUtf8 can roundtrip strings`` (value: string)  =
+    //let sEncoder = Equinox.Codec.NewtonsoftJson.Json.Create<US>(defaultSettings)
+    //let [<Theory; InlineData ""; InlineData null>] ``Equinox.Codec.NewtonsoftJson.Json can roundtrip strings`` (value: string)  =
     //    let x = SS value
     //    let encoded = sEncoder.Encode x
     //    let decoded = sEncoder.TryDecode encoded |> Option.get

--- a/tests/Equinox.EventStore.Integration/EventStoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/EventStoreIntegration.fs
@@ -21,7 +21,7 @@ let createGesGateway connection batchSize = GesGateway(connection, GesBatchingPo
 
 let serializationSettings = JsonSerializerSettings()
 let genCodec<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>() =
-    Equinox.Codec.JsonNet.JsonUtf8.Create<'Union>(serializationSettings)
+    Equinox.Codec.NewtonsoftJson.Json.Create<'Union>(serializationSettings)
 
 module Cart =
     let fold, initial = Domain.Cart.Folds.fold, Domain.Cart.Folds.initial

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -217,7 +217,8 @@ module LoadTest =
                 decorateWithLogger (log,verbose) execForClient
             | Some storeConfig, _ ->
                 let services = ServiceCollection()
-                Samples.Infrastructure.Services.register(services, storeConfig, storeLog)
+                let codecGen : Services.ICodecGen = Services.NewtonsoftJsonCodecGen() :> _ 
+                Samples.Infrastructure.Services.register(services, storeConfig, storeLog, codecGen)
                 let container = services.BuildServiceProvider()
                 let execForClient = Tests.executeLocal container test
                 decorateWithLogger (log, verbose) execForClient


### PR DESCRIPTION
Prompted by #113 (and the imminent 2.0 breaking changes) I'm planning to rename:
- `Equinox.Codec.JsonUtf8.Create()` -> `Equinox.Codec.Custom.Create()`
- `Equinox.Codec.JsonNet.JsonUtf8.Create()` -> `Equinox.Codec.NewtonsoftJson.Json.Create()`

This scheme has the following benefits:
- The `Json` bit makes it clear that you're encoding as Json (in some stores it may make sense to render as protobuf, avro etc.)
- No need to mentally map `JsonNet` to "That must be Json.net"
- `Equinox.Codec.Utf8Json.Json.Create()` from #113 slots in logically (and less messy than it would have been: `Equinox.Codec.Utf8Json.JsonUtf8.Create()`)
- No direct clash with top level namespace `Newtonsoft`
- `Equinox.Codec.SystemTextJson.Json.Create()` slots in for #79
- If a codec plugin supports multiple encodings, it naturally slots in as `Equinox.Codec.`<codec>`.`<Format>`.Create()

However:
- There is a clash with the top level `Utf8Json` namespace in https://github.com/neuecc/Utf8Json
- There is repetition in the namings that result for the ones in view:
  - `Equinox.Codec.Custom.Create()`
  - `Equinox.Codec.NewtonsoftJson.Json.Create()`
  - `Equinox.Codec.Utf8Json.Json.Create()`
  - `Equinox.Codec.SystemTextJson.Json.Create()`
- Json is the dominant format and hence may be worth optimizing in favor of
- `Factory` from `System.Tasks` didn't gain traction ;)

Note: `Custom` and `Json` are `module`s; `Equinox.Codec` and `Equinox.Codec.*` are `namespace`s

But... I can't see a better compromise than this from this vantage point... Thoughts ?