### PR TITLE
Remove special casing of Tip documents in CFP helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Changed
 
 - Targeted `Jet.ConfluentKafka.FSharp` v `1.0.0-rc2` in `eqx` tool
+- Removed special casing of `Tip` batches from `Equinox.Cosmos.Projection` in preparation for transparent integration of [#110](https://github.com/jet/equinox/pull/110) without necessitating updating of projectors and related systems
 
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Changed
 
 - Targeted `Jet.ConfluentKafka.FSharp` v `1.0.0-rc2` in `eqx` tool
-- Removed special casing of `Tip` batches from `Equinox.Cosmos.Projection` in preparation for transparent integration of [#110](https://github.com/jet/equinox/pull/110) without necessitating updating of projectors and related systems
+- Removed special casing of `Tip` batches from `Equinox.Cosmos.Projection` in preparation for transparent integration of [#110](https://github.com/jet/equinox/pull/110) without necessitating updating of projectors and related systems [#119](https://github.com/jet/equinox/pull/119)
 
 ### Removed
 ### Fixed

--- a/src/Equinox.Cosmos.Projection/DocumentParser.fs
+++ b/src/Equinox.Cosmos.Projection/DocumentParser.fs
@@ -1,7 +1,6 @@
 namespace Equinox.Cosmos.Projection
 
 open Microsoft.Azure.Documents
-open System
 
 [<RequireQualifiedAccess>]
 module DocumentParser =
@@ -10,23 +9,28 @@ module DocumentParser =
             let tmp = new Document()
             tmp.SetPropertyValue("content", document)
             tmp.GetPropertyValue<'T>("content")
-    /// Determines whether this document represents an index page [and hence should not be expected to contain any events]
-    let isIndex (d : Document) = d.Id = "-1"
     type IEvent =
         inherit Equinox.Codec.Core.IIndexedEvent<byte[]>
             abstract member Stream : string
-    /// Infers whether the document represents a valid Event-Batch
-    let enumEvents (d : Document) = seq {
-        if not (isIndex d)
-           && d.GetPropertyValue("p") <> null && d.GetPropertyValue("i") <> null
-           && d.GetPropertyValue("n") <> null && d.GetPropertyValue("e") <> null then
-            let batch = d.Cast<Equinox.Cosmos.Store.Batch>()
-            yield! batch.e |> Seq.mapi (fun offset x ->
-                { new IEvent with
-                      member __.Index = batch.i + int64 offset
-                      member __.IsUnfold = false
-                      member __.EventType = x.c
-                      member __.Data = x.d
-                      member __.Meta = x.m
-                      member __.Timestamp = x.t
-                      member __.Stream = batch.p } ) }
+    /// Sanity check to determine whether the Document represents an `Equinox.Cosmos` >= 1.0 based batch
+    let isEquinoxBatch (d : Document) = 
+        d.GetPropertyValue "p" <> null && d.GetPropertyValue "i" <> null
+        && d.GetPropertyValue "n" <> null && d.GetPropertyValue "e" <> null
+    /// Enumerates the events represented within a batch
+    // NOTE until `tip-isa-batch` gets merged, this causes a null-traversal of `-1`-index pages which presently do not contain data
+    // This is intentional in the name of forward compatibility for projectors - enabling us to upgrade the data format without necessitating
+    //   updates of all projectors (even if there can potentially be significant at-least-once-ness to the delivery)
+    let enumEquinoxCosmosEvents (batch : Equinox.Cosmos.Store.Batch) =
+        batch.e |> Seq.mapi (fun offset x ->
+            { new IEvent with
+                  member __.Index = batch.i + int64 offset
+                  member __.IsUnfold = false
+                  member __.EventType = x.c
+                  member __.Data = x.d
+                  member __.Meta = x.m
+                  member __.Timestamp = x.t
+                  member __.Stream = batch.p } )
+    /// Collects all events with a Document [typically obtained via the CosmosDb ChangeFeed] that potentially represents an Equinox.Cosmos event-batch
+    let enumEvents (d : Document) : IEvent seq =
+        if isEquinoxBatch d then d.Cast<Equinox.Cosmos.Store.Batch>() |> enumEquinoxCosmosEvents
+        else Seq.empty


### PR DESCRIPTION
I'm removing the guard clause which prevents events, if any, in Tip being walked by the`enumEvents` function within a projector.

On reflection, it's not necessary for the 1.x-2.x storage formats of `Equinox.Cosmos` and instead means it's another thing to consider should we arrive at the point where we merge #110 
