### PR TITLE
Expose aggregate Version on Equinox.Stream.QueryEx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `Equinox.Stream.QueryEx`: exposes the stream's version in order to support versioned summary projections [#152](https://github.com/jet/equinox/pull/152)
+
 ### Changed
 ### Removed
 ### Fixed

--- a/samples/Tutorial/Cosmos.fsx
+++ b/samples/Tutorial/Cosmos.fsx
@@ -1,6 +1,8 @@
 ﻿// Compile Tutorial.fsproj by either a) right-clicking or b) typing
 // dotnet build samples/Tutorial before attempting to send this to FSI with Alt-Enter
+#if VISUALSTUDIO
 #r "netstandard"
+#endif
 #I "bin/Debug/netstandard2.0/"
 #r "Serilog.dll"
 #r "Serilog.Sinks.Console.dll"

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -110,7 +110,7 @@ module Log =
                     name, count, (if count = 0L then Double.NaN else float lat/float count))
             let mutable rows, totalCount, totalMs = 0, 0L, 0L
             for name, stat in stats do
-                if stat.count <> 0L then    
+                if stat.count <> 0L then
                     totalCount <- totalCount + stat.count
                     totalMs <- totalMs + stat.ms
                     logActivity name stat.count stat.ms
@@ -287,9 +287,10 @@ type Token = { stream: Stream; pos: Position }
 
 module Token =
     let private create compactionEventNumber batchCapacityLimit streamName streamVersion : Store.StreamToken =
-        { value = box {
-            stream = { name = streamName}
-            pos = { streamVersion = streamVersion; compactionEventNumber = compactionEventNumber; batchCapacityLimit = batchCapacityLimit } } }
+        {   value = box {
+                stream = { name = streamName}
+                pos = { streamVersion = streamVersion; compactionEventNumber = compactionEventNumber; batchCapacityLimit = batchCapacityLimit } }
+            version = streamVersion }
     /// No batching / compaction; we only need to retain the StreamVersion
     let ofNonCompacting streamName streamVersion : Store.StreamToken =
         create None None streamName streamVersion

--- a/src/Equinox.MemoryStore/MemoryStore.fs
+++ b/src/Equinox.MemoryStore/MemoryStore.fs
@@ -62,7 +62,8 @@ type Token = { streamVersion: int; streamName: string }
 /// Internal implementation detail of MemoryStreamStore
 module private Token =
     let private streamTokenOfIndex streamName (streamVersion : int) : Store.StreamToken =
-        { value = box { streamName = streamName; streamVersion = streamVersion; } }
+        {   value = box { streamName = streamName; streamVersion = streamVersion }
+            version = int64 streamVersion }
     let (|Unpack|) (token: Store.StreamToken) : Token = unbox<Token> token.value
     /// Represent a stream known to be empty
     let ofEmpty streamName initial = streamTokenOfIndex streamName -1, initial

--- a/src/Equinox/Flow.fs
+++ b/src/Equinox/Flow.fs
@@ -12,6 +12,7 @@ type SyncState<'event, 'state>
 
     member __.Memento = tokenAndState
     member __.State = snd __.Memento
+    member __.Version = (fst __.Memento).version
 
     member __.TryOr(log, events, handleFailureResync : (Async<StreamToken*'state> -> Async<bool>)) : Async<bool> = async {
         let! res = trySync log tokenAndState events

--- a/src/Equinox/Interfaces.fs
+++ b/src/Equinox/Interfaces.fs
@@ -7,7 +7,7 @@ open System
 
 /// Store-specific opaque token to be used for synchronization purposes
 [<NoComparison>]
-type StreamToken = { value : obj }
+type StreamToken = { value : obj; version: int64 }
 
 /// Internal type used to represent the outcome of a TrySync operation
 [<NoEquality; NoComparison; RequireQualifiedAccess>]

--- a/src/Equinox/Stream.fs
+++ b/src/Equinox/Stream.fs
@@ -27,10 +27,10 @@ type Stream<'event, 'state>
     /// Tries up to `maxAttempts` times in the case of a conflict, throwing MaxResyncsExhaustedException` to signal failure.
     member __.TransactAsync(decide : 'state -> Async<'result*'event list>) : Async<'result> = transact decide
 
-    /// Project from the folded `Version` and `State` without executing a decision flow as `Decide` does
-    member __.QueryEx(projection : int64 -> 'state -> 'view) : Async<'view> = Flow.query(stream, log, fun syncState -> projection syncState.Version syncState.State)
     /// Project from the folded `State` without executing a decision flow as `Decide` does
     member __.Query(projection : 'state -> 'view) : Async<'view> = Flow.query(stream, log, fun syncState -> projection syncState.State)
+    /// Project from the folded `State` (with the current version of the stream supplied for context) without executing a decision flow as `Decide` does
+    member __.QueryEx(projection : int64 -> 'state -> 'view) : Async<'view> = Flow.query(stream, log, fun syncState -> projection syncState.Version syncState.State)
 
     /// Low-level helper to allow one to obtain a reference to a stream and state pair (including the position) in order to pass it as a continuation within the application
     /// Such a memento is then held within the application and passed in lieue of a StreamId to the StreamResolver in order to avoid having to reload state

--- a/src/Equinox/Stream.fs
+++ b/src/Equinox/Stream.fs
@@ -27,6 +27,8 @@ type Stream<'event, 'state>
     /// Tries up to `maxAttempts` times in the case of a conflict, throwing MaxResyncsExhaustedException` to signal failure.
     member __.TransactAsync(decide : 'state -> Async<'result*'event list>) : Async<'result> = transact decide
 
+    /// Project from the folded `Version` and `State` without executing a decision flow as `Decide` does
+    member __.QueryEx(projection : int64 -> 'state -> 'view) : Async<'view> = Flow.query(stream, log, fun syncState -> projection syncState.Version syncState.State)
     /// Project from the folded `State` without executing a decision flow as `Decide` does
     member __.Query(projection : 'state -> 'view) : Async<'view> = Flow.query(stream, log, fun syncState -> projection syncState.State)
 


### PR DESCRIPTION
When producing summaries, one often performs a `Query` but need to know the Version in question. While this can be inferred from the underlying events, factors like:
- `Equinox.Cosmos.RollingState` (which has snapshots that get revised, which means event level `Index` value is not meaningful)
- each store has its own way of representing versions etc
complicate matters.

This PR exposes a `Version` alongside the state solely for the `QueryEx` method in order to meet a need of the Summary Projection template (having the change feed triggering the app emitting a summary - knowing the version one read allows one to skip projections based on an older state in the projector)