### PR TITLE
Accumulator tidying followup to #97

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - Updated `FsCodec` to `1.0.0-pr.20.rc2.5` to pick up final name changes [#162](https://github.com/jet/equinox/pull/162)
 - Replaced `TargetId.AggregateIdEmpty` with `ResolveOption.AssumeEmpty` [#163](https://github.com/jet/equinox/pull/163)
 - Extracted `Equinox.Core` module [#164](https://github.com/jet/equinox/pull/164)
+- Used `Transact` name consistently in `Accummulator` (follow-up to [#97](https://github.com/jet/equinox/pull/97)) [#166](https://github.com/jet/equinox/pull/166)
 
 ### Removed
 ### Fixed

--- a/samples/Store/Backend/Cart.fs
+++ b/samples/Store/Backend/Cart.fs
@@ -11,7 +11,7 @@ type Service(log, resolveStream) =
         stream.TransactAsync(fun state -> async {
             match prepare with None -> () | Some prep -> do! prep
             let ctx = Equinox.Accumulator(Folds.fold,state)
-            let execute = Commands.interpret >> ctx.Execute
+            let execute = Commands.interpret >> ctx.Transact
             let res = flow ctx execute
             return res,ctx.Accumulated })
     let read (Stream stream) : Async<Folds.State> =

--- a/samples/TodoBackend/Todo.fs
+++ b/samples/TodoBackend/Todo.fs
@@ -54,7 +54,7 @@ type Service(log, resolveStream, ?maxAttempts) =
     let handle (Stream stream) command =
         stream.Transact(fun state ->
             let ctx = Equinox.Accumulator(Folds.fold, state)
-            ctx.Execute (Commands.interpret command)
+            ctx.Transact (Commands.interpret command)
             ctx.State.items,ctx.Accumulated)
 
     member __.List(clientId) : Async<Todo seq> =

--- a/samples/Tutorial/Todo.fsx
+++ b/samples/Tutorial/Todo.fsx
@@ -65,7 +65,7 @@ type Service(log, resolveStream, ?maxAttempts) =
     let handle (Stream stream) command : Async<Todo list> =
         stream.Transact(fun state ->
             let ctx = Equinox.Accumulator(fold, state)
-            ctx.Execute (interpret command)
+            ctx.Transact (interpret command)
             ctx.State.items,ctx.Accumulated)
     let query (Stream stream) (projection : State -> 't) : Async<'t> =
         stream.Query projection

--- a/src/Equinox/Accumulator.fs
+++ b/src/Equinox/Accumulator.fs
@@ -1,6 +1,6 @@
 ﻿namespace Equinox
 
-/// Maintains a rolling folded State while Accumulating Events decided upon as part of a decision flow
+/// Maintains a rolling folded State while Accumulating Events pended as part of a decision flow
 type Accumulator<'event, 'state>(fold : 'state -> 'event seq -> 'state, originState : 'state) =
     let accumulated = ResizeArray<'event>()
 
@@ -13,19 +13,19 @@ type Accumulator<'event, 'state>(fold : 'state -> 'event seq -> 'state, originSt
         accumulated |> fold originState
 
     /// Invoke a decision function, gathering the events (if any) that it decides are necessary into the `Accumulated` sequence
-    member __.Execute(decide : 'state -> 'event list) : unit =
-        decide __.State |> accumulated.AddRange
+    member __.Transact(interpret : 'state -> 'event list) : unit =
+        interpret __.State |> accumulated.AddRange
     /// Invoke an Async decision function, gathering the events (if any) that it decides are necessary into the `Accumulated` sequence
-    member __.ExecuteAsync(decide : 'state -> Async<'event list>) : Async<unit> = async {
-        let! events = decide __.State
+    member __.TransactAsync(interpret : 'state -> Async<'event list>) : Async<unit> = async {
+        let! events = interpret __.State
         accumulated.AddRange events }
-    /// As per `Execute`, invoke a decision function, while also propagating a result yielded as the fst of an (result, events) pair
-    member __.Decide(decide : 'state -> 'result * 'event list) : 'result =
+    /// Invoke a decision function, while also propagating a result yielded as the fst of an (result, events) pair
+    member __.Transact(decide : 'state -> 'result * 'event list) : 'result =
         let result, newEvents = decide __.State
         accumulated.AddRange newEvents
         result
-    /// As per `ExecuteAsync`, invoke a decision function, while also propagating a result yielded as the fst of an (result, events) pair
-    member __.DecideAsync(decide : 'state -> Async<'result * 'event list>) : Async<'result> = async {
+    /// Invoke a decision function, while also propagating a result yielded as the fst of an (result, events) pair
+    member __.TransactAsync(decide : 'state -> Async<'result * 'event list>) : Async<'result> = async {
         let! result, newEvents = decide __.State
         accumulated.AddRange newEvents
         return result }


### PR DESCRIPTION
While the Decide vs Execute distinction was once part of a naming scheme, Accumulator was the only remaining usage thereof. The `interpret` vs `decide` naming of the parameter is intended to provide an equivalent cue