### PR TITLE
Add Cosmos.Connector.CreateClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `Cosmos`: Exposed a `Connector.CreateClient` for interop with V2 ChangeFeedProcessor and `Propulsion.Cosmos` [#171](https://github.com/jet/equinox/pull/171) 
+
 ### Changed
+
+- `Cosmos`: renamed `Connector`'s `maxRetryAttemptsOnThrottledRequests` and `maxRetryWaitTimeInSeconds` to maxRetryAttemptsOnRateLimitedRequests` and `maxRetryWaitTimeOnRateLimitedRequests` and changed latter to `TimeSpan` to match V3 SDK [#171](https://github.com/jet/equinox/pull/171) 
+
 ### Removed
 ### Fixed
 

--- a/samples/Infrastructure/Storage.fs
+++ b/samples/Infrastructure/Storage.fs
@@ -36,7 +36,7 @@ module Cosmos =
         | [<AltCommandLine "-m">]       ConnectionMode of Equinox.Cosmos.ConnectionMode
         | [<AltCommandLine "-o">]       Timeout of float
         | [<AltCommandLine "-r">]       Retries of int
-        | [<AltCommandLine "-rt">]      RetriesWaitTime of int
+        | [<AltCommandLine "-rt">]      RetriesWaitTimeS of float
         | [<AltCommandLine "-s">]       Connection of string
         | [<AltCommandLine "-d">]       Database of string
         | [<AltCommandLine "-c">]       Container of string
@@ -46,7 +46,7 @@ module Cosmos =
                 | VerboseStore ->       "Include low level Store logging."
                 | Timeout _ ->          "specify operation timeout in seconds (default: 5)."
                 | Retries _ ->          "specify operation retries (default: 1)."
-                | RetriesWaitTime _ ->  "specify max wait-time for retry when being throttled by Cosmos in seconds (default: 5)"
+                | RetriesWaitTimeS _ -> "specify max wait-time for retry when being throttled by Cosmos in seconds (default: 5)"
                 | ConnectionMode _ ->   "override the connection mode. Default: Direct."
                 | Connection _ ->       "specify a connection string for a Cosmos account. (optional if environment variable EQUINOX_COSMOS_CONNECTION specified)"
                 | Database _ ->         "specify a database name for store. (optional if environment variable EQUINOX_COSMOS_DATABASE specified)"
@@ -59,7 +59,7 @@ module Cosmos =
 
         member __.Timeout =             args.GetResult(Timeout,5.) |> TimeSpan.FromSeconds
         member __.Retries =             args.GetResult(Retries,1)
-        member __.MaxRetryWaitTime =    args.GetResult(RetriesWaitTime, 5)
+        member __.MaxRetryWaitTime =    args.GetResult(RetriesWaitTimeS, 5.) |> TimeSpan.FromSeconds
 
     /// Standing up an Equinox instance is necessary to run for test purposes; You'll need to either:
     /// 1) replace connection below with a connection string or Uri+Key for an initialized Equinox instance with a database and collection named "equinox-test"
@@ -74,7 +74,7 @@ module Cosmos =
         log.Information("CosmosDb {mode} {connection} Database {database} Container {container}",
             a.Mode, endpointUri, a.Database, a.Container)
         log.Information("CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
-            (let t = a.Timeout in t.TotalSeconds), a.Retries, a.MaxRetryWaitTime)
+            (let t = a.Timeout in t.TotalSeconds), a.Retries, let x = a.MaxRetryWaitTime in x.TotalSeconds)
         discovery, a.Database, a.Container, Connector(a.Timeout, a.Retries, a.MaxRetryWaitTime, log=storeLog, mode=a.Mode)
     let config (log: ILogger, storeLog) (cache, unfolds, batchSize) info =
         let discovery, dName, cName, connector = connection (log, storeLog) info

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -1075,7 +1075,8 @@ type Connector
         /// Maximum number of times attempt when failure reason is a 429 from CosmosDb, signifying RU limits have been breached
         maxRetryAttemptsOnRateLimitedRequests: int,
         /// Maximum number of seconds to wait (especially if a higher wait delay is suggested by CosmosDb in the 429 response)
-        maxRetryWaitTimeOnRateLimitedRequestsSeconds: int,
+        // naming matches SDK ver >=3
+        maxRetryWaitTimeOnRateLimitedRequests: TimeSpan,
         /// Log to emit connection messages to
         log : ILogger,
         /// Connection limit for Gateway Mode (default 1000)
@@ -1113,7 +1114,7 @@ type Connector
         co.RetryOptions <-
             Client.RetryOptions(
                 MaxRetryAttemptsOnThrottledRequests = maxRetryAttemptsOnRateLimitedRequests,
-                MaxRetryWaitTimeInSeconds = maxRetryWaitTimeOnRateLimitedRequestsSeconds)
+                MaxRetryWaitTimeInSeconds = (Math.Ceiling(maxRetryWaitTimeOnRateLimitedRequests.TotalSeconds) |> int))
         co.RequestTimeout <- requestTimeout
         co.MaxConnectionLimit <- defaultArg gatewayModeMaxConnectionLimit 1000
         co

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -1073,9 +1073,9 @@ type Connector
     (   /// Timeout to apply to individual reads/write round-trips going to CosmosDb
         requestTimeout: TimeSpan,
         /// Maximum number of times attempt when failure reason is a 429 from CosmosDb, signifying RU limits have been breached
-        maxRetryAttemptsOnThrottledRequests: int,
+        maxRetryAttemptsOnRateLimitedRequests: int,
         /// Maximum number of seconds to wait (especially if a higher wait delay is suggested by CosmosDb in the 429 response)
-        maxRetryWaitTimeInSeconds: int,
+        maxRetryWaitTimeOnRateLimitedRequestsSeconds: int,
         /// Log to emit connection messages to
         log : ILogger,
         /// Connection limit for Gateway Mode (default 1000)
@@ -1112,8 +1112,8 @@ type Connector
         | Some ConnectionMode.Direct -> co.ConnectionMode <- Client.ConnectionMode.Direct; co.ConnectionProtocol <- Client.Protocol.Tcp
         co.RetryOptions <-
             Client.RetryOptions(
-                MaxRetryAttemptsOnThrottledRequests = maxRetryAttemptsOnThrottledRequests,
-                MaxRetryWaitTimeInSeconds = maxRetryWaitTimeInSeconds)
+                MaxRetryAttemptsOnThrottledRequests = maxRetryAttemptsOnRateLimitedRequests,
+                MaxRetryWaitTimeInSeconds = maxRetryWaitTimeOnRateLimitedRequestsSeconds)
         co.RequestTimeout <- requestTimeout
         co.MaxConnectionLimit <- defaultArg gatewayModeMaxConnectionLimit 1000
         co

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -1129,7 +1129,7 @@ type Connector
         (   /// Name should be sufficient to uniquely identify this connection within a single app instance's logs
             name, discovery : Discovery,
             /// <c>true</c> to inhibit logging of client name
-            ?skipLog) : Client.DocumentClient =
+            [<O; D null>]?skipLog) : Client.DocumentClient =
         mkClient name (defaultArg skipLog false) discovery
 
     /// Yields a Connection configured per the specified strategy
@@ -1137,9 +1137,9 @@ type Connector
         (   /// Name should be sufficient to uniquely identify this connection within a single app instance's logs
             name, discovery : Discovery,
             /// <c>true</c> to inhibit OpenAsync call
-            ?skipOpen,
+            [<O; D null>]?skipOpen,
             /// <c>true</c> to inhibit logging of client name
-            ?skipLog) : Async<Connection> = async {
+            [<O; D null>]?skipLog) : Async<Connection> = async {
         let client = __.CreateClient(name, discovery, ?skipLog=skipLog)
         if skipOpen <> Some true then do! client.OpenAsync() |> Async.AwaitTaskCorrect
         return Connection(client, ?readRetryPolicy=readRetryPolicy, ?writeRetryPolicy=writeRetryPolicy) }

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -1109,7 +1109,6 @@ type Connector
         co.RequestTimeout <- requestTimeout
         co.MaxConnectionLimit <- defaultArg gatewayModeMaxConnectionLimit 1000
         co
-
     let logName (uri : Uri) name =
         let name = String.concat ";" <| seq {
             yield name
@@ -1124,9 +1123,6 @@ type Connector
                 let inhibitCertCheck = new System.Net.Http.HttpClientHandler(ServerCertificateCustomValidationCallback = fun _ _ _ _ -> true)
                 new Client.DocumentClient(uri, key, inhibitCertCheck, clientOptions, consistencyLevel) // overload introduced in 2.2.0 SDK
             else new Client.DocumentClient(uri, key, clientOptions, consistencyLevel)
-
-    /// ClientOptions (ConnectionPolicy with v2 SDK) for this Connector as configured
-    member __.ClientOptions : Client.ConnectionPolicy = clientOptions
 
     /// Yields a DocumentClient configured per the specified strategy
     member __.CreateClient

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -1140,7 +1140,7 @@ type Connector
             ?skipOpen,
             /// <c>true</c> to inhibit logging of client name
             ?skipLog) : Async<Connection> = async {
-        let client = mkClient name (defaultArg skipLog false) discovery
+        let client = __.CreateClient(name, discovery, ?skipLog=skipLog)
         if skipOpen <> Some true then do! client.OpenAsync() |> Async.AwaitTaskCorrect
         return Connection(client, ?readRetryPolicy=readRetryPolicy, ?writeRetryPolicy=writeRetryPolicy) }
 

--- a/tests/Equinox.Cosmos.Integration/CosmosFixtures.fs
+++ b/tests/Equinox.Cosmos.Integration/CosmosFixtures.fs
@@ -11,7 +11,7 @@ module Option =
 /// - replace connection below with a connection string or Uri+Key for an initialized Equinox instance
 /// - Create a local Equinox via dotnet run cli/Equinox.cli -s $env:EQUINOX_COSMOS_CONNECTION -d test -c $env:EQUINOX_COSMOS_CONTAINER provision -ru 10000
 let private connectToCosmos (log: Serilog.ILogger) name discovery =
-    Connector(log=log, requestTimeout=TimeSpan.FromSeconds 3., maxRetryAttemptsOnThrottledRequests=2, maxRetryWaitTimeInSeconds=60)
+    Connector(log=log, requestTimeout=TimeSpan.FromSeconds 3., maxRetryAttemptsOnRateLimitedRequests=2, maxRetryWaitTimeOnRateLimitedRequestsSeconds=60)
        .Connect(name, discovery)
 let private read env = Environment.GetEnvironmentVariable env |> Option.ofObj
 let (|Default|) def name = (read name),def ||> defaultArg

--- a/tests/Equinox.Cosmos.Integration/CosmosFixtures.fs
+++ b/tests/Equinox.Cosmos.Integration/CosmosFixtures.fs
@@ -11,7 +11,7 @@ module Option =
 /// - replace connection below with a connection string or Uri+Key for an initialized Equinox instance
 /// - Create a local Equinox via dotnet run cli/Equinox.cli -s $env:EQUINOX_COSMOS_CONNECTION -d test -c $env:EQUINOX_COSMOS_CONTAINER provision -ru 10000
 let private connectToCosmos (log: Serilog.ILogger) name discovery =
-    Connector(log=log, requestTimeout=TimeSpan.FromSeconds 3., maxRetryAttemptsOnRateLimitedRequests=2, maxRetryWaitTimeOnRateLimitedRequestsSeconds=60)
+    Connector(log=log, requestTimeout=TimeSpan.FromSeconds 3., maxRetryAttemptsOnRateLimitedRequests=2, maxRetryWaitTimeOnRateLimitedRequests=TimeSpan.FromMinutes 1.)
        .Connect(name, discovery)
 let private read env = Environment.GetEnvironmentVariable env |> Option.ofObj
 let (|Default|) def name = (read name),def ||> defaultArg


### PR DESCRIPTION
Addendum to #170, exposing a `CreateClient` which exposes the `DocumentClient`
Intended for use with https://github.com/jet/propulsion/pull/40
@Kelvin4702 