### PR TITLE
Implement Cosmos RollingUnfolds strategy re #146

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
-- `Cosmos`: Add `AccessStrategy.RollingState`, leveraging `_etag`-contingent writes to allow state management without needing to write an event per update [#146](https://github.com/jet/equinox/pull/146)
+- `Cosmos`: Add `AccessStrategy.RollingUnfolds`, leveraging `_etag`-contingent writes to allow state management without needing to write >=1 event per update [#146](https://github.com/jet/equinox/pull/146)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `Cosmos`: Add `AccessStrategy.RollingState`, leveraging `_etag`-contingent writes to allow state management without needing to write an event per update [#146](https://github.com/jet/equinox/pull/146)
+
 ### Changed
 
 - Updated README.md to refer to `propulsion init` and `propulsion project` (formerly `eqx` `initAux` and `project`) (jet/propulsion#17)[https://github.com/jet/propulsion/pull/17]

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -65,7 +65,7 @@ Range | Subset of the hashed key space of a collection held as a physical partit
 Replay | The ability to re-run the processing of the Change Feed from the oldest Item (document) forward at will
 Request Units | Virtual units representing max query processor capacity per second provisioned within CosmosDb to host a Range of a Container
 Request Charge | Number of RUs charged for a specific action, taken from the RUs allocation for the relevant Range
-Stored Procedure | JavaScript code stored in a collection that can translate an input request to a set of actions to be transacted as a group within CosmosDb. Incurs equuivalent Request Charges for work performed; can chain to a continuation internally after a read or write.
+Stored Procedure | JavaScript code stored in a collection that can translate an input request to a set of actions to be transacted as a group within CosmosDb. Incurs equivalent Request Charges for work performed; can chain to a continuation internally after a read or write.
 
 ## EventStore
 
@@ -744,7 +744,6 @@ This is a very loose laundry list of items that have occurred to us to do, given
 
 ## Wouldn't it be nice - `Equinox`
 
-- While the plan is to support linux and MacOS, there are skipped tests wrt Mono etc. In terms of non-Windows developer experience, there's plenty scope for improvement.
 - Performance tuning for non-store-specific logic; no perf tuning has been done to date (though some of the Store/Domain implementations do show perf-optimized fold implementation techniques). While in general the work is I/O bound, there are definitely opportunities to use `System.IO.Pipelines` etc, and the `MemoryStore` and CLI gives a good testbed to drive this improvement.
 
 ## Wouldn't it be nice - `Equinox.EventStore`
@@ -761,7 +760,6 @@ EventStore, and it's Store adapter is the most proven and is pretty feature rich
 - Multiple writers support for `u`nfolds (at present a `sync` completely replaces the unfolds in the Tip; this will be extended by having the stored proc maintain the union of the unfolds in play (both for semi-related services and for blue/green deploy scenarios); TBD how we decide when a union that's no longer in use gets removed) [#108](https://github.com/jet/equinox/issues/108)
 - performance, efficiency and concurrency improvements based on [`tip-isa-batch`](https://github.com/jet/equinox/tree/tip-isa-batch) schema generalization [#109](https://github.com/jet/equinox/issues/109)
 - performance improvements in loading logic
-- `_etag`-based consistency checks?
 - Perf tuning of `JObject` vs `UTF-8` arrays and/or using a different serializer [#79](https://github.com/jet/equinox/issues/79)
 
 ## Wouldn't it be nice - `Equinox.SqlStreamStore`

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ A key facility of this repo is being able to run load tests, either in process a
 
 - `Favorite` - Simulate a very enthusiastic user that favorites something once per second
   - the test generates an ever-growing state that can only be managed efficiently if you apply either caching, snapshotting or both
-  - NB due to being unbounded, even `RollingSnapshots` `Unfolded` (event `RollingUnfolds`) will eventually hit the Store's limits (4MB/event for EventStore, 3MB/Item (document) for CosmosDB)
+  - NB due to being unbounded, `RollingSnapshots`, `Snapshot`, `Unfolded` etc. (even `RollingUnfolds`) will eventually hit the Store's limits (4MB/event for EventStore, 3MB/Item (document) for CosmosDB)
 - `SaveForLater` - Simulate a happy shopper that saves 3 items per second, and empties the Save For Later list whenever it is full (when it hits 50 items)
   - Snapshotting helps a lot
   - Caching is not as essential as it is for the `Favorite` test (as long as you have either caching or snapshotting, that is)

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ A key facility of this repo is being able to run load tests, either in process a
 
 - `Favorite` - Simulate a very enthusiastic user that favorites something once per second
   - the test generates an ever-growing state that can only be managed efficiently if you apply either caching, snapshotting or both
-  - NB due to being unbounded, `RollingSnapshots`, `Snapshot`, `Unfolded` etc. will eventually hit the Store's limits (4MB/event for EventStore, 3MB/Item (document) for CosmosDB)
+  - NB due to being unbounded, even `RollingSnapshots` `Unfolded` (event `RollingUnfolds`) will eventually hit the Store's limits (4MB/event for EventStore, 3MB/Item (document) for CosmosDB)
 - `SaveForLater` - Simulate a happy shopper that saves 3 items per second, and empties the Save For Later list whenever it is full (when it hits 50 items)
   - Snapshotting helps a lot
   - Caching is not as essential as it is for the `Favorite` test (as long as you have either caching or snapshotting, that is)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The implementations are distilled from [`Jet.com` systems dating all the way bac
   - no additional roundtrips to the store needed at either the Load or Sync points in the flow
 
   It should be noted that from a querying perspective, the `Tip` shares the same structure as `Batch` documents (a potential future extension would be to carry some events in the `Tip` as [some interim versions of the implementation once did](https://github.com/jet/equinox/pull/58), see also [#109](https://github.com/jet/equinox/pull/109).
+- **`Equinox.Cosmos` `RollingUnfolds` 'non-event-sourced' mode**: Uses 'Tip with Unfolds' encoding to avoid having to write events at all - this allows one to build, reason about and test your aggregates in the normal manner, but prevent events from being persisted. This enables one to benefit from the caching and consistency management mechanisms without having to represent every change as an event. Search for `transmute` in the `samples` and/or see [the `Checkpoint` Aggregate in Propulsion](https://github.com/jet/propulsion/blob/master/src/Propulsion.EventStore/Checkpoint.fs). One chief use of this mechanism is for tracking Summary Event feeds in the `dotnet-templates` Consumption templates.
 
 ## Components
 

--- a/samples/Store/Domain/Cart.fs
+++ b/samples/Store/Domain/Cart.fs
@@ -42,6 +42,8 @@ module Folds =
     let fold state = Seq.fold evolve state
     let isOrigin = function Events.Compacted _ -> true | _ -> false
     let compact = State.toSnapshot >> Events.Compacted
+    /// This transmute impl a) removes events - we're not interested in storing the events b) packs the post-state into a Compacted unfold-event
+    let transmute _events state = [],[compact state]
 type Context =              { time: System.DateTime; requestId : RequestId }
 type Command =
     | AddItem               of Context * SkuId * quantity: int

--- a/samples/Store/Domain/ContactPreferences.fs
+++ b/samples/Store/Domain/ContactPreferences.fs
@@ -19,6 +19,10 @@ module Folds =
         | Events.Updated { preferences = value } -> value
     let fold (state: State) (events: seq<Events.Event>) : State =
         Seq.tryLast events |> Option.fold evolve state
+    let isOrigin _ = true
+    /// When using AccessStrategy.RollingUnfolds, the events become unfolds, but the logic remains identical
+    let transmute events _state =
+        [],events
 
 type Command =
     | Update of Events.Value

--- a/samples/Store/Domain/Favorites.fs
+++ b/samples/Store/Domain/Favorites.fs
@@ -37,6 +37,8 @@ module Folds =
         s.AsState()
     let isOrigin = function Events.Compacted _ -> true | _ -> false
     let compact state = Events.Compacted { net = state }
+    /// This transmute impl a) removes events - we're not interested in storing the events b) packs the post-state into a Compacted unfold-event
+    let transmute _events state = [],[compact state]
 
 type Command =
     | Favorite      of date : System.DateTimeOffset * skuIds : SkuId list

--- a/samples/Store/Domain/SavedForLater.fs
+++ b/samples/Store/Domain/SavedForLater.fs
@@ -63,6 +63,8 @@ module Folds =
         Array.length newState > maxSavedItems
     let isOrigin = function Compacted _ -> true | _ -> false
     let compact state = Events.Compacted { items = state }
+    /// This transmute impl a) removes events - we're not interested in storing the events b) packs the post-state into a Compacted unfold-event
+    let transmute _events state = [],[compact state]
 
 type Command =
     | Merge of merges : Events.Item []

--- a/samples/Store/Integration/ContactPreferencesIntegration.fs
+++ b/samples/Store/Integration/ContactPreferencesIntegration.fs
@@ -24,6 +24,9 @@ let resolveStreamCosmosWithKnownEventTypeSemantics gateway =
     Cosmos.Resolver(gateway 1, codec, fold, initial, Cosmos.CachingStrategy.NoCaching, Cosmos.AccessStrategy.AnyKnownEventType).Resolve
 let resolveStreamCosmosWithoutCustomAccessStrategy gateway =
     Cosmos.Resolver(gateway defaultBatchSize, codec, fold, initial, Cosmos.CachingStrategy.NoCaching).Resolve
+let resolveStreamCosmosRollingUnfolds gateway =
+    let access = Cosmos.AccessStrategy.RollingUnfolds(Domain.ContactPreferences.Folds.isOrigin, Domain.ContactPreferences.Folds.transmute)
+    Cosmos.Resolver(gateway defaultBatchSize, codec, fold, initial, Cosmos.CachingStrategy.NoCaching, access).Resolve
 
 type Tests(testOutputHelper) =
     let testOutput = TestOutputAdapter testOutputHelper
@@ -69,5 +72,11 @@ type Tests(testOutputHelper) =
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let ``Can roundtrip against Cosmos, correctly folding the events with compaction semantics`` args = Async.RunSynchronously <| async {
         let! service = arrange connectToSpecifiedCosmosOrSimulator createCosmosContext resolveStreamCosmosWithKnownEventTypeSemantics
+        do! act service args
+    }
+    
+    [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
+    let ``Can roundtrip against Cosmos, correctly folding the events with RollingUnfold semantics`` args = Async.RunSynchronously <| async {
+        let! service = arrange connectToSpecifiedCosmosOrSimulator createCosmosContext resolveStreamCosmosRollingUnfolds
         do! act service args
     }

--- a/tests/Equinox.Cosmos.Integration/CosmosCoreIntegration.fs
+++ b/tests/Equinox.Cosmos.Integration/CosmosCoreIntegration.fs
@@ -67,7 +67,7 @@ type Tests(testOutputHelper) =
 
         let index = 0L
         let! res = Events.append ctx streamName index (TestEvents.Create(0,0)) |> Async.Catch
-        test <@ match res with Choice2Of2 ((:? ArgumentException) as ex) -> ex.Message.StartsWith "Cannot write empty events batch." | x -> failwithf "%A" x @>
+        test <@ match res with Choice2Of2 ((:? InvalidOperationException) as ex) -> ex.Message.StartsWith "Must write either events or unfolds." | x -> failwithf "%A" x @>
     }
 
     let blobEquals (x: byte[]) (y: byte[]) = System.Linq.Enumerable.SequenceEqual(x,y)

--- a/tests/Equinox.Cosmos.Integration/CosmosIntegration.fs
+++ b/tests/Equinox.Cosmos.Integration/CosmosIntegration.fs
@@ -115,7 +115,7 @@ type Tests(testOutputHelper) =
     }
 
     [<AutoData(MaxTest = 2, SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
-    let ``Can roundtrip against Cosmos, managing sync conflicts by retrying`` ctx initialState = Async.RunSynchronously <| async {
+    let ``Can roundtrip against Cosmos, managing sync conflicts by retrying`` withOptimizations ctx initialState = Async.RunSynchronously <| async {
         let log1, capture1 = log, capture
         capture1.Clear()
         let! conn = connectToSpecifiedCosmosOrSimulator log1
@@ -126,7 +126,9 @@ type Tests(testOutputHelper) =
         let cartId = % Guid.NewGuid()
 
         // establish base stream state
-        let service1 = Cart.createServiceWithEmptyUnfolds conn batchSize log1
+        let service1 =
+            if withOptimizations then Cart.createServiceWithSnapshotStrategy conn batchSize log1
+            else Cart.createServiceWithSnapshotStrategy conn batchSize log1
         let! maybeInitialSku =
             let (streamEmpty, skuId) = initialState
             async {
@@ -160,7 +162,7 @@ type Tests(testOutputHelper) =
             do! s4 }
         let log2, capture2 = TestsWithLogCapture.CreateLoggerWithCapture testOutputHelper
         use _flush = log2
-        let service2 = Cart.createServiceWithEmptyUnfolds conn batchSize log2
+        let service2 = Cart.createServiceWithSnapshotStrategy conn batchSize log2
         let t2 = async {
             // Signal we have state, wait for other to do same, engineer conflict
             let prepare = async {
@@ -185,7 +187,7 @@ type Tests(testOutputHelper) =
         test <@ maybeInitialSku |> Option.forall (fun (skuId, quantity) -> has skuId quantity)
                 && has sku11 11 && has sku12 12
                 && has sku21 21 && has sku22 22 @>
-        // Intended conflicts arose
+       // Intended conflicts pertained
         let conflict = function EqxAct.Conflict | EqxAct.Resync as x -> Some x | _ -> None
 #if EVENTS_IN_TIP
         test <@ let c2 = List.choose conflict capture2.ExternalCalls
@@ -330,7 +332,7 @@ type Tests(testOutputHelper) =
 #endif
     }
 
-    [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
+     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let ``Can roundtrip against Cosmos, using Snapshotting to avoid queries`` context skuId = Async.RunSynchronously <| async {
         let! conn = connectToSpecifiedCosmosOrSimulator log
         let batchSize = 10


### PR DESCRIPTION
TL;DR magic mode that keeps a rolling state in a single document with the same power and surface API as the normal event-sourced model
See #146 for motivation
- [x] Main code/API surface
- [x] JS (code complete but not run)
- [x] tests
- [x] tidy JS and/or refactor interface of SP