### PR TITLE
Use ArrayPool in json.net Codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+ - `Equinox.Codec` now uses `System.Buffers.ArrayPool` to reduce allocations when encoding/decoding union objects using json.net [#140](https://github.com/jet/equinox/pull/140)
+
 ### Changed
 
 - `TypeShape` dependency in `Equinox.Codec` now `7.*` (was `6.*`)

--- a/src/Equinox.Codec/Codec.fs
+++ b/src/Equinox.Codec/Codec.fs
@@ -94,6 +94,7 @@ open System.IO
 open System.Runtime.InteropServices
 
 /// Reuse interim buffers when coding/encoding
+// https://stackoverflow.com/questions/55812343/newtonsoft-json-net-jsontextreader-garbage-collector-intensive
 module private CharBuffersPool =
     let private inner = System.Buffers.ArrayPool<char>.Shared
     let instance =

--- a/src/Equinox.Codec/Equinox.Codec.fsproj
+++ b/src/Equinox.Codec/Equinox.Codec.fsproj
@@ -20,6 +20,7 @@
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="TypeShape" Version="7.*" />
   </ItemGroup>
 


### PR DESCRIPTION
Uses an `ArrayPool` to reduce allocations when using `Equinox.Codec`
- https://adamsitnik.com/Array-Pool/
- http://james.newtonking.com/archive/2015/12/20/json-net-8-0-release-1-allocations-and-bug-fixes

Impl is largely guided by https://stackoverflow.com/questions/55812343/newtonsoft-json-net-jsontextreader-garbage-collector-intensive