### PR TITLE
Add EventStore.Gateway.Sync, Stats, ConflictUnknown actualVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - `Equinox.EventStore.GesGateway.Sync` API including adding `actualVersion` to `ConflictUnknown` Result DU case for [`dotnet new eqxsync` template `EventStoreSink` impl](https://github.com/jet/dotnet-templates/pull/23) [#133](https://github.com/jet/equinox/pull/133)
+- `Equinox.EventStore` `Stats` for consistency with CosmosDb equivalent [#133](https://github.com/jet/equinox/pull/133)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
-- `Equinox.EventStore.GesGateway.Sync` API including adding `ConflictUnknown.actualVersion` to Result type for [`dotnet new eqxsync` template `EventStoreSink` impl](https://github.com/jet/dotnet-templates/pull/23) [#133](https://github.com/jet/equinox/pull/133)
+- `Equinox.EventStore.GesGateway.Sync` API including adding `actualVersion` to `ConflictUnknown` Result DU case for [`dotnet new eqxsync` template `EventStoreSink` impl](https://github.com/jet/dotnet-templates/pull/23) [#133](https://github.com/jet/equinox/pull/133)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `Equinox.EventStore.GesGateway.Sync` API including adding `ConflictUnknown.actualVersion` to Result type for [`dotnet new eqxsync` template `EventStoreSink` impl](https://github.com/jet/dotnet-templates/pull/23) [#133](https://github.com/jet/equinox/pull/133)
+
 ### Changed
 
 - Targeted `Jet.ConfluentKafka.FSharp` v `1.0.0-rc10` in `eqx` tool

--- a/samples/Web/Program.fs
+++ b/samples/Web/Program.fs
@@ -28,6 +28,7 @@ module Program =
                     .Enrich.FromLogContext()
                     .WriteTo.Console()
                     // TOCONSIDER log and reset every minute or something ?
+                    .WriteTo.Sink(Equinox.EventStore.Log.InternalMetrics.Stats.LogSink())
                     .WriteTo.Sink(Equinox.Cosmos.Store.Log.InternalMetrics.Stats.LogSink())
             let c =
                 let maybeSeq = if args.Contains LocalSeq then Some "http://localhost:5341" else None

--- a/samples/Web/Program.fs
+++ b/samples/Web/Program.fs
@@ -28,7 +28,7 @@ module Program =
                     .Enrich.FromLogContext()
                     .WriteTo.Console()
                     // TOCONSIDER log and reset every minute or something ?
-                    .WriteTo.Sink(Equinox.Cosmos.Store.Log.InternalMetrics.RuCounters.RuCounterSink())
+                    .WriteTo.Sink(Equinox.Cosmos.Store.Log.InternalMetrics.Stats.LogSink())
             let c =
                 let maybeSeq = if args.Contains LocalSeq then Some "http://localhost:5341" else None
                 match maybeSeq with None -> c | Some endpoint -> c.WriteTo.Seq(endpoint)

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -52,6 +52,75 @@ module Log =
             retryPolicy withLoggingContextWrapping
     let (|BlobLen|) = function null -> 0 | (x : byte[]) -> x.Length
 
+    /// NB Caveat emptor; this is subject to unlimited change without the major version changing - while the `dotnet-templates` repo will be kept in step, and
+    /// the ChangeLog will mention changes, it's critical to not assume that the presence or nature of these helpers be considered stable
+    module InternalMetrics =
+
+        module Counters =
+            let inline (|Stats|) ({ interval = i }: Measurement) = let e = i.Elapsed in int64 e.TotalMilliseconds
+
+            let (|Read|Write|Resync|Aggregate|) = function
+                | Slice (_,(Stats s)) -> Read s
+                | WriteSuccess (Stats s) -> Write s
+                | WriteConflict (Stats s) -> Resync s
+                // slices are rolled up into batches so be sure not to double-count
+                | Batch (_,_,(Stats s)) -> Aggregate s
+            let (|SerilogScalar|_|) : LogEventPropertyValue -> obj option = function
+                | (:? ScalarValue as x) -> Some x.Value
+                | _ -> None
+            let (|CosmosMetric|_|) (logEvent : LogEvent) : Event option =
+                match logEvent.Properties.TryGetValue("esEvt") with
+                | true, SerilogScalar (:? Event as e) -> Some e
+                | _ -> None
+            type Counter =
+                { mutable count: int64; mutable ms: int64 }
+                static member Create() = { count = 0L; ms = 0L }
+                member __.Ingest(ms) =
+                    System.Threading.Interlocked.Increment(&__.count) |> ignore
+                    System.Threading.Interlocked.Add(&__.ms, ms) |> ignore
+            type CounterSink() =
+                static let epoch = System.Diagnostics.Stopwatch.StartNew()
+                static member val Read = Counter.Create() with get, set
+                static member val Write = Counter.Create() with get, set
+                static member val Resync = Counter.Create() with get, set
+                static member Restart() =
+                    CounterSink.Read <- Counter.Create()
+                    CounterSink.Write <- Counter.Create()
+                    CounterSink.Resync <- Counter.Create()
+                    let span = epoch.Elapsed
+                    epoch.Restart()
+                    span
+                interface Serilog.Core.ILogEventSink with
+                    member __.Emit logEvent = logEvent |> function
+                        | CosmosMetric (Read stats) -> CounterSink.Read.Ingest stats
+                        | CosmosMetric (Write stats) -> CounterSink.Write.Ingest stats
+                        | CosmosMetric (Resync stats) -> CounterSink.Resync.Ingest stats
+                        | CosmosMetric (Aggregate _) -> ()
+                        | _ -> ()
+
+        /// Relies on feeding of metrics from Log through to RuCounterSink
+        /// Use RuCounters.RuCounterSink.Reset() to reset the start point (and stats) where relevant
+        let dump (log: Serilog.ILogger) =
+            let stats =
+              [ "Read", Counters.CounterSink.Read
+                "Write", Counters.CounterSink.Write
+                "Resync", Counters.CounterSink.Resync ]
+            let mutable totalCount, totalMs = 0L, 0L
+            let logActivity name count lat =
+                if count <> 0L then
+                    log.Information("{name}: {count:n0} requests; Average latency: {lat:n0}ms",
+                        name, count, (if count = 0L then Double.NaN else float lat/float count))
+            for name, stat in stats do
+                totalCount <- totalCount + stat.count
+                totalMs <- totalMs + stat.ms
+                logActivity name stat.count stat.ms
+            // Yes, there's a minor race here between the use of the values and the reset
+            let duration = Counters.CounterSink.Restart()
+            logActivity "TOTAL" totalCount totalMs
+            let measures : (string * (TimeSpan -> float)) list = [ "s", fun x -> x.TotalSeconds(*; "m", fun x -> x.TotalMinutes; "h", fun x -> x.TotalHours*) ]
+            let logPeriodicRate name count = log.Information("rp{name} {count:n0}", name, count)
+            for uom, f in measures do let d = f duration in if d <> 0. then logPeriodicRate uom (float totalCount/d |> int64)
+
 [<RequireQualifiedAccess; NoEquality; NoComparison>]
 type EsSyncResult = Written of EventStore.ClientAPI.WriteResult | Conflict of actualVersion: int64
 

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -200,12 +200,9 @@ module private Read =
 
 module UnionEncoderAdapters =
     let encodedEventOfResolvedEvent (x : ResolvedEvent) : Equinox.Codec.IEvent<byte[]> =
-        { new Equinox.Codec.IEvent<_> with
-            member __.EventType = x.Event.EventType
-            member __.Data = x.Event.Data
-            member __.Meta = x.Event.Metadata 
-            // Inspecting server code shows both Created and CreatedEpoch are set; taking this as it's less ambiguous than DateTime in the general case
-            member __.Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(x.Event.CreatedEpoch) }
+        // Inspecting server code shows both Created and CreatedEpoch are set; taking this as it's less ambiguous than DateTime in the general case
+        let ts = DateTimeOffset.FromUnixTimeMilliseconds(x.Event.CreatedEpoch)
+        Equinox.Codec.Core.EventData.Create(x.Event.EventType, x.Event.Data, x.Event.Metadata, ts) :> _
     let private eventDataOfEncodedEvent (x : Codec.IEvent<byte[]>) =
         EventData(Guid.NewGuid(), x.EventType, (*isJson*) true, x.Data, x.Meta)
     let encode (xs : Codec.IEvent<byte[]> []) : EventData[] = Array.map eventDataOfEncodedEvent xs

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -173,7 +173,7 @@ and Test = Favorite | SaveForLater | Todo
 let createStoreLog verbose verboseConsole maybeSeqEndpoint =
     let c = LoggerConfiguration().Destructure.FSharpTypes()
     let c = if verbose then c.MinimumLevel.Debug() else c
-    let c = c.WriteTo.Sink(Equinox.Cosmos.Store.Log.InternalMetrics.RuCounters.RuCounterSink())
+    let c = c.WriteTo.Sink(Equinox.Cosmos.Store.Log.InternalMetrics.Stats.LogSink())
     let c = c.WriteTo.Console((if verbose && verboseConsole then LogEventLevel.Debug else LogEventLevel.Warning), theme = Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code)
     let c = match maybeSeqEndpoint with None -> c | Some endpoint -> c.WriteTo.Seq(endpoint)
     c.CreateLogger() :> ILogger
@@ -238,7 +238,7 @@ module LoadTest =
         log.Information( "Running {test} for {duration} @ {tps} hits/s across {clients} clients; Max errors: {errorCutOff}, reporting intervals: {ri}, report file: {report}",
             test, a.Duration, a.TestsPerSecond, clients.Length, a.ErrorCutoff, a.ReportingIntervals, reportFilename)
         // Reset the start time based on which the shared global metrics will be computed
-        let _ = Equinox.Cosmos.Store.Log.InternalMetrics.RuCounters.RuCounterSink.Restart() 
+        let _ = Equinox.Cosmos.Store.Log.InternalMetrics.Stats.LogSink.Restart() 
         let results = runLoadTest log a.TestsPerSecond (duration.Add(TimeSpan.FromSeconds 5.)) a.ErrorCutoff a.ReportingIntervals clients runSingleTest |> Async.RunSynchronously
 
         let resultFile = createResultLog reportFilename
@@ -254,7 +254,7 @@ module LoadTest =
 let createDomainLog verbose verboseConsole maybeSeqEndpoint =
     let c = LoggerConfiguration().Destructure.FSharpTypes().Enrich.FromLogContext()
     let c = if verbose then c.MinimumLevel.Debug() else c
-    let c = c.WriteTo.Sink(Equinox.Cosmos.Store.Log.InternalMetrics.RuCounters.RuCounterSink())
+    let c = c.WriteTo.Sink(Equinox.Cosmos.Store.Log.InternalMetrics.Stats.LogSink())
     let c = c.WriteTo.Console((if verboseConsole then LogEventLevel.Debug else LogEventLevel.Information), theme = Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code)
     let c = match maybeSeqEndpoint with None -> c | Some endpoint -> c.WriteTo.Seq(endpoint)
     c.CreateLogger()


### PR DESCRIPTION
For symmetry with `Equinox.Cosmos`, this adds a `Sync` API that enables one to do a blind write to a stream without going through the transactional API.

This is used in the implementation of the `EventStoreSink` in https://github.com/jet/dotnet-templates/pull/23 (which uses `Equinox.Projection.Scheduling` to track the stream state).

Includes two minor tidying changes