### PR TITLE
Cleanup and clarification of ChangeFeedProcessor naming and asyncness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 ### Changed
 
+- `ChangeFeedObserver`: Made `assign` and `revoke` extensibility points in builder `async` [#124](https://github.com/jet/equinox/pull/124)
+- `ChangeFeedObserver`: Renamed `ChangeFeedObserver`'s `processBatch` to `ingest` and documented role of `IChangeFeedObserverContext.Checkpoint` in more detail [#124](https://github.com/jet/equinox/pull/124)
 - Targeted `Jet.ConfluentKafka.FSharp` v `1.0.0-rc6` in `eqx` tool
 
 ### Removed

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -345,13 +345,13 @@ let main argv =
                     let! et = async {
                         match producer with
                         | None ->
-                            let! et,() = ctx.CheckpointAsync() |> Async.AwaitTaskCorrect |> Stopwatch.Time
+                            let! et,() = ctx.Checkpoint() |> Stopwatch.Time
                             return et
                         | Some producer ->
                             let es = [| for e in events -> e.s, Newtonsoft.Json.JsonConvert.SerializeObject e |]
                             let! et,() = async {
                                 let! _ = producer.ProduceBatch es
-                                do! ctx.CheckpointAsync() |> Async.AwaitTaskCorrect } |> Stopwatch.Time 
+                                do! ctx.Checkpoint() } |> Stopwatch.Time 
                             return et }
                             
                     if log.IsEnabled LogEventLevel.Debug then log.Debug("Response Headers {0}", let hs = ctx.FeedResponse.ResponseHeaders in [for h in hs -> h, hs.[h]])


### PR DESCRIPTION
This addresses needs arising from work in https://github.com/jet/dotnet-templates/pull/16 wrt:

1. having the assignment and/or revocation do more than just logging; given the underlying `ChangeFeedObserver` offers `Task`-async, exposes the `assign` and `revoke` Async<unit>` methods (For symmetry with `dispose` (and due to lack of imagination!), the `assign` and `revoke` helpers had not previously been async.)

2. Mapping the `IChangeFeedObserverContext.CheckpointAsync` in `Async` (this is used in various places in the templates)

3. Clarifies and documents the `ingest` protocol (formerly `processBatch`) wrt how it needs to cover

    i. Flow control / backpressure - the need to impede the consumption by not returning from `ingest` when there's too much of a backlog
    ii. Exception management - the underlying CFP does not deal with exceptions in a meaningful or useful manner
    iii. Potentially offloading the processing in the interests of not impeding the maximum potential read throughput
    iv. having something, somewhere call `IChangeFeedObserverContext.Checkpoint` to mark progress at some point