### PR TITLE
CFP cleanup: Switch to manual checkpointing, tidy logging, expose further callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Fixed
 
 <a name="2.0.0"></a>
+<a name="2.0.0-preview5"></a>
+## [2.0.0-preview5] - 2019-04-12
+
+### Added
+
+- exposed `assign` and `revoke` extensibility points in `ChangeFeedObserver` builder [#119](https://github.com/jet/equinox/pull/119)
+
+### Changed
+
+- switched ChangeFeedProcessor checkpointing to be _explicit_ (was automatic) based on requirements of [`equinox-sync` template PR #19](https://github.com/jet/dotnet-templates/pull/19) [#119](https://github.com/jet/equinox/pull/119)
+
+### Fixed
+
+- Added `partitionRangeId` context to `ChangeFeedObserver` logging [#119](https://github.com/jet/equinox/pull/119)
+
 <a name="2.0.0-preview4"></a>
 ## [2.0.0-preview4] - 2019-04-03
 

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -331,7 +331,7 @@ let main argv =
                         let p = KafkaProducer.Create(log, cfg, t)
                         Some p, (p :> IDisposable).Dispose
                     | _ -> None, id
-                let projectBatch (ctx : IChangeFeedObserverContext) (docs : IReadOnlyList<Microsoft.Azure.Documents.Document>) = async {
+                let projectBatch (log : ILogger) (ctx : IChangeFeedObserverContext) (docs : IReadOnlyList<Microsoft.Azure.Documents.Document>) = async {
                     sw.Stop() // Stop the clock after CFP hands off to us
                     let validator = BatchValidator(validator)
                     let toKafkaEvent (e: DocumentParser.IEvent) : Equinox.Projection.Codec.RenderedEvent =
@@ -368,7 +368,7 @@ let main argv =
                         log.Information("Feed at least once delivery: {dups} duplicates encountered across {streams} affected streams", s.dup, streamsWithDupsCount)
                     sw.Restart() // restart the clock as we handoff back to the CFP
                 }
-                ChangeFeedObserver.Create(log, projectBatch, disposeProducer)
+                ChangeFeedObserver.Create(log, projectBatch, dispose = disposeProducer)
 
             let run = async {
                 let logLag (interval : TimeSpan) remainingWork = async {

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -349,7 +349,9 @@ let main argv =
                             return et
                         | Some producer ->
                             let es = [| for e in events -> e.s, Newtonsoft.Json.JsonConvert.SerializeObject e |]
-                            let! et,_ = producer.ProduceBatch es |> Stopwatch.Time
+                            let! et,() = async {
+                                let! _ = producer.ProduceBatch es
+                                do! ctx.CheckpointAsync() |> Async.AwaitTaskCorrect } |> Stopwatch.Time 
                             return et }
                             
                     if log.IsEnabled LogEventLevel.Debug then log.Debug("Response Headers {0}", let hs = ctx.FeedResponse.ResponseHeaders in [for h in hs -> h, hs.[h]])


### PR DESCRIPTION
This PR results from work in the `equinox-sync` template in https://github.com/jet/dotnet-templates/pull/19, consisting of:
- [x] Switch checkpointing to _manual_ mode - because the default behavior of the `processBatch` function does not afford a way to inhibit the implicit writing of progress, the only viable solution is to turn it to manual mode
- [x] In order to enable a `ChangeFeedObserver` to log contextually, the wrapper will now decorate (and pass the decorated logger) with a `partitionRangeId` property
- [x] added contextual logging
- [x] exposed optional `assign` and `revoke` functions