### PR TITLE
Update to FsCodec 1.0.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- EventStore: expose `Index` when decoding events via `IIndexedEvent` [#157](https://github.com/jet/equinox/pull/157)
+
 ### Changed
+
+- Updated to `FsCodec 1.0.0-rc2` to enable `TryDecode` to see `IIndexedEvent` without casting [#157](https://github.com/jet/equinox/pull/157)
+
 ### Removed
 ### Fixed
 

--- a/samples/Store/Domain/Domain.fsproj
+++ b/samples/Store/Domain/Domain.fsproj
@@ -21,7 +21,7 @@
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
 
-    <PackageReference Include="FsCodec.NewtonsoftJson" Version="1.0.0-rc1" />
+    <PackageReference Include="FsCodec.NewtonsoftJson" Version="1.0.0-rc2" />
     <PackageReference Include="FSharp.UMX" Version="1.0.0" />
   </ItemGroup>
 

--- a/samples/Store/Integration/CodecIntegration.fs
+++ b/samples/Store/Integration/CodecIntegration.fs
@@ -44,5 +44,6 @@ let codec = FsCodec.NewtonsoftJson.Codec.Create()
 let ``Can roundtrip, rendering correctly`` (x: SimpleDu) =
     let serialized = codec.Encode x
     render x =! if serialized.Data = null then null else System.Text.Encoding.UTF8.GetString(serialized.Data)
-    let deserialized = codec.TryDecode serialized |> Option.get
+    let adapted = FsCodec.Core.IndexedEventData(-1L,false,serialized.EventType,serialized.Data,serialized.Meta,serialized.Timestamp)
+    let deserialized = codec.TryDecode adapted |> Option.get
     deserialized =! x

--- a/src/Equinox.Cosmos/Equinox.Cosmos.fsproj
+++ b/src/Equinox.Cosmos/Equinox.Cosmos.fsproj
@@ -26,7 +26,7 @@
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' != 'netstandard2.0' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
 
-    <PackageReference Include="FsCodec.NewtonsoftJson" Version="1.0.0-rc1" />
+    <PackageReference Include="FsCodec.NewtonsoftJson" Version="1.0.0-rc2" />
     <PackageReference Include="FSharp.Control.AsyncSeq" Version="2.0.21" />
     <PackageReference Include="Microsoft.Azure.DocumentDB" Version="2.0.0" Condition=" '$(TargetFramework)' != 'netstandard2.0' " />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.0.0" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />

--- a/src/Equinox.EventStore/Equinox.EventStore.fsproj
+++ b/src/Equinox.EventStore/Equinox.EventStore.fsproj
@@ -27,7 +27,7 @@
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
 
     <PackageReference Include="EventStore.Client" Version="5.0.1" />
-    <PackageReference Include="FsCodec" Version="1.0.0-rc1" />
+    <PackageReference Include="FsCodec" Version="1.0.0-rc2" />
     <PackageReference Include="FSharp.Control.AsyncSeq" Version="2.0.21" />
     <PackageReference Include="System.Runtime.Caching" Version="4.5.0" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
     <Reference Include="System.Runtime.Caching" Condition=" '$(TargetFramework)' != 'netstandard2.0'" />

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -269,10 +269,11 @@ module private Read =
         return version, events }
 
 module UnionEncoderAdapters =
-    let encodedEventOfResolvedEvent (x : ResolvedEvent) : FsCodec.IEvent<byte[]> =
+    let encodedEventOfResolvedEvent (x : ResolvedEvent) : FsCodec.IIndexedEvent<byte[]> =
+        let e = x.Event
         // Inspecting server code shows both Created and CreatedEpoch are set; taking this as it's less ambiguous than DateTime in the general case
-        let ts = DateTimeOffset.FromUnixTimeMilliseconds(x.Event.CreatedEpoch)
-        FsCodec.Core.EventData.Create(x.Event.EventType, x.Event.Data, x.Event.Metadata, ts) :> _
+        let ts = DateTimeOffset.FromUnixTimeMilliseconds(e.CreatedEpoch)
+        FsCodec.Core.IndexedEventData(e.EventNumber, (*isUnfold*)false, e.EventType, e.Data, e.Metadata, ts) :> _
     let eventDataOfEncodedEvent (x : FsCodec.IEvent<byte[]>) =
         EventData(Guid.NewGuid(), x.EventType, (*isJson*) true, x.Data, x.Meta)
 

--- a/tests/Equinox.Cosmos.Integration/JsonConverterTests.fs
+++ b/tests/Equinox.Cosmos.Integration/JsonConverterTests.fs
@@ -46,6 +46,6 @@ type Base64ZipUtf8Tests() =
         let ser = JsonConvert.SerializeObject(e)
         test <@ ser.Contains("\"d\":\"") @>
         let des = JsonConvert.DeserializeObject<Store.Unfold>(ser)
-        let d = FsCodec.Core.EventData.Create(des.c, des.d)
+        let d = FsCodec.Core.IndexedEventData(-1L, false, des.c, des.d, null, DateTimeOffset.UtcNow)
         let decoded = unionEncoder.TryDecode d |> Option.get
         test <@ value = decoded @>

--- a/tests/Equinox.EventStore.Integration/Equinox.EventStore.Integration.fsproj
+++ b/tests/Equinox.EventStore.Integration/Equinox.EventStore.Integration.fsproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="FsCheck.xUnit" Version="2.13.0" />
-    <PackageReference Include="FsCodec.NewtonsoftJson" Version="1.0.0-rc1" />
+    <PackageReference Include="FsCodec.NewtonsoftJson" Version="1.0.0-rc2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
     <Reference Include="System.Runtime.Caching" Condition=" '$(TargetFramework)' != 'netstandard2.0'" />


### PR DESCRIPTION
- [x] Support IIndexedEvent for Equinox.EventStore
- [x] Rebase on FsCodec 1.0.0-rc2 to simplify code (and enable direct access to `Index` in upconverters)