### PR TITLE
Expose Event Timestamp in lower level APIs resolves #116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
-- `Cosmos.Projection.ChangeFeedProcessor`: Support management of an `aux` collection in account other than the one being read from by adding `auxAccountKey` param [#115](https://github.com/jet/equinox/issues/115)
+- `Cosmos.Projection.ChangeFeedProcessor`: Support management of an `aux` collection in account other than the one being read from by adding `auxAccountKey` param [#115](https://github.com/jet/equinox/pull/115)
+- Support ETL scenarios by enabling the event creation `Timestamp` to be [read and] written by supplying it in `Equinox.Codec.IEvent` [#116](https://github.com/jet/equinox/issues/116)
 
 ### Changed
 

--- a/src/Equinox.Cosmos.Projection/DocumentParser.fs
+++ b/src/Equinox.Cosmos.Projection/DocumentParser.fs
@@ -15,7 +15,6 @@ module DocumentParser =
     type IEvent =
         inherit Equinox.Codec.Core.IIndexedEvent<byte[]>
             abstract member Stream : string
-            abstract member TimeStamp : DateTimeOffset
     /// Infers whether the document represents a valid Event-Batch
     let enumEvents (d : Document) = seq {
         if not (isIndex d)
@@ -29,5 +28,5 @@ module DocumentParser =
                       member __.EventType = x.c
                       member __.Data = x.d
                       member __.Meta = x.m
-                      member __.TimeStamp = x.t
+                      member __.Timestamp = x.t
                       member __.Stream = batch.p } ) }

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -205,7 +205,9 @@ module UnionEncoderAdapters =
         { new Equinox.Codec.IEvent<_> with
             member __.EventType = x.Event.EventType
             member __.Data = x.Event.Data
-            member __.Meta = x.Event.Metadata }
+            member __.Meta = x.Event.Metadata 
+            // Inspecting server code shows both Created and CreatedEpoch are set; taking this as it's less ambiguous than DateTime in the general case
+            member __.Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(x.Event.CreatedEpoch) }
     let private eventDataOfEncodedEvent (x : Codec.IEvent<byte[]>) =
         EventData(Guid.NewGuid(), x.EventType, (*isJson*) true, x.Data, x.Meta)
     let encodeEvents (codec : Codec.IUnionEncoder<'event,byte[]>) (xs : 'event seq) : EventData[] =

--- a/tests/Equinox.Cosmos.Integration/CosmosCoreIntegration.fs
+++ b/tests/Equinox.Cosmos.Integration/CosmosCoreIntegration.fs
@@ -183,7 +183,7 @@ type Tests(testOutputHelper) =
         let! res = Events.append ctx streamName 0L expected
         test <@ AppendResult.Ok 1L = res @>
         test <@ [EqxAct.Append] = capture.ExternalCalls @>
-        verifyRequestChargesMax 14 // 13.1 WAS 11 // 10.33
+        verifyRequestChargesMax 15 // 14.65 WAS 11 // 10.33
         capture.Clear()
 
         // Try overwriting it (a competing consumer would see the same)

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -324,7 +324,7 @@ let main argv =
                     sw.Stop() // Stop the clock after CFP hands off to us
                     let validator = BatchValidator(validator)
                     let toKafkaEvent (e: DocumentParser.IEvent) : Equinox.Projection.Codec.RenderedEvent =
-                        { s = e.Stream; i = e.Index; c = e.EventType; t = e.TimeStamp; d = e.Data; m = e.Meta }
+                        { s = e.Stream; i = e.Index; c = e.EventType; t = e.Timestamp; d = e.Data; m = e.Meta }
                     let validate (e: DocumentParser.IEvent) =
                         match validator.TryIngest(e.Stream, int e.Index) with
                         | Gap -> None // We cannot emit if we have evidence that this will leave a gap


### PR DESCRIPTION
In general, the `Timestamp` is worth having for troubleshooting purposes but should generally not be coupled to in application logic
This PR addresses the need (noted in #116) for this facility wrt the `eqxetl` template in https://github.com/jet/dotnet-templates