### PR TITLE
Remove ResolveEx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Cosmos`: renamed `Connector`'s `maxRetryAttemptsOnThrottledRequests` and `maxRetryWaitTimeInSeconds` to maxRetryAttemptsOnRateLimitedRequests` and `maxRetryWaitTimeOnRateLimitedRequests` and changed latter to `TimeSpan` to match V3 SDK [#171](https://github.com/jet/equinox/pull/171) 
 
 ### Removed
+
+- `Resolver.ResolveEx` [#172](https://github.com/jet/equinox/pull/172)
+
 ### Fixed
 
 <a name="2.0.0"></a>

--- a/samples/Store/Integration/CartIntegration.fs
+++ b/samples/Store/Integration/CartIntegration.fs
@@ -14,19 +14,19 @@ let snapshot = Domain.Cart.Folds.isOrigin, Domain.Cart.Folds.compact
 let createMemoryStore () =
     new VolatileStore ()
 let createServiceMemory log store =
-    Backend.Cart.Service(log, Resolver(store, fold, initial).ResolveEx)
+    Backend.Cart.Service(log, fun (id,opt) -> Resolver(store, fold, initial).Resolve(id,?option=opt))
 
 let codec = Domain.Cart.Events.codec
 
 let resolveGesStreamWithRollingSnapshots gateway =
-    EventStore.Resolver(gateway, codec, fold, initial, access = AccessStrategy.RollingSnapshots snapshot).ResolveEx
+    fun (id,opt) -> EventStore.Resolver(gateway, codec, fold, initial, access = AccessStrategy.RollingSnapshots snapshot).Resolve(id,?option=opt)
 let resolveGesStreamWithoutCustomAccessStrategy gateway =
-    EventStore.Resolver(gateway, codec, fold, initial).ResolveEx
+    fun (id,opt) -> EventStore.Resolver(gateway, codec, fold, initial).Resolve(id,?option=opt)
 
 let resolveCosmosStreamWithSnapshotStrategy gateway =
-    Cosmos.Resolver(gateway, codec, fold, initial, Cosmos.CachingStrategy.NoCaching, Cosmos.AccessStrategy.Snapshot snapshot).ResolveEx
+    fun (id,opt) -> Cosmos.Resolver(gateway, codec, fold, initial, Cosmos.CachingStrategy.NoCaching, Cosmos.AccessStrategy.Snapshot snapshot).Resolve(id,?option=opt)
 let resolveCosmosStreamWithoutCustomAccessStrategy gateway =
-    Cosmos.Resolver(gateway, codec, fold, initial, Cosmos.CachingStrategy.NoCaching).ResolveEx
+    fun (id,opt) -> Cosmos.Resolver(gateway, codec, fold, initial, Cosmos.CachingStrategy.NoCaching).Resolve(id,?option=opt)
 
 let addAndThenRemoveItemsManyTimesExceptTheLastOne context cartId skuId (service: Backend.Cart.Service) count =
     service.FlowAsync(cartId, false, fun _ctx execute ->

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -1041,7 +1041,6 @@ type Resolver<'event, 'state, 'context>(context : Context, codec, fold, initial,
         | streamArgs,(None|Some AllowStale) -> resolveStream streamArgs option context
         | (containerStream,maybeInit),Some AssumeEmpty ->
             Stream.ofMemento (Token.create containerStream Position.fromKnownEmpty,initial) (resolveStream (containerStream,maybeInit) option context)
-    member __.ResolveEx(target, opt, ?context) = __.Resolve(target, ?option=opt, ?context=context)
 
     member __.FromMemento(Token.Unpack (container,stream,_pos) as streamToken,state) =
         let skipInitialization = None

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -535,7 +535,6 @@ type Resolver<'event, 'state, 'context>
         match resolveTarget target, option with
         | sn,(None|Some AllowStale) -> resolveStream sn option context
         | sn,Some AssumeEmpty -> Stream.ofMemento (loadEmpty sn) (resolveStream sn option context)
-    member __.ResolveEx(target, opt, ?context : 'context) = __.Resolve(target, ?option=opt, ?context=context)
 
     /// Resolve from a Memento being used in a Continuation [based on position and state typically from Stream.CreateMemento]
     member __.FromMemento(Token.Unpack token as streamToken, state, ?context) =

--- a/src/Equinox.MemoryStore/MemoryStore.fs
+++ b/src/Equinox.MemoryStore/MemoryStore.fs
@@ -103,7 +103,6 @@ type Resolver<'event, 'state, 'context>(store : VolatileStore, fold, initial) =
         match resolveTarget target, option with
         | sn,(None|Some AllowStale) -> resolveStream sn context
         | sn,Some AssumeEmpty -> Stream.ofMemento (Token.ofEmpty sn initial) (resolveStream sn context)
-    member __.ResolveEx(target,opt) = __.Resolve(target,?option=opt)
 
     /// Resolve from a Memento being used in a Continuation [based on position and state typically from Stream.CreateMemento]
     member __.FromMemento(Token.Unpack stream as streamToken, state, ?context) =

--- a/tests/Equinox.Cosmos.Integration/CosmosIntegration.fs
+++ b/tests/Equinox.Cosmos.Integration/CosmosIntegration.fs
@@ -14,28 +14,28 @@ module Cart =
     let codec = Domain.Cart.Events.codec
     let createServiceWithoutOptimization connection batchSize log =
         let store = createCosmosContext connection batchSize
-        let resolveStream = Resolver(store, codec, fold, initial, CachingStrategy.NoCaching).ResolveEx
+        let resolveStream (id,opt) = Resolver(store, codec, fold, initial, CachingStrategy.NoCaching).Resolve(id,?option=opt)
         Backend.Cart.Service(log, resolveStream)
     let projection = "Compacted",snd snapshot
     /// Trigger looking in Tip (we want those calls to occur, but without leaning on snapshots, which would reduce the paths covered)
     let createServiceWithEmptyUnfolds connection batchSize log =
         let store = createCosmosContext connection batchSize
         let unfArgs = Domain.Cart.Folds.isOrigin, fun _ -> Seq.empty
-        let resolveStream = Resolver(store, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.Unfolded unfArgs).ResolveEx
+        let resolveStream (id,opt) = Resolver(store, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.Unfolded unfArgs).Resolve(id,?option=opt)
         Backend.Cart.Service(log, resolveStream)
     let createServiceWithSnapshotStrategy connection batchSize log =
         let store = createCosmosContext connection batchSize
-        let resolveStream = Resolver(store, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.Snapshot snapshot).ResolveEx
+        let resolveStream (id,opt) = Resolver(store, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.Snapshot snapshot).Resolve(id,?option=opt)
         Backend.Cart.Service(log, resolveStream)
     let createServiceWithSnapshotStrategyAndCaching connection batchSize log cache =
         let store = createCosmosContext connection batchSize
         let sliding20m = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        let resolveStream = Resolver(store, codec, fold, initial, sliding20m, AccessStrategy.Snapshot snapshot).ResolveEx
+        let resolveStream (id,opt) = Resolver(store, codec, fold, initial, sliding20m, AccessStrategy.Snapshot snapshot).Resolve(id,?option=opt)
         Backend.Cart.Service(log, resolveStream)
     let createServiceWithRollingUnfolds connection log =
         let store = createCosmosContext connection 1
         let access = AccessStrategy.RollingUnfolds(Domain.Cart.Folds.isOrigin,Domain.Cart.Folds.transmute)
-        let resolveStream = Resolver(store, codec, fold, initial, CachingStrategy.NoCaching, access).ResolveEx
+        let resolveStream (id,opt) = Resolver(store, codec, fold, initial, CachingStrategy.NoCaching, access).Resolve(id,?option=opt)
         Backend.Cart.Service(log, resolveStream)
 
 module ContactPreferences =

--- a/tests/Equinox.EventStore.Integration/EventStoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/EventStoreIntegration.fs
@@ -31,7 +31,7 @@ module Cart =
         Backend.Cart.Service(log, resolveStream)
     let createServiceWithCaching log gateway cache =
         let sliding20m = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        Backend.Cart.Service(log, (id,opt) -> Resolver(gateway, codec, fold, initial, sliding20m).Resolve(id,?option=opt))
+        Backend.Cart.Service(log, fun (id,opt) -> Resolver(gateway, codec, fold, initial, sliding20m).Resolve(id,?option=opt))
     let createServiceWithCompactionAndCaching log gateway cache =
         let sliding20m = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
         Backend.Cart.Service(log, fun (id,opt) -> Resolver(gateway, codec, fold, initial, sliding20m, AccessStrategy.RollingSnapshots snapshot).Resolve(id,?option=opt))

--- a/tests/Equinox.EventStore.Integration/EventStoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/EventStoreIntegration.fs
@@ -25,16 +25,16 @@ module Cart =
     let codec = Domain.Cart.Events.codec
     let snapshot = Domain.Cart.Folds.isOrigin, Domain.Cart.Folds.compact
     let createServiceWithoutOptimization log gateway =
-        Backend.Cart.Service(log, Resolver(gateway, Domain.Cart.Events.codec, fold, initial).ResolveEx)
+        Backend.Cart.Service(log, fun (id,opt) -> Resolver(gateway, Domain.Cart.Events.codec, fold, initial).Resolve(id,?option=opt))
     let createServiceWithCompaction log gateway =
-        let resolveStream = Resolver(gateway, codec, fold, initial, access = AccessStrategy.RollingSnapshots snapshot).ResolveEx
+        let resolveStream (id,opt) = Resolver(gateway, codec, fold, initial, access = AccessStrategy.RollingSnapshots snapshot).Resolve(id,?option=opt)
         Backend.Cart.Service(log, resolveStream)
     let createServiceWithCaching log gateway cache =
         let sliding20m = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        Backend.Cart.Service(log, Resolver(gateway, codec, fold, initial, sliding20m).ResolveEx)
+        Backend.Cart.Service(log, (id,opt) -> Resolver(gateway, codec, fold, initial, sliding20m).Resolve(id,?option=opt))
     let createServiceWithCompactionAndCaching log gateway cache =
         let sliding20m = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        Backend.Cart.Service(log, Resolver(gateway, codec, fold, initial, sliding20m, AccessStrategy.RollingSnapshots snapshot).ResolveEx)
+        Backend.Cart.Service(log, fun (id,opt) -> Resolver(gateway, codec, fold, initial, sliding20m, AccessStrategy.RollingSnapshots snapshot).Resolve(id,?option=opt))
 
 module ContactPreferences =
     let fold, initial = Domain.ContactPreferences.Folds.fold, Domain.ContactPreferences.Folds.initial

--- a/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
+++ b/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
@@ -7,7 +7,8 @@ let createMemoryStore () =
     new VolatileStore()
 
 let createServiceMemory log store =
-    Backend.Cart.Service(log, Resolver(store, Domain.Cart.Folds.fold, Domain.Cart.Folds.initial).ResolveEx)
+    let resolveStream (id,opt) = Resolver(store, Domain.Cart.Folds.fold, Domain.Cart.Folds.initial).Resolve(id,?option=opt)
+    Backend.Cart.Service(log, resolveStream)
 
 #nowarn "1182" // From hereon in, we may have some 'unused' privates (the tests)
 


### PR DESCRIPTION
`ResolveEx` is not as useful in real world apps as it is within this repo
🤔there may be a better angle of approach too: perhaps an `IResolver` common to all stores can have standard helpers over it 