### PR TITLE
Tidy ChangeFeedProcessor init/assign signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 - Targeted `Jet.ConfluentKafka.FSharp` v `1.0.0-rc10` in `eqx` tool
 - `Equinox.Tool`: Switched `IndexingMode` to `Automatic=false,IndexingMode=None`, remove `DefaultTimeToLive` from `aux` collections [#134](https://github.com/jet/equinox/pull/134)
-- `Equinox.Cosmos.Projection`: Tidied `assign` and `init`, signatures; provided mechanism to inhibit logging
+- `Equinox.Cosmos.Projection`: Tidy `assign` and `init`, signatures; provided mechanism to inhibit logging [#137](https://github.com/jet/equinox/pull/137)
 
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 - Targeted `Jet.ConfluentKafka.FSharp` v `1.0.0-rc10` in `eqx` tool
 - `Equinox.Tool`: Switched `IndexingMode` to `Automatic=false,IndexingMode=None`, remove `DefaultTimeToLive` from `aux` collections [#134](https://github.com/jet/equinox/pull/134)
+- `Equinox.Cosmos.Projection`: Tidied `assign` and `init`, signatures; provided mechanism to inhibit logging
 
 ### Removed
 ### Fixed


### PR DESCRIPTION
Having the partitionId value be known when an observer is `init`ialized and/or `assign`ed can make client code much cleaner

Also provides a way to prevent the default assign/revoke logging