### PR TITLE
Fix EventStore Connection Logic wrt Slave/Random nodes on cluster connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+- `Equinox.EventStore`: Fixed `PreferSlave` bug for `Discovery.Uri` mode [#135](https://github.com/jet/equinox/pull/135)
+- `Equinox.EventStore`: Fixed `PreferSlave` and `Random` modes for gossip-based `Discovery` modes [#135](https://github.com/jet/equinox/pull/135) [@asetda](https://github.com/asetda)
+
 <a name="2.0.0"></a>
 <a name="2.0.0-preview8"></a>
 ## [2.0.0-preview8] - 2019-05-16

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -525,9 +525,9 @@ type Discovery =
 
 module private Discovery =
     let buildDns (f : DnsClusterSettingsBuilder -> DnsClusterSettingsBuilder) =
-        ClusterSettings.Create().DiscoverClusterViaDns().SetMaxDiscoverAttempts(Int32.MaxValue) |> f |> fun s -> s.Build()
+        ClusterSettings.Create().DiscoverClusterViaDns().KeepDiscovering() |> f |> fun s -> s.Build()
     let buildSeeded (f : GossipSeedClusterSettingsBuilder -> GossipSeedClusterSettingsBuilder) =
-        ClusterSettings.Create().DiscoverClusterViaGossipSeeds().SetMaxDiscoverAttempts(Int32.MaxValue) |> f |> fun s -> s.Build()
+        ClusterSettings.Create().DiscoverClusterViaGossipSeeds().KeepDiscovering() |> f |> fun s -> s.Build()
     let configureDns clusterDns maybeManagerPort (x : DnsClusterSettingsBuilder) =
         x.SetClusterDns(clusterDns)
         |> fun s -> match maybeManagerPort with Some port -> s.SetClusterGossipPort(port) | None -> s
@@ -616,4 +616,4 @@ type GesConnector
             let! masterInParallel = Async.StartChild (__.Connect(name + "-TwinW", discovery, NodePreference.Master))
             let! slave = __.Connect(name + "-TwinR", discovery, NodePreference.PreferSlave)
             let! master = masterInParallel
-            return GesConnection(readConnection=slave, writeConnection=master,?readRetryPolicy=readRetryPolicy, ?writeRetryPolicy=writeRetryPolicy) }
+            return GesConnection(readConnection=slave, writeConnection=master, ?readRetryPolicy=readRetryPolicy, ?writeRetryPolicy=writeRetryPolicy) }

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -577,7 +577,7 @@ type GesConnector
             match node with
             | NodePreference.Master -> s.PerformOnMasterOnly()  // explicitly use ES default of requiring master, use default Node preference of Master
             | NodePreference.PreferMaster -> s.PerformOnAnyNode() // override default [implied] PerformOnMasterOnly(), use default Node preference of Master
-            | NodePreference.PreferSlave -> s.PerformOnAnyNode().PreferRandomNode() // override default PerformOnMasterOnly(), override Master Node preference
+            | NodePreference.PreferSlave -> s.PerformOnAnyNode().PreferSlaveNode() // override default PerformOnMasterOnly(), override Master Node preference
             | NodePreference.Random -> s.PerformOnAnyNode().PreferRandomNode()  // override default PerformOnMasterOnly(), override Master Node preference
         |> fun s -> match concurrentOperationsLimit with Some col -> s.LimitConcurrentOperationsTo(col) | None -> s // ES default: 5000
         |> fun s -> match heartbeatTimeout with Some v -> s.SetHeartbeatTimeout v | None -> s // default: 1500 ms


### PR DESCRIPTION
This code, derived from a fix by @asetda (Aset Dauletbaev) to a downstream version fixes the fact that the gossip-based Discovery profiles don't pick up the `.PreferRandomNode()`/`.PreferSlaveNode()` preference on EventStore's `ConnectionSettings`

There's also a fix for a typo which means that the `PreferSlave` semantics would never have worked even in the `Uri` case (this was not present in the downstream repo)...