### PR TITLE
Microsoft.Azure.Cosmos / V3 anticipatory renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 - Updated README.md to refer to `propulsion init` and `propulsion project` (formerly `eqx` `initAux` and `project`) (jet/propulsion#17)[https://github.com/jet/propulsion/pull/17]
 - `eqx project` now uses environment variables `PROPULSION_KAFKA_`* instead of `EQUINOX_`* [#143](https://github.com/jet/equinox/pull/143)
-- `Equinox.Cosmos` now uses `Container` in preference to `Collection`, in alignment with the `Microsoft.Azure.Cosmos` SDK's standardized naming [#149](https://github.com/jet/equinox/pull/149)
+- `Equinox.Cosmos` now uses `Container` in preference to `Collection`, in alignment with the `Microsoft.Azure.Cosmos` SDK's standardized naming, _and other minor changes, see PR for details_ [#149](https://github.com/jet/equinox/pull/149)
+- `EQUINOX_COSMOS_COLLECTION` environment variable argument for `eqx` tool is now `EQUINOX_COSMOS_CONTAINER` [#143](https://github.com/jet/equinox/pull/143)
 - renamed `Equinox.DeprecatedRawName` -> `StreamName` [#150](https://github.com/jet/equinox/pull/150)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 - Updated README.md to refer to `propulsion init` and `propulsion project` (formerly `eqx` `initAux` and `project`) (jet/propulsion#17)[https://github.com/jet/propulsion/pull/17]
 - `eqx project` now uses environment variables `PROPULSION_KAFKA_`* instead of `EQUINOX_`* [#143](https://github.com/jet/equinox/pull/143)
+- `Equinox.Cosmos` now uses `Container` in preference to `Collection`, in alignment with the `Microsoft.Azure.Cosmos` SDK's standardized naming [#149](https://github.com/jet/equinox/pull/149)
 - renamed `Equinox.DeprecatedRawName` -> `StreamName` [#150](https://github.com/jet/equinox/pull/150)
 
 ### Removed

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -54,7 +54,7 @@ Change Feed | set of query patterns allowing one to run a continuous query readi
 Change Feed Processor | Library from Microsoft exposing facilities to Project from a Change Feed, maintaining Offsets per Physical Partition (Range) in the Lease Container
 Container | logical space in a CosmosDb holding [loosely] related Items (aka Documents). Items bear logical Partition Keys. Formerly aka Collection.
 CosmosDb | Microsoft Azure's managed document database system
-Database | Group of collections
+Database | Group of Containers
 DocumentDb | Original offering of CosmosDb, now entitled the SQL Query Model, `Microsoft.Azure.DocumentDb.Client[.Core]`
 Document id | Identifier used to load a document (Item) directly without a Query
 Lease Container | Container, outside of the storage Container (to avoid feedback effects) that maintains a set of Offsets per Range, together with leases reflecting instances of the Change Feed Processors and their Range assignments (aka `aux` container)

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -50,19 +50,19 @@ Stream | Ordered sequence of Events in a Store
 
 Term | Description
 -----|------------
-Change Feed | set of query patterns allowing one to run a continuous query reading documents in a Range in order of their last update
+Change Feed | set of query patterns allowing one to run a continuous query reading Items (documents) in a Range in order of their last update
 Change Feed Processor | Library from Microsoft exposing facilities to Project from a Change Feed, maintaining Offsets per Physical Partition (Range) in the Lease Container
-Container | logical space in a CosmosDb holding [loosely] related documents. Documents bear logical Partition Keys. Formerly aka Collection.
+Container | logical space in a CosmosDb holding [loosely] related Items (aka Documents). Items bear logical Partition Keys. Formerly aka Collection.
 CosmosDb | Microsoft Azure's managed document database system
 Database | Group of collections
 DocumentDb | Original offering of CosmosDb, now entitled the SQL Query Model, `Microsoft.Azure.DocumentDb.Client[.Core]`
-Document id | Identifier used to load a document directly without a Query
+Document id | Identifier used to load a document (Item) directly without a Query
 Lease Container | Container, outside of the storage Container (to avoid feedback effects) that maintains a set of Offsets per Range, together with leases reflecting instances of the Change Feed Processors and their Range assignments (aka `aux` container)
 Partition Key | Logical key identifying a Stream (maps to a Range)
 Projector | Process running a [set of] Change Feed Processors across the Ranges of a Container in order to perform a global synchronization within the system across Streams
-Query | Using indices to walk a set of relevant documents in a Container, yielding Documents
+Query | Using indices to walk a set of relevant items in a Container, yielding Items (documents)
 Range | Subset of the hashed key space of a collection held as a physical partition, can be split as part of scaling up the RUs allocated to a Container
-Replay | The ability to re-run the processing of the Change Feed from the oldest document forward at will
+Replay | The ability to re-run the processing of the Change Feed from the oldest Item (document) forward at will
 Request Units | Virtual units representing max query processor capacity per second provisioned within CosmosDb to host a Range of a Container
 Request Charge | Number of RUs charged for a specific action, taken from the RUs allocation for the relevant Range
 Stored Procedure | JavaScript code stored in a collection that can translate an input request to a set of actions to be transacted as a group within CosmosDb. Incurs equuivalent Request Charges for work performed; can chain to a continuation internally after a read or write.
@@ -354,9 +354,9 @@ c) submit the Events, if any, for appending
 d) retrying b+c where there's a conflict (i.e., the version of the stream that pertained in (a) has been superseded)
 e) after `maxAttempts` / `3` retries, a `MaxResyncAttemptsExceededException` is thrown, and an upstream can retry as necessary (depending on SLAs, a timeout may further constrain number of retries that can occur)
 
-Aside from reading the various documents regarding the conepts underlying CQRS, it's important to consider that (unless you're trying to leverage the Read-your-writes guarantee), doing reads direct from an event-sourced store is generally not considered a best practice (the opposite, in fact). Any state you surface to a caller is by definition out of date the millisecond you obtain it, so in many cases a caller might as well use an eventually-consistent version of the same state obtained via a [n eventually-consistent] Projection (see terms above).
+Aside from reading the various documentation regarding the concepts underlying CQRS, it's important to consider that (unless you're trying to leverage the Read-your-writes guarantee), doing reads direct from an event-sourced store is generally not considered a best practice (the opposite, in fact). Any state you surface to a caller is by definition out of date the millisecond you obtain it, so in many cases a caller might as well use an eventually-consistent version of the same state obtained via a [n eventually-consistent] Projection (see terms above).
 
-All that said, if you're in a situation where your cache hit ratio is goig to be high and/or you have reason to believe the underlying Event-Streams are not going to be long, pretty goof performance can be achieved nonetheless; just consider that taking this shortcut _will_ impede scaling and, at worst, can result in you ending up with a model that's potentially both:
+All that said, if you're in a situation where your cache hit ratio is going to be high and/or you have reason to believe the underlying Event-Streams are not going to be long, pretty goof performance can be achieved nonetheless; just consider that taking this shortcut _will_ impede scaling and, at worst, can result in you ending up with a model that's potentially both:
 
 - overly simplistic - you're passing up the opportunity to provide a Read Model that directly models the requirement by providing a Materialized View
 - unnecessarily complex - the increased complexity of the `fold` function and/or any output from `unfold` (and its storage cost) is a drag on one's ability to read, test, extend and generally maintain the Command Handling/Decision logic that can only live on the write side
@@ -399,7 +399,7 @@ The fact that we have a `Cleared` Event stems from the fact that the spec define
   ii) Because the `Cleared` Event establishes a known State, one can have the `isOrigin` flag the event as being the furthest one needs to search backwards before starting to `fold` events to establish the state. This also prevents the fact that the stream gets long in terms of numbers of events from impacting the effiency of the processing
   iii) While having a `Cleared` event happens to work, it also represents a technical trick in a toy domain and should not be considered some cure-all Pattern - real Todo apps don't have a 'declare backruptcy' function. And example alternate approaches might be to represent each Todo list as it's own stream, and then have a `TodoLists` aggregate coordinating those.
 
-The `Compacted` event is used to represent Rolling Snapshots (stored in-stream) and/or Unfolds (stored in Tip document); For a real Todo list, using this facility may well make sense - the State can fit in a reasonable space, and the likely number of Events may reach an interesting enough count to justify applying such a feature
+The `Compacted` event is used to represent Rolling Snapshots (stored in-stream) and/or Unfolds (stored in Tip document-Item); For a real Todo list, using this facility may well make sense - the State can fit in a reasonable space, and the likely number of Events may reach an interesting enough count to justify applying such a feature
   i) it should also be noted that Caching may be a better answer - note `Compacted` is also an `isOrigin` event - there's no need to go back any further if you meet one.
   ii) we use an Array in preference to a [F#] `list`; while there are `ListConverter`s out there (notably not in [`Jet.JsonNet.Converters`](https://github.com/jet/Jet.JsonNet.Converters)), in this case an Array is better from a GC and memory-efficiency stance, and does not need any special consideration when using `Newtonsoft.Json` to serialize.
 
@@ -535,13 +535,13 @@ Key aspects relevant to the Equinox programming model:
 - Similarly to EventStore, the default ARS encoding CosmosDb provides, together with interoperability concerns, means that straight json makes sense as an encoding form for events (UTF-8 arrays)
 - Collectively, the above implies (arguably counterintuitively) that using the powerful generic querying facility that CosmosDb provides should actually be a last resort.
 - See [Cosmos Storage Model](#cosmos-storage-model) for further information on the specific encoding used, informed by these concerns.
-- Because reads, writes _and updates_ of items in the Tip document are charged based on the size of the document in units of 1KB, it's worth compressing and/or storing snapshots ouside of the Tip-document (while those factors are also a concern with EventStore, the key difference is their direct effect of charges in this case).
+- Because reads, writes _and updates_ of items in the Tip document are charged based on the size of the item in units of 1KB, it's worth compressing and/or storing snapshots outside of the Tip-document (while those factors are also a concern with EventStore, the key difference is their direct effect of charges in this case).
 
 The implications of how the changefeed mechanism works also have implications for how events and snapshots should be encoded and/or stored:
 
 - Each write results in a potential cost per changefeed consumer, hence one should minimize changefeed consumers count
 - Each update of a document can have the same effect in terms of Request Charges incurred in tracking the changefeed (each write results in a document "moving to the tail" in the consumption order - if multiple writes occur within a polling period, you'll only see the last one)
-- The ChangeFeedProcessor presents a programming model which needs to maintain a position. Typically one should store that in an auxilliary collection in order to avoid feedback and/or interaction between the changefeed and those writes
+- The ChangeFeedProcessor presents a programming model which needs to maintain a position. Typically one should store that in an auxiliary collection in order to avoid feedback and/or interaction between the changefeed and those writes
 
 It can be useful to consider keeping snapshots in the auxilliary collection employed by the changefeed in order to optimize the interrelated concerns of not reading data redundantly, and not feeding back into the oneself (although having separate roundtrips obviously has implications).
  
@@ -558,7 +558,7 @@ Events are stored in immutable batches consisting of:
 - `p`artitionKey: `string` // stream identifier, e.g. "Cart-{guid}"
 - `i`ndex: `int64` // base index position of this batch (`0` for first event in a stream)
 - `n`extIndex: `int64` // base index ('i') position value of the next record in the stream - NB this _always_ corresponds to `i`+`e.length` (in the case of the `Tip` record, there won't actually be such a record yet)
-- `id`: `string` // same as `i` (CosmosDb forces every doc to have one[, and it must be a `string`])
+- `id`: `string` // same as `i` (CosmosDb forces every item (document) to have one[, and it must be a `string`])
 - `e`vents: `Event[]` // (see next section) typically there is one item in the array (can be many if events are small, for RU and performance/efficiency reasons; RU charges are per 1024 byte block)
 - `ts` // CosmosDb-intrinsic last updated date for this record (changes when replicated etc, hence see `t` below)
 
@@ -631,7 +631,7 @@ Given a stream with:
 ]
 ```
 
-If we have `state4` based on the events up to `{i:3, c:c1, d: d4}` and the index document, we can produce the `state` by folding in a variety of ways:
+If we have `state4` based on the events up to `{i:3, c:c1, d: d4}` and the Tip Item-document, we can produce the `state` by folding in a variety of ways:
 
 - `fold initial [ C1 d1; C2 d2; C3 d3; C1 d4; C3 d5 ]` (but would need a query to load the first 2 batches, with associated RUs and roundtrips)
 - `fold state4 [ C3 d5 ]` (only need to pay to transport the _tip_ document as a point read)
@@ -640,7 +640,7 @@ If we have `state4` based on the events up to `{i:3, c:c1, d: d4}` and the index
 
 If we have `state3` based on the events up to `{i:3, c:c1, d: d4}`, we can produce the `state` by folding in a variety of ways:
 
-- `fold initial [ C1 d1; C2 d2; C3 d3; C1 d4; C3 d5 ]` (but query, roundtrips)
+- `fold initial [ C1 d1; C2 d2; C3 d3; C1 d4; C3 d5 ]` (but query, round-trips)
 - `fold state3 [C1 d4 C3 d5]` (only pay for point read+transport)
 - `fold initial [S2 s4; C3 d5]` (only pay for point read+transport)
 - (if `isOrigin (S1 s5)` = `true`): `fold initial [S1 s5]` (point read + transport + decompress `s5`)
@@ -656,14 +656,14 @@ See [Programming Model](#programing-model) for what happens in the application b
 
 This covers what the most complete possible implementation of the JS Stored Procedure (see [source](https://github.com/jet/equinox/blob/tip-isa-batch/src/Equinox.Cosmos/Cosmos.fs#L302)) does when presented with a batch to be written. (NB The present implementation is slightly simplified; see [source](src/Equinox.Cosmos/Cosmos.fs#L303).
 
-The `sync` stored procedure takes a document as input which is almost identical to the format of the _`Tip`_ batch (in fact, if the stream is found to be empty, it is pretty much the template for the first document created in the stream). The request includes the following elements:
+The `sync` stored procedure takes as input, a document that is almost identical to the format of the _`Tip`_ batch (in fact, if the stream is found to be empty, it is pretty much the template for the first document created in the stream). The request includes the following elements:
 
 - `expectedVersion`: the position the requestor has based their [proposed] events on (no, [providing an `etag` to save on Request Charges is not possible in the Stored Proc](https://stackoverflow.com/questions/53355886/azure-cosmosdb-stored-procedure-ifmatch-predicate))
 - `e`: array of Events (see Event, above) to append iff the expectedVersion check is fulfilled
 - `u`: array of `unfold`ed events (aka snapshots) that supersede items with equivalent `c`ase values  
 - `maxEvents`: the maximum number of events in an individual batch prior to starting a new one. For example:
 
-  - if `e` contains 2 events, the _tip_ document's `e` has 2 documents and the `maxEvents` is `5`, the events get appended onto the tip
+  - if `e` contains 2 events, the _tip_ document's `e` has 2 events and the `maxEvents` is `5`, the events get appended onto the tip
   - if the total length including the new `e`vents would exceed `maxEvents`, the Tip is 'renamed' (gets its `id` set to `i.toString()`) to become a batch, and the new events go into the new Tip-Batch, the _tip_ gets frozen as a `Batch`, and the new request becomes the _tip_ (as an atomic transaction on the server side)
 
 - (PROPOSAL/FUTURE) `thirdPartyUnfoldRetention`: how many events to keep before the base (`i`) of the batch if required by lagging `u`nfolds which would otherwise fall out of scope as a result of the appends in this batch (this will default to `0`, so for example if a writer says maxEvents `10` and there is an `u`nfold based on an event more than `10` old it will be removed as part of the appending process)

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ While Equinox is implemented in F#, and F# is a great fit for writing event-sour
     ```powershell
     $env:EQUINOX_COSMOS_CONNECTION="AccountEndpoint=https://....;AccountKey=....=;"
     $env:EQUINOX_COSMOS_DATABASE="equinox-test"
-    $env:EQUINOX_COSMOS_COLLECTION="equinox-test"
+    $env:EQUINOX_COSMOS_CONTAINER="equinox-test"
     ```
 
 2. use the `eqx` tool to initialize the database and/or collection (using preceding env vars)
@@ -372,12 +372,12 @@ The CLI can drive the Store and TodoBackend samples in the `samples/Web` ASP.NET
 
     $env:EQUINOX_COSMOS_CONNECTION="AccountEndpoint=https://....;AccountKey=....=;"
     $env:EQUINOX_COSMOS_DATABASE="equinox-test"
-    $env:EQUINOX_COSMOS_COLLECTION="equinox-test"
+    $env:EQUINOX_COSMOS_CONTAINER="equinox-test"
 
     tools/Equinox.Tool/bin/Release/net461/eqx run `
-      cosmos -s $env:EQUINOX_COSMOS_CONNECTION -d $env:EQUINOX_COSMOS_DATABASE -c $env:EQUINOX_COSMOS_COLLECTION
+      cosmos -s $env:EQUINOX_COSMOS_CONNECTION -d $env:EQUINOX_COSMOS_DATABASE -c $env:EQUINOX_COSMOS_CONTAINER
     dotnet run -f netcoreapp2.1 -p tools/Equinox.Tool -- run `
-      cosmos -s $env:EQUINOX_COSMOS_CONNECTION -d $env:EQUINOX_COSMOS_DATABASE -c $env:EQUINOX_COSMOS_COLLECTION
+      cosmos -s $env:EQUINOX_COSMOS_CONNECTION -d $env:EQUINOX_COSMOS_DATABASE -c $env:EQUINOX_COSMOS_CONTAINER
 
 ## PROVISIONING
 
@@ -393,7 +393,7 @@ For EventStore, the tests assume a running local instance configured as follows 
 ### Provisioning CosmosDb (when not using -sc)
 
     dotnet run -f netcoreapp2.1 -p tools/Equinox.Tool -- init -ru 1000 `
-        cosmos -s $env:EQUINOX_COSMOS_CONNECTION -d $env:EQUINOX_COSMOS_DATABASE -c $env:EQUINOX_COSMOS_COLLECTION
+        cosmos -s $env:EQUINOX_COSMOS_CONNECTION -d $env:EQUINOX_COSMOS_DATABASE -c $env:EQUINOX_COSMOS_CONTAINER
 
 ## DEPROVISIONING
 
@@ -406,7 +406,7 @@ While EventStore rarely shows any negative effects from repeated load test runs,
 
 ### Deprovisioning CosmosDb
 
-The [provisioning](provisioning) step spins up RUs in DocDB for the Collection, which will keep draining your account until you reach a spending limit (if you're lucky!). *When finished running any test, it's critical to drop the RU allocations back down again via some mechanism (either delete the collection or reset teh RU provision dpwn to the lowest possible value)*.
+The [provisioning](provisioning) step spins up RUs in CosmosDB for the Container, which will keep draining your account until you reach a spending limit (if you're lucky!). *When finished running any test, it's critical to drop the RU allocations back down again via some mechanism (either delete the collection or reset teh RU provision dpwn to the lowest possible value)*.
 
 - Kill the collection and/or database
 - Use the portal to change the allocation

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ A key facility of this repo is being able to run load tests, either in process a
 
 - `Favorite` - Simulate a very enthusiastic user that favorites something once per second
   - the test generates an ever-growing state that can only be managed efficiently if you apply either caching, snapshotting or both
-  - NB due to being unbounded, even Rolling Snapshots or Unfolds will eventually hit the Store's limits (4MB/event for EventStore, 3MB/document for CosmosDb)
+  - NB due to being unbounded, even Rolling Snapshots or Unfolds will eventually hit the Store's limits (4MB/event for EventStore, 3MB/Item (document) for CosmosDB)
 - `SaveForLater` - Simulate a happy shopper that saves 3 items per second, and empties the Save For Later list whenever it is full (when it hits 50 items)
   - Snapshotting helps a lot
   - Caching is not as essential as it is for the `Favorite` test (as long as oyu have either aching or snapshotting, that is)

--- a/README.md
+++ b/README.md
@@ -308,10 +308,10 @@ A key facility of this repo is being able to run load tests, either in process a
 
 - `Favorite` - Simulate a very enthusiastic user that favorites something once per second
   - the test generates an ever-growing state that can only be managed efficiently if you apply either caching, snapshotting or both
-  - NB due to being unbounded, even Rolling Snapshots or Unfolds will eventually hit the Store's limits (4MB/event for EventStore, 3MB/Item (document) for CosmosDB)
+  - NB due to being unbounded, `RollingSnapshots`, `Snapshot`, `Unfolded` etc. will eventually hit the Store's limits (4MB/event for EventStore, 3MB/Item (document) for CosmosDB)
 - `SaveForLater` - Simulate a happy shopper that saves 3 items per second, and empties the Save For Later list whenever it is full (when it hits 50 items)
   - Snapshotting helps a lot
-  - Caching is not as essential as it is for the `Favorite` test (as long as oyu have either aching or snapshotting, that is)
+  - Caching is not as essential as it is for the `Favorite` test (as long as you have either caching or snapshotting, that is)
 - `Todo` - Keeps a) getting the list b) adding an item c) clearing the list when it hits 1000 items.
   - the `Cleared` event acts as a natural event to use in the `isOrigin` check. This makes snapshotting less crucial than it is, for example, in the case of the `Favorite` test
   - the `-s` parameter can be used to adjust the maximum item text length from the default (`100`, implying average length of 50)

--- a/build.ps1
+++ b/build.ps1
@@ -5,8 +5,8 @@ param(
 	[Alias("sc")][switch][bool] $skipCosmos=$skipStores,
 	[Alias("cs")][string] $cosmosServer=$env:EQUINOX_COSMOS_CONNECTION,
 	[Alias("cd")][string] $cosmosDatabase=$env:EQUINOX_COSMOS_DATABASE,
-	[Alias("cc")][string] $cosmosCollection=$env:EQUINOX_COSMOS_COLLECTION,
-	[Alias("scp")][switch][bool] $skipProvisionCosmos=$skipCosmos -or -not $cosmosServer -or -not $cosmosDatabase -or -not $cosmosCollection,
+	[Alias("cc")][string] $cosmosContainer=$env:EQUINOX_COSMOS_CONTAINER,
+	[Alias("scp")][switch][bool] $skipProvisionCosmos=$skipCosmos -or -not $cosmosServer -or -not $cosmosDatabase -or -not $cosmosContainer,
 	[Alias("scd")][switch][bool] $skipDeprovisionCosmos=$skipProvisionCosmos,
 	[string] $additionalMsBuildArgs="-t:Build"
 )
@@ -20,8 +20,8 @@ $env:EQUINOX_INTEGRATION_SKIP_EVENTSTORE=[string]$skipEs
 if ($skipEs) { warn "Skipping EventStore tests" }
 
 function cliCosmos($arghs) {
-	Write-Host "dotnet run tools/Equinox.Tool -- $arghs cosmos -s <REDACTED> -d $cosmosDatabase -c $cosmosCollection"
-	dotnet run -p tools/Equinox.Tool -f netcoreapp2.1 -- @arghs cosmos -s $cosmosServer -d $cosmosDatabase -c $cosmosCollection
+	Write-Host "dotnet run tools/Equinox.Tool -- $arghs cosmos -s <REDACTED> -d $cosmosDatabase -c $cosmosContainer"
+	dotnet run -p tools/Equinox.Tool -f netcoreapp2.1 -- @arghs cosmos -s $cosmosServer -d $cosmosDatabase -c $cosmosContainer
 }
 
 if ($skipCosmos) {

--- a/samples/Infrastructure/Services.fs
+++ b/samples/Infrastructure/Services.fs
@@ -15,8 +15,8 @@ type StreamResolver(storage) =
         | Storage.StorageConfig.Es (context, caching, unfolds) ->
             let accessStrategy = if unfolds then Equinox.EventStore.AccessStrategy.RollingSnapshots snapshot |> Some else None
             Equinox.EventStore.Resolver<'event,'state>(context, codec, fold, initial, ?caching = caching, ?access = accessStrategy).Resolve
-        | Storage.StorageConfig.Cosmos (gateway, caching, unfolds, databaseId, collectionId) ->
-            let store = Equinox.Cosmos.Context(gateway, databaseId, collectionId)
+        | Storage.StorageConfig.Cosmos (gateway, caching, unfolds, databaseId, containerId) ->
+            let store = Equinox.Cosmos.Context(gateway, databaseId, containerId)
             let accessStrategy = if unfolds then Equinox.Cosmos.AccessStrategy.Snapshot snapshot |> Some else None
             Equinox.Cosmos.Resolver<'event,'state>(store, codec, fold, initial, caching, ?access = accessStrategy).Resolve
 

--- a/samples/Infrastructure/Storage.fs
+++ b/samples/Infrastructure/Storage.fs
@@ -43,11 +43,11 @@ module Cosmos =
                 | Retries _ ->          "specify operation retries (default: 1)."
                 | RetriesWaitTime _ ->  "specify max wait-time for retry when being throttled by Cosmos in seconds (default: 5)"
                 | Connection _ ->       "specify a connection string for a Cosmos account (defaults: envvar:EQUINOX_COSMOS_CONNECTION, Cosmos Emulator)."
-                | ConnectionMode _ ->   "override the connection mode (default: DirectTcp)."
+                | ConnectionMode _ ->   "override the connection mode (default: Direct)."
                 | Database _ ->         "specify a database name for Cosmos account (defaults: envvar:EQUINOX_COSMOS_DATABASE, test)."
                 | Collection _ ->       "specify a collection name for Cosmos account (defaults: envvar:EQUINOX_COSMOS_COLLECTION, test)."
     type Info(args : ParseResults<Arguments>) =
-        member __.Mode = args.GetResult(ConnectionMode,Equinox.Cosmos.ConnectionMode.DirectTcp)
+        member __.Mode = args.GetResult(ConnectionMode,Equinox.Cosmos.ConnectionMode.Direct)
         member __.Connection =  match args.TryGetResult Connection  with Some x -> x | None -> envBackstop "Connection" "EQUINOX_COSMOS_CONNECTION"
         member __.Database =    match args.TryGetResult Database    with Some x -> x | None -> envBackstop "Database"   "EQUINOX_COSMOS_DATABASE"
         member __.Collection =  match args.TryGetResult Collection  with Some x -> x | None -> envBackstop "Collection" "EQUINOX_COSMOS_COLLECTION"

--- a/samples/Store/Integration/CartIntegration.fs
+++ b/samples/Store/Integration/CartIntegration.fs
@@ -23,7 +23,7 @@ let resolveGesStreamWithRollingSnapshots gateway =
 let resolveGesStreamWithoutCustomAccessStrategy gateway =
     EventStore.Resolver(gateway, codec, fold, initial).Resolve
 
-let resolveCosmosStreamWithProjection gateway =
+let resolveCosmosStreamWithSnapshotStrategy gateway =
     Cosmos.Resolver(gateway, codec, fold, initial, Cosmos.CachingStrategy.NoCaching, Cosmos.AccessStrategy.Snapshot snapshot).Resolve
 let resolveCosmosStreamWithoutCustomAccessStrategy gateway =
     Cosmos.Resolver(gateway, codec, fold, initial, Cosmos.CachingStrategy.NoCaching).Resolve
@@ -78,7 +78,7 @@ type Tests(testOutputHelper) =
     }
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
-    let ``Can roundtrip against Cosmos, correctly folding the events with With Projection`` args = Async.RunSynchronously <| async {
-        let! service = arrange connectToSpecifiedCosmosOrSimulator createCosmosContext resolveCosmosStreamWithProjection
+    let ``Can roundtrip against Cosmos, correctly folding the events with With Snapshotting`` args = Async.RunSynchronously <| async {
+        let! service = arrange connectToSpecifiedCosmosOrSimulator createCosmosContext resolveCosmosStreamWithSnapshotStrategy
         do! act service args
     }

--- a/samples/Store/Integration/LogIntegration.fs
+++ b/samples/Store/Integration/LogIntegration.fs
@@ -124,7 +124,7 @@ type Tests() =
         let log = createLoggerWithMetricsExtraction buffer.Enqueue
         let! conn = connectToSpecifiedCosmosOrSimulator log
         let gateway = createCosmosContext conn batchSize
-        let service = Backend.Cart.Service(log, CartIntegration.resolveCosmosStreamWithProjection gateway)
+        let service = Backend.Cart.Service(log, CartIntegration.resolveCosmosStreamWithSnapshotStrategy gateway)
         let itemCount = batchSize / 2 + 1
         let cartId = % Guid.NewGuid()
         do! act buffer service itemCount context cartId skuId "EqxCosmos Tip " // one is a 404, one is a 200

--- a/samples/Store/Integration/LogIntegration.fs
+++ b/samples/Store/Integration/LogIntegration.fs
@@ -10,7 +10,7 @@ open System.Collections.Concurrent
 module EquinoxEsInterop =
     open Equinox.EventStore
     [<NoEquality; NoComparison>]
-    type FlatMetric = { action: string; stream: string; interval: StopwatchInterval; bytes: int; count: int; batches: int option } with
+    type FlatMetric = { action: string; stream : string; interval: StopwatchInterval; bytes: int; count: int; batches: int option } with
         override __.ToString() = sprintf "%s-Stream=%s %s-Elapsed=%O" __.action __.stream __.action __.interval.Elapsed
     let flatten (evt : Log.Event) : FlatMetric =
         let action, metric, batches =
@@ -25,7 +25,7 @@ module EquinoxEsInterop =
 module EquinoxCosmosInterop =
     open Equinox.Cosmos.Store
     [<NoEquality; NoComparison>]
-    type FlatMetric = { action: string; stream: string; interval: StopwatchInterval; bytes: int; count: int; responses: int option; ru: float } with
+    type FlatMetric = { action: string; stream : string; interval: StopwatchInterval; bytes: int; count: int; responses: int option; ru: float } with
         override __.ToString() = sprintf "%s-Stream=%s %s-Elapsed=%O Ru=%O" __.action __.stream __.action __.interval.Elapsed __.ru
     let flatten (evt : Log.Event) : FlatMetric =
         let action, metric, batches, ru =

--- a/samples/Tutorial/Cosmos.fsx
+++ b/samples/Tutorial/Cosmos.fsx
@@ -67,7 +67,7 @@ module Store =
     let conn = connector.Connect("equinox-tutorial", Discovery.FromConnectionString (read "EQUINOX_COSMOS_CONNECTION")) |> Async.RunSynchronously
     let gateway = Gateway(conn, BatchingPolicy())
 
-    let context = Context(gateway, read "EQUINOX_COSMOS_DATABASE", read "EQUINOX_COSMOS_COLLECTION")
+    let context = Context(gateway, read "EQUINOX_COSMOS_DATABASE", read "EQUINOX_COSMOS_CONTAINER")
     let cache = Caching.Cache("equinox-tutorial", 20)
     let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
 

--- a/samples/Tutorial/Todo.fsx
+++ b/samples/Tutorial/Todo.fsx
@@ -111,7 +111,7 @@ module Store =
     let conn = connector.Connect("equinox-tutorial", Discovery.FromConnectionString (read "EQUINOX_COSMOS_CONNECTION")) |> Async.RunSynchronously
     let gateway = Gateway(conn, BatchingPolicy())
 
-    let store = Context(gateway, read "EQUINOX_COSMOS_DATABASE", read "EQUINOX_COSMOS_COLLECTION")
+    let store = Context(gateway, read "EQUINOX_COSMOS_DATABASE", read "EQUINOX_COSMOS_CONTAINER")
     let cache = Caching.Cache("equinox-tutorial", 20)
     let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
 

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -1035,7 +1035,7 @@ type ConnectionMode =
     /// Default mode, uses Https - inefficient as uses a double hop
     | Gateway
     /// Most efficient, but requires direct connectivity
-    | DirectTcp
+    | Direct
     // More efficient than Gateway, but suboptimal
     | DirectHttps
 
@@ -1069,7 +1069,7 @@ type Connector
         match mode with
         | None | Some ConnectionMode.Gateway -> cp.ConnectionMode <- Client.ConnectionMode.Gateway // default; only supports Https
         | Some ConnectionMode.DirectHttps -> cp.ConnectionMode <- Client.ConnectionMode.Direct; cp.ConnectionProtocol <- Client.Protocol.Https // Https is default when using Direct
-        | Some ConnectionMode.DirectTcp -> cp.ConnectionMode <- Client.ConnectionMode.Direct; cp.ConnectionProtocol <- Client.Protocol.Tcp
+        | Some ConnectionMode.Direct -> cp.ConnectionMode <- Client.ConnectionMode.Direct; cp.ConnectionProtocol <- Client.Protocol.Tcp
         cp.RetryOptions <-
             Client.RetryOptions(
                 MaxRetryAttemptsOnThrottledRequests = maxRetryAttemptsOnThrottledRequests,
@@ -1095,8 +1095,8 @@ type Connector
 
         match discovery with Discovery.UriAndKey(databaseUri=uri; key=key) -> connect (uri,key)
 
-    /// Connection policy (for ChangeFeed)
-    member __.ConnectionPolicy : Client.ConnectionPolicy = clientOptions
+    /// ClientOptions (ConnectionPolicy with v2 SDK) for this Connection as configured
+    member __.ClientOptions : Client.ConnectionPolicy = clientOptions
 
     /// Yields a DocDbConnection configured per the specified strategy
     member __.Connect(name, discovery : Discovery) : Async<Connection> = async {

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -867,7 +867,7 @@ module Caching =
             | x -> failwithf "TryGet Incompatible cache entry %A" x
 
     /// Forwards all state changes in all streams of an ICategory to a `tee` function
-    type CategoryTee<'event, 'state>(inner: Store.ICategory<'event, 'state, Store.Container*string>, tee : string -> Store.StreamToken * 'state -> unit) =
+    type CategoryTee<'event, 'state>(inner: Store.ICategory<'event, 'state, Container*string>, tee : string -> Store.StreamToken * 'state -> unit) =
         let intercept streamName tokenAndState =
             tee streamName tokenAndState
             tokenAndState
@@ -1065,18 +1065,18 @@ type Connector
     do if log = null then nullArg "log"
 
     let clientOptions =
-        let cp = Client.ConnectionPolicy.Default
+        let co = Client.ConnectionPolicy.Default
         match mode with
-        | None | Some ConnectionMode.Gateway -> cp.ConnectionMode <- Client.ConnectionMode.Gateway // default; only supports Https
-        | Some ConnectionMode.DirectHttps -> cp.ConnectionMode <- Client.ConnectionMode.Direct; cp.ConnectionProtocol <- Client.Protocol.Https // Https is default when using Direct
-        | Some ConnectionMode.Direct -> cp.ConnectionMode <- Client.ConnectionMode.Direct; cp.ConnectionProtocol <- Client.Protocol.Tcp
-        cp.RetryOptions <-
+        | None | Some ConnectionMode.Gateway -> co.ConnectionMode <- Client.ConnectionMode.Gateway // default; only supports Https
+        | Some ConnectionMode.DirectHttps -> co.ConnectionMode <- Client.ConnectionMode.Direct; co.ConnectionProtocol <- Client.Protocol.Https // Https is default when using Direct
+        | Some ConnectionMode.Direct -> co.ConnectionMode <- Client.ConnectionMode.Direct; co.ConnectionProtocol <- Client.Protocol.Tcp
+        co.RetryOptions <-
             Client.RetryOptions(
                 MaxRetryAttemptsOnThrottledRequests = maxRetryAttemptsOnThrottledRequests,
                 MaxRetryWaitTimeInSeconds = maxRetryWaitTimeInSeconds)
-        cp.RequestTimeout <- requestTimeout
-        cp.MaxConnectionLimit <- defaultArg gatewayModeMaxConnectionLimit 1000
-        cp
+        co.RequestTimeout <- requestTimeout
+        co.MaxConnectionLimit <- defaultArg gatewayModeMaxConnectionLimit 1000
+        co
 
     /// Yields an CosmosClient configured and Connect()ed to a given DocDB collection per the requested `discovery` strategy
     let connect

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -183,7 +183,7 @@ type IRetryPolicy = abstract member Execute: (int -> Async<'T>) -> Async<'T>
 
 module Log =
     [<NoEquality; NoComparison>]
-    type Measurement = { stream: string; interval: StopwatchInterval; bytes: int; count: int; ru: float }
+    type Measurement = { stream : string; interval: StopwatchInterval; bytes: int; count: int; ru: float }
     [<NoEquality; NoComparison>]
     type Event =
         /// Individual read request for the Tip
@@ -415,7 +415,7 @@ function sync(req, expectedVersion, maxEvents) {
         | Conflict of Position * events: IIndexedEvent[]
         | ConflictUnknown of Position
 
-    let private run (container : Container, stream: string) (expectedVersion: int64 option, req: Tip, maxEvents: int)
+    let private run (container : Container, stream : string) (expectedVersion: int64 option, req: Tip, maxEvents: int)
         : Async<float*Result> = async {
         let sprocLink = sprintf "%O/sprocs/%s" container.CollectionUri sprocName
         let opts = Client.RequestOptions(PartitionKey=PartitionKey stream)
@@ -537,7 +537,7 @@ function sync(req, expectedVersion, maxEvents) {
             return! createAuxContainerIfNotExists client (dbName,collName) mode }
 
 module internal Tip =
-    let private get (container : Container, stream: string) (maybePos: Position option) =
+    let private get (container : Container, stream : string) (maybePos: Position option) =
         let ac = match maybePos with Some { etag=Some etag } -> Client.AccessCondition(Type=Client.AccessConditionType.IfNoneMatch, Condition=etag) | _ -> null
         let ro = Client.RequestOptions(PartitionKey=PartitionKey(stream), AccessCondition = ac)
         container.TryReadItem(PartitionKey stream, Tip.WellKnownDocumentId, ro)
@@ -569,7 +569,7 @@ module internal Tip =
  module internal Query =
     open Microsoft.Azure.Documents.Linq
     open FSharp.Control
-    let private mkQuery (container : Container, stream: string) maxItems (direction: Direction) startPos =
+    let private mkQuery (container : Container, stream : string) maxItems (direction: Direction) startPos =
         let query =
             let root = sprintf "SELECT c.id, c.i, c._etag, c.n, c.e FROM c WHERE c.id!=\"%s\"" Tip.WellKnownDocumentId
             let tail = sprintf "ORDER BY c.i %s" (if direction = Direction.Forward then "ASC" else "DESC")

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -17,7 +17,7 @@ type [<NoEquality; NoComparison; JsonObject(ItemRequired=Required.Always)>]
         /// The Case (Event Type); used to drive deserialization
         c: string // required
 
-        /// Event body, as UTF-8 encoded json ready to be injected into the Json being rendered for DocDb
+        /// Event body, as UTF-8 encoded json ready to be injected into the Json being rendered for CosmosDB
         [<JsonConverter(typeof<Equinox.Cosmos.Internal.Json.VerbatimUtf8JsonConverter>)>]
         [<JsonProperty(Required=Required.AllowNull)>]
         d: byte[] // Required, but can be null so Nullary cases can work
@@ -35,7 +35,7 @@ type [<NoEquality; NoComparison; JsonObject(ItemRequired=Required.Always)>]
         [<JsonProperty(Required=Required.Default)>] // Not requested in queries
         p: string // "{streamName}"
 
-        /// DocDb-mandated unique row key; needs to be unique within any partition it is maintained; must be string
+        /// CosmosDB-mandated unique row key; needs to be unique within any partition it is maintained; must be string
         /// At the present time, one can't perform an ORDER BY on this field, hence we also have i shadowing it
         /// NB Tip uses a well known value here while it's actively 'open'
         id: string // "{index}"
@@ -1020,7 +1020,7 @@ type Resolver<'event, 'state>(context : Context, codec, fold, initial, caching, 
 [<RequireQualifiedAccess; NoComparison>]
 type Discovery =
     | UriAndKey of databaseUri:Uri * key:string
-    /// Implements connection string parsing logic curiously missing from the DocDb SDK
+    /// Implements connection string parsing logic curiously missing from the CosmosDB SDK
     static member FromConnectionString (connectionString: string) =
         match connectionString with
         | _ when String.IsNullOrWhiteSpace connectionString -> nullArg "connectionString"
@@ -1120,7 +1120,7 @@ type AppendResult<'t> =
 
 /// Encapsulates the core facilites Equinox.Cosmos offers for operating directly on Events in Streams.
 type Context
-    (   /// Connection to CosmosDb with DocumentDb Transient Read and Write Retry policies
+    (   /// Connection to CosmosDb, includes defined Transient Read and Write Retry policies
         conn : Connection,
         /// Container selector, mapping Stream Categories to Containers
         containers : Containers,

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -526,9 +526,9 @@ function sync(req, expectedVersion, maxEvents) {
             def.IndexingPolicy.IndexingMode <- IndexingMode.None
             createOrProvisionContainer client (dName,def) mode
         let init log (client : Client.DocumentClient) (dName,cName) mode skipStoredProc = async {
+            do! createOrProvisionDatabase client dName mode
+            do! createBatchAndTipContainerIfNotExists client (dName,cName) mode
             let container = Container(client,dName,cName)
-            do! createOrProvisionDatabase container.Client dName mode
-            do! createBatchAndTipContainerIfNotExists container.Client (dName,cName) mode
             if not skipStoredProc then
                 do! createSyncStoredProcIfNotExists (Some log) container }
         let initAux (client: Client.DocumentClient) (dName,cName) rus = async {

--- a/src/Equinox.Cosmos/CosmosInternalJson.fs
+++ b/src/Equinox.Cosmos/CosmosInternalJson.fs
@@ -26,7 +26,7 @@ open System.IO
 open System.IO.Compression
 
 /// Manages zipping of the UTF-8 json bytes to make the index record minimal from the perspective of the writer stored proc
-/// Only applied to snapshots in the Index
+/// Only applied to snapshots in the Tip
 type Base64ZipUtf8JsonConverter() =
     inherit JsonConverter()
     let pickle (input : byte[]) : string =

--- a/src/Equinox.Cosmos/CosmosInternalJson.fs
+++ b/src/Equinox.Cosmos/CosmosInternalJson.fs
@@ -3,7 +3,7 @@
 open Newtonsoft.Json.Linq
 open Newtonsoft.Json
 
-/// Manages injecting prepared json into the data being submitted to DocDb as-is, on the basis we can trust it to be valid json as DocDb will need it to be
+/// Manages injecting prepared json into the data being submitted to CosmosDB as-is, on the basis we can trust it to be valid json as CosmosDB will need it to be
 type VerbatimUtf8JsonConverter() =
     inherit JsonConverter()
     

--- a/src/Equinox.MemoryStore/MemoryStore.fs
+++ b/src/Equinox.MemoryStore/MemoryStore.fs
@@ -13,7 +13,7 @@ exception private WrongVersionException of streamName: string * expected: int * 
 [<NoEquality; NoComparison>]
 type ConcurrentDictionarySyncResult<'t> = Written of 't | Conflict of int
 
-/// Response type for ConcurrentArrayStore.TrySync to communicate the outcome and updated state of a stream
+/// Response type for VolatileStore.TrySync to communicate the outcome and updated state of a stream
 [<NoEquality; NoComparison>]
 type ConcurrentArraySyncResult<'t> = Written of 't | Conflict of 't
 

--- a/tests/Equinox.Cosmos.Integration/CosmosCoreIntegration.fs
+++ b/tests/Equinox.Cosmos.Integration/CosmosCoreIntegration.fs
@@ -31,7 +31,7 @@ type Tests(testOutputHelper) =
         incr testIterations
         sprintf "events-%O-%i" name !testIterations
     let mkContextWithItemLimit conn defaultBatchSize =
-        Context(conn,collections,log,?defaultMaxItems=defaultBatchSize)
+        Context(conn,containers,log,?defaultMaxItems=defaultBatchSize)
     let mkContext conn = mkContextWithItemLimit conn None
 
     let verifyRequestChargesMax rus =

--- a/tests/Equinox.Cosmos.Integration/CosmosCoreIntegration.fs
+++ b/tests/Equinox.Cosmos.Integration/CosmosCoreIntegration.fs
@@ -55,7 +55,7 @@ type Tests(testOutputHelper) =
         test <@ AppendResult.Ok 6L = res @>
         test <@ [EqxAct.Append] = capture.ExternalCalls @>
         // We didnt request small batches or splitting so it's not dramatically more expensive to write N events
-        verifyRequestChargesMax 40 // observed 38.95 // was 11
+        verifyRequestChargesMax 41 // observed 40.78 // was 11
     }
 
     // It's conceivable that in the future we might allow zero-length batches as long as a sync mechanism leveraging the etags and unfolds updote mechanisms
@@ -150,7 +150,7 @@ type Tests(testOutputHelper) =
         let extrasCount = match extras with x when x > 50 -> 5000 | x when x < 1 -> 1 | x -> x*100
         let! _pos = ctx.NonIdempotentAppend(stream, TestEvents.Create (int pos,extrasCount))
         test <@ [EqxAct.Append] = capture.ExternalCalls @>
-        verifyRequestChargesMax 300 // 251.39 observed
+        verifyRequestChargesMax 460 // 451.01 observed
         capture.Clear()
 
         let! pos = ctx.Sync(stream,?position=None)

--- a/tests/Equinox.Cosmos.Integration/CosmosFixtures.fs
+++ b/tests/Equinox.Cosmos.Integration/CosmosFixtures.fs
@@ -9,7 +9,7 @@ module Option =
 
 /// Standing up an Equinox instance is necessary to run for test purposes; either:
 /// - replace connection below with a connection string or Uri+Key for an initialized Equinox instance
-/// - Create a local Equinox via dotnet run cli/Equinox.cli -s $env:EQUINOX_COSMOS_CONNECTION -d test -c $env:EQUINOX_COSMOS_COLLECTION provision -ru 10000
+/// - Create a local Equinox via dotnet run cli/Equinox.cli -s $env:EQUINOX_COSMOS_CONNECTION -d test -c $env:EQUINOX_COSMOS_CONTAINER provision -ru 10000
 let private connectToCosmos (log: Serilog.ILogger) name discovery =
     Connector(log=log, requestTimeout=TimeSpan.FromSeconds 3., maxRetryAttemptsOnThrottledRequests=2, maxRetryWaitTimeInSeconds=60)
        .Connect(name, discovery)
@@ -28,9 +28,9 @@ let connectToSpecifiedCosmosOrSimulator (log: Serilog.ILogger) =
 let defaultBatchSize = 500
 
 let collections =
-    Collections(
+    Containers(
         read "EQUINOX_COSMOS_DATABASE" |> Option.defaultValue "equinox-test",
-        read "EQUINOX_COSMOS_COLLECTION" |> Option.defaultValue "equinox-test")
+        read "EQUINOX_COSMOS_CONTAINER" |> Option.defaultValue "equinox-test")
 
 let createCosmosContext connection batchSize =
     let gateway = Gateway(connection, BatchingPolicy(defaultMaxItems=batchSize))

--- a/tests/Equinox.Cosmos.Integration/CosmosFixtures.fs
+++ b/tests/Equinox.Cosmos.Integration/CosmosFixtures.fs
@@ -27,11 +27,11 @@ let connectToSpecifiedCosmosOrSimulator (log: Serilog.ILogger) =
 
 let defaultBatchSize = 500
 
-let collections =
+let containers =
     Containers(
         read "EQUINOX_COSMOS_DATABASE" |> Option.defaultValue "equinox-test",
         read "EQUINOX_COSMOS_CONTAINER" |> Option.defaultValue "equinox-test")
 
 let createCosmosContext connection batchSize =
     let gateway = Gateway(connection, BatchingPolicy(defaultMaxItems=batchSize))
-    Context(gateway, collections)
+    Context(gateway, containers)

--- a/tests/Equinox.Cosmos.Integration/CosmosFixturesInfrastructure.fs
+++ b/tests/Equinox.Cosmos.Integration/CosmosFixturesInfrastructure.fs
@@ -29,10 +29,10 @@ type AutoDataAttribute() =
 // Derived from https://github.com/damianh/CapturingLogOutputWithXunit2AndParallelTests
 // NB VS does not surface these atm, but other test runners / test reports do
 type TestOutputAdapter(testOutput : Xunit.Abstractions.ITestOutputHelper) =
-    let formatter = Serilog.Formatting.Display.MessageTemplateTextFormatter("{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {Message}{NewLine}{Exception}", null);
+    let formatter = Serilog.Formatting.Display.MessageTemplateTextFormatter("{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {Message}{NewLine}{Properties}{Exception}", null);
     let writeSerilogEvent logEvent =
         use writer = new System.IO.StringWriter()
-        formatter.Format(logEvent, writer);
+        formatter.Format(logEvent, writer)
         writer |> string |> testOutput.WriteLine
     interface Serilog.Core.ILogEventSink with member __.Emit logEvent = writeSerilogEvent logEvent
 

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -27,7 +27,7 @@ type Arguments =
             | LocalSeq -> "Configures writing to a local Seq endpoint at http://localhost:5341, see https://getseq.net"
             | LogFile _ -> "specify a log file to write the result breakdown into (default: eqx.log)."
             | Run _ -> "Run a load test"
-            | Init _ -> "Initialize Store/Collection (presently only relevant for `cosmos`; also handles adjusting RU/s provisioning adjustment)."
+            | Init _ -> "Initialize Store/Container (presently only relevant for `cosmos`; also handles RU/s provisioning adjustment)."
 and [<NoComparison>]InitArguments =
     | [<AltCommandLine("-ru"); Mandatory>] Rus of int
     | [<AltCommandLine("-D")>] Shared
@@ -35,9 +35,9 @@ and [<NoComparison>]InitArguments =
     | [<CliPrefix(CliPrefix.None)>] Cosmos of ParseResults<Storage.Cosmos.Arguments>
     interface IArgParserTemplate with
         member a.Usage = a |> function
-            | Rus _ -> "Specify RU/s level to provision for the Collection."
+            | Rus _ -> "Specify RU/s level to provision for the Container."
             | Shared -> "Use Database-level RU allocations (Default: Use Container-level allocation)."
-            | SkipStoredProc -> "Inhibit creation of stored procedure in cited Collection."
+            | SkipStoredProc -> "Inhibit creation of stored procedure in specified Container."
             | Cosmos _ -> "Cosmos Connection parameters."
 and [<NoComparison>]InitDbArguments =
     | [<AltCommandLine("-ru"); Mandatory>] Rus of int
@@ -46,7 +46,7 @@ and [<NoComparison>]InitDbArguments =
     interface IArgParserTemplate with
         member a.Usage = a |> function
             | Rus _ -> "Specify RU/s level to provision for the Database."
-            | SkipStoredProc -> "Inhibit creation of stored procedure in cited Collection."
+            | SkipStoredProc -> "Inhibit creation of stored procedure in specified Container."
             | Cosmos _ -> "Cosmos Connection parameters."
 and [<NoComparison>]WebArguments =
     | [<AltCommandLine("-u")>] Endpoint of string
@@ -221,7 +221,7 @@ module CosmosInit =
             let storeLog = createStoreLog (sargs.Contains Storage.Cosmos.Arguments.VerboseStore) verboseConsole maybeSeq
             let discovery, dbName, collName, connector = Storage.Cosmos.connection (log,storeLog) (Storage.Cosmos.Info sargs)
             let modeStr, rus = match mode with Provisioning.Container rus -> "Container",rus | Provisioning.Database rus -> "Database",rus
-            log.Information("Provisioning `Equinox.Cosmos` Store Collection at {mode:l} level for {rus:n0} RU/s", modeStr, rus)
+            log.Information("Provisioning `Equinox.Cosmos` Store collection at {mode:l} level for {rus:n0} RU/s", modeStr, rus)
             let! conn = connector.Connect("equinox-tool", discovery)
             let container = Equinox.Cosmos.Store.Container(conn.Client,dbName,collName)
             return! init log container (dbName,collName) mode skipStoredProc

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -219,12 +219,12 @@ module CosmosInit =
             let rus, skipStoredProc = iargs.GetResult(InitArguments.Rus), iargs.Contains InitArguments.SkipStoredProc
             let mode = if iargs.Contains InitArguments.Shared then Provisioning.Database rus else Provisioning.Container rus
             let storeLog = createStoreLog (sargs.Contains Storage.Cosmos.Arguments.VerboseStore) verboseConsole maybeSeq
-            let discovery, dbName, collName, connector = Storage.Cosmos.connection (log,storeLog) (Storage.Cosmos.Info sargs)
+            let discovery, dName, cName, connector = Storage.Cosmos.connection (log,storeLog) (Storage.Cosmos.Info sargs)
             let modeStr, rus = match mode with Provisioning.Container rus -> "Container",rus | Provisioning.Database rus -> "Database",rus
             log.Information("Provisioning `Equinox.Cosmos` Store collection at {mode:l} level for {rus:n0} RU/s", modeStr, rus)
             let! conn = connector.Connect("equinox-tool", discovery)
-            let container = Equinox.Cosmos.Store.Container(conn.Client,dbName,collName)
-            return! init log container (dbName,collName) mode skipStoredProc
+            let container = Equinox.Cosmos.Store.Container(conn.Client,dName,cName)
+            return! init log container (dName,cName) mode skipStoredProc
         | _ -> failwith "please specify a `cosmos` endpoint" }
 
 [<EntryPoint>]

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -223,8 +223,7 @@ module CosmosInit =
             let modeStr, rus = match mode with Provisioning.Container rus -> "Container",rus | Provisioning.Database rus -> "Database",rus
             log.Information("Provisioning `Equinox.Cosmos` Store collection at {mode:l} level for {rus:n0} RU/s", modeStr, rus)
             let! conn = connector.Connect("equinox-tool", discovery)
-            let container = Equinox.Cosmos.Store.Container(conn.Client,dName,cName)
-            return! init log container (dName,cName) mode skipStoredProc
+            return! init log conn.Client (dName,cName) mode skipStoredProc
         | _ -> failwith "please specify a `cosmos` endpoint" }
 
 [<EntryPoint>]


### PR DESCRIPTION
Renaming brought forward from #144 in order to reduce knock on effects of renames that will come in the Cosmos V3 SDK timeframe
- [x] `ConnectionMode.DirectTcp` -> `Direct` (V3 is introducing an enum as we presaged, but the name is more ... direct) #re
- [x] `ConnectionPolicy` -> `ClientOptions` (this is the type name in V3 and better describes the real purpose; usage is minimal at present, as it's mainly used by Propulsion and/or dotnet-templates internally)
- [x] `Collection` -> `Container` - See #148 - this name is being used consistently elsewhere now
- [x] `DocumentDb` / `DocDb` -> `CosmosDB`
- [x] Typos