### PR TITLE
Change env vars from EQUINOX_KAFKA* -> PROPULSION_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- `eqx project` now uses environment variables `PROPULSION_KAFKA_`* instead of `EQUINOX_`* [#143](https://github.com/jet/equinox/pull/143)
+
 ### Removed
 
 - `eqx project` - `ChangeFeedProcessor` and Kafka support - All projection management logic now lives in the `Propulsion` libraries [#138](https://github.com/jet/equinox/pull/138)

--- a/README.md
+++ b/README.md
@@ -277,8 +277,8 @@ While Equinox is implemented in F#, and F# is a great fit for writing event-sour
 
     # start one or more Projectors (see above for more examples/info re the Projector.fsproj)
 
-    $env:EQUINOX_KAFKA_BROKER="instance.kafka.mysite.com:9092" # or use -b
-    $env:EQUINOX_KAFKA_TOPIC="topic0" # or use -t
+    $env:PROPULSION_KAFKA_BROKER="instance.kafka.mysite.com:9092" # or use -b
+    $env:PROPULSION_KAFKA_TOPIC="topic0" # or use -t
     dotnet run -- projector4 -t topic0 cosmos
 
     # generate a consumer app
@@ -286,7 +286,7 @@ While Equinox is implemented in F#, and F# is a great fit for writing event-sour
     dotnet new proConsumer
 
     # start one or more Consumers
-    $env:EQUINOX_KAFKA_GROUP="consumer1" # or use -g
+    $env:PROPULSION_KAFKA_GROUP="consumer1" # or use -g
     dotnet run -- -t topic0 -g consumer1
     ```
 


### PR DESCRIPTION
Same change is happening in https://github.com/jet/dotnet-templates to reflect that projection is not tied to Equinox, and ease confusion badging everything EQUINOX can bring.

(NB this information will likely eventually move to the propulsion API as part of https://github.com/jet/propulsion/issues/6)