### PR TITLE
Use id as partitionKey in aux coll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 ### Changed
 
-- `eqx initAux` now sets Partion Key to `/id` as recommended for new aux collections
+- `eqx initAux` now sets Partion Key to `/id` as recommended for new aux collections  [#142](https://github.com/jet/equinox/pull/142)
 
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- `eqx initAux` now sets Partion Key to `/id` as recommended for new aux collections
+
 ### Removed
 ### Fixed
 


### PR DESCRIPTION
As confirmed by @ealsur in https://github.com/Azure/azure-cosmos-dotnet-v3/issues/491, the answer to https://github.com/Azure/azure-documentdb-changefeedprocessor-dotnet/issues/142 is that best practice is to define the partition key for the aux collection to be `/id` - this change also means we always define a partion key per new conventions