### PR TITLE
Remove TTLs, indexing from Aux config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Changed
 
 - Targeted `Jet.ConfluentKafka.FSharp` v `1.0.0-rc10` in `eqx` tool
+- `Equinox.Tool`: Switched `IndexingMode` to `Automatic=false,IndexingMode=None`, remove `DefaultTimeToLive` from `aux` collections [#134](https://github.com/jet/equinox/pull/134)
 
 ### Removed
 ### Fixed

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -519,10 +519,9 @@ function sync(req, expectedVersion, maxEvents) {
             | Some log -> log.Information("Created stored procedure {sprocId} in {ms}ms rc={ru}", sprocName, (let e = t.Elapsed in e.TotalMilliseconds), ru) }
         let private createAuxCollectionIfNotExists (client: Client.DocumentClient) (dbName,collName) mode : Async<unit> =
             let def = DocumentCollection(Id = collName)
-            // for now, we are leaving the default IndexingPolicy mode wrt fields to index and in which manner as default: autoindexing all fields
-            def.IndexingPolicy.IndexingMode <- IndexingMode.Lazy
-            // Expire Projector documentId to Kafka offsets mapping records after one year
-            def.DefaultTimeToLive <- Nullable (365 * 60 * 60 * 24)
+            // TL;DR no indexing of any kind; see https://github.com/Azure/azure-documentdb-changefeedprocessor-dotnet/issues/142
+            def.IndexingPolicy.Automatic <- false
+            def.IndexingPolicy.IndexingMode <- IndexingMode.None
             createOrProvisionCollection client (dbName,def) mode
         let init log (client: Client.DocumentClient) (dbName,collName) mode skipStoredProc = async {
             do! createOrProvisionDatabase client dbName mode


### PR DESCRIPTION
This PR cleans up the `initaux` indexing behavior with the aim of maximizing efficiency and correctness :-
- removing `DefaultTimeToLive` on order to avoid risk of Lease and/or other documents used by either the present or future versions of the CFP lib being removed (used by an internal alternate projector system; use of that system will now now necessitate applying such configuration manually)
- removing indexing (now turned to `Automatic=false, IndexingMode = None`)