### PR TITLE
Add all-in-one Cosmos.Context ctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - `Equinox.Stream.QueryEx`: exposes the stream's version in order to support versioned summary projections [#152](https://github.com/jet/equinox/pull/152)
+- `Equinox.Cosmos.Context` : added overload requiring only (Connection, databaseId, containerId), enabling `Gateway` and `BatchingPolicy` concepts to be skipped over in single-Aggregate microservices where they are less relevant [#153](https://github.com/jet/equinox/pull/153) @jakzale
 
 ### Changed
 ### Removed

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -966,6 +966,8 @@ type Context(gateway: Gateway, containers: Containers, [<O; D(null)>] ?log) =
     let init = gateway.CreateSyncStoredProcIfNotExists log
     new(gateway: Gateway, databaseId: string, containerId: string, [<O; D(null)>]?log) =
         Context(gateway, Containers(databaseId, containerId), ?log = log)
+    new(connection: Connection, databaseId: string, containerId: string, [<O; D(null)>]?log) =
+        Context(Gateway(connection, BatchingPolicy()), databaseId, containerId, ?log = log)
 
     member __.Gateway = gateway
     member __.Containers = containers


### PR DESCRIPTION
@jakzale always said it should be like this; It's hard to disagree when a given micro service only touches a single aggregate and a `BatchingPolicy` is far from one's list of concerns.

Example: `return Context(connection, x.Database, x.Container)`