### PR TITLE
Add Codec support for MemoryStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - `Cosmos`: Exposed a `Connector.CreateClient` for interop with V2 ChangeFeedProcessor and `Propulsion.Cosmos` [#171](https://github.com/jet/equinox/pull/171) 
-- `MemoryStore`: Supports custom Codec logic; defaults to using `FsCodec.Box.Codec` [#173](https://github.com/jet/equinox/pull/173) 
+- `MemoryStore`: Supports custom Codec logic (can use `FsCodec.Box.Codec` as default) [#173](https://github.com/jet/equinox/pull/173) 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - `Cosmos`: Exposed a `Connector.CreateClient` for interop with V2 ChangeFeedProcessor and `Propulsion.Cosmos` [#171](https://github.com/jet/equinox/pull/171) 
+- `MemoryStore`: Supports custom Codec logic; defaults to using `FsCodec.Box.Codec` [#173](https://github.com/jet/equinox/pull/173) 
 
 ### Changed
 

--- a/samples/Infrastructure/Services.fs
+++ b/samples/Infrastructure/Services.fs
@@ -12,7 +12,7 @@ type StreamResolver(storage) =
             snapshot: (('event -> bool) * ('state -> 'event))) =
         match storage with
         | Storage.StorageConfig.Memory store ->
-            Equinox.MemoryStore.Resolver(store, fold, initial).Resolve
+            Equinox.MemoryStore.Resolver<_,_>(store, fold, initial).Resolve
         | Storage.StorageConfig.Es (context, caching, unfolds) ->
             let accessStrategy = if unfolds then Equinox.EventStore.AccessStrategy.RollingSnapshots snapshot |> Some else None
             Equinox.EventStore.Resolver<'event,'state,_>(context, codec, fold, initial, ?caching = caching, ?access = accessStrategy).Resolve

--- a/samples/Infrastructure/Services.fs
+++ b/samples/Infrastructure/Services.fs
@@ -12,7 +12,7 @@ type StreamResolver(storage) =
             snapshot: (('event -> bool) * ('state -> 'event))) =
         match storage with
         | Storage.StorageConfig.Memory store ->
-            Equinox.MemoryStore.Resolver<_,_>(store, fold, initial).Resolve
+            Equinox.MemoryStore.Resolver(store, codec, fold, initial).Resolve
         | Storage.StorageConfig.Es (context, caching, unfolds) ->
             let accessStrategy = if unfolds then Equinox.EventStore.AccessStrategy.RollingSnapshots snapshot |> Some else None
             Equinox.EventStore.Resolver<'event,'state,_>(context, codec, fold, initial, ?caching = caching, ?access = accessStrategy).Resolve

--- a/samples/Infrastructure/Storage.fs
+++ b/samples/Infrastructure/Storage.fs
@@ -7,7 +7,8 @@ exception MissingArg of string
 
 [<RequireQualifiedAccess; NoEquality; NoComparison>]
 type StorageConfig =
-    | Memory of Equinox.MemoryStore.VolatileStore
+    // For MemoryStore, we keep the events as UTF8 arrays - we could use FsCodec.Codec.Box to remove the JSON encoding, which would improve perf but can conceal problems
+    | Memory of Equinox.MemoryStore.VolatileStore<byte[]>
     | Es     of Equinox.EventStore.Context * Equinox.EventStore.CachingStrategy option * unfolds: bool
     | Cosmos of Equinox.Cosmos.Gateway * Equinox.Cosmos.CachingStrategy * unfolds: bool * databaseId: string * containerId: string
     

--- a/samples/Store/Integration/CartIntegration.fs
+++ b/samples/Store/Integration/CartIntegration.fs
@@ -14,7 +14,7 @@ let snapshot = Domain.Cart.Folds.isOrigin, Domain.Cart.Folds.compact
 let createMemoryStore () =
     new VolatileStore ()
 let createServiceMemory log store =
-    Backend.Cart.Service(log, fun (id,opt) -> MemoryStore.Resolver(store, fold, initial).Resolve(id,?option=opt))
+    Backend.Cart.Service(log, fun (id,opt) -> MemoryStore.Resolver<_,_>(store, fold, initial).Resolve(id,?option=opt))
 
 let codec = Domain.Cart.Events.codec
 

--- a/samples/Store/Integration/CartIntegration.fs
+++ b/samples/Store/Integration/CartIntegration.fs
@@ -12,9 +12,10 @@ let fold, initial = Domain.Cart.Folds.fold, Domain.Cart.Folds.initial
 let snapshot = Domain.Cart.Folds.isOrigin, Domain.Cart.Folds.compact
 
 let createMemoryStore () =
-    new VolatileStore ()
+    // we want to validate that the JSON UTF8 is working happily
+    new VolatileStore<byte[]>()
 let createServiceMemory log store =
-    Backend.Cart.Service(log, fun (id,opt) -> MemoryStore.Resolver<_,_>(store, fold, initial).Resolve(id,?option=opt))
+    Backend.Cart.Service(log, fun (id,opt) -> MemoryStore.Resolver(store, Domain.Cart.Events.codec, fold, initial).Resolve(id,?option=opt))
 
 let codec = Domain.Cart.Events.codec
 

--- a/samples/Store/Integration/ContactPreferencesIntegration.fs
+++ b/samples/Store/Integration/ContactPreferencesIntegration.fs
@@ -12,7 +12,7 @@ let fold, initial = Domain.ContactPreferences.Folds.fold, Domain.ContactPreferen
 let createMemoryStore () =
     new MemoryStore.VolatileStore()
 let createServiceMemory log store =
-    Backend.ContactPreferences.Service(log, MemoryStore.Resolver(store, fold, initial).Resolve)
+    Backend.ContactPreferences.Service(log, MemoryStore.Resolver<_,_>(store, fold, initial).Resolve)
 
 let codec = Domain.ContactPreferences.Events.codec
 let resolveStreamGesWithOptimizedStorageSemantics gateway =

--- a/samples/Store/Integration/ContactPreferencesIntegration.fs
+++ b/samples/Store/Integration/ContactPreferencesIntegration.fs
@@ -10,9 +10,9 @@ open Xunit
 let fold, initial = Domain.ContactPreferences.Folds.fold, Domain.ContactPreferences.Folds.initial
 
 let createMemoryStore () =
-    new MemoryStore.VolatileStore()
+    new MemoryStore.VolatileStore<_>()
 let createServiceMemory log store =
-    Backend.ContactPreferences.Service(log, MemoryStore.Resolver<_,_>(store, fold, initial).Resolve)
+    Backend.ContactPreferences.Service(log, MemoryStore.Resolver(store, FsCodec.Box.Codec.Create(), fold, initial).Resolve)
 
 let codec = Domain.ContactPreferences.Events.codec
 let resolveStreamGesWithOptimizedStorageSemantics gateway =

--- a/samples/Store/Integration/FavoritesIntegration.fs
+++ b/samples/Store/Integration/FavoritesIntegration.fs
@@ -10,9 +10,9 @@ let fold, initial = Domain.Favorites.Folds.fold, Domain.Favorites.Folds.initial
 let snapshot = Domain.Favorites.Folds.isOrigin, Domain.Favorites.Folds.compact
 
 let createMemoryStore () =
-    new MemoryStore.VolatileStore()
+    new MemoryStore.VolatileStore<_>()
 let createServiceMemory log store =
-    Backend.Favorites.Service(log, MemoryStore.Resolver<_,_>(store, fold, initial).Resolve)
+    Backend.Favorites.Service(log, MemoryStore.Resolver(store, FsCodec.Box.Codec.Create(), fold, initial).Resolve)
 
 let codec = Domain.Favorites.Events.codec
 let createServiceGes gateway log =

--- a/samples/Store/Integration/FavoritesIntegration.fs
+++ b/samples/Store/Integration/FavoritesIntegration.fs
@@ -12,7 +12,7 @@ let snapshot = Domain.Favorites.Folds.isOrigin, Domain.Favorites.Folds.compact
 let createMemoryStore () =
     new MemoryStore.VolatileStore()
 let createServiceMemory log store =
-    Backend.Favorites.Service(log, MemoryStore.Resolver(store, fold, initial).Resolve)
+    Backend.Favorites.Service(log, MemoryStore.Resolver<_,_>(store, fold, initial).Resolve)
 
 let codec = Domain.Favorites.Events.codec
 let createServiceGes gateway log =

--- a/src/Equinox.MemoryStore/Equinox.MemoryStore.fsproj
+++ b/src/Equinox.MemoryStore/Equinox.MemoryStore.fsproj
@@ -22,6 +22,9 @@
 
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
+
+<!--    only uses FsCodec.Box, which happens to be houses in the NewtonsotJson package-->
+    <PackageReference Include="FsCodec.NewtonsoftJson" Version="1.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Equinox.MemoryStore/MemoryStore.fs
+++ b/src/Equinox.MemoryStore/MemoryStore.fs
@@ -5,11 +5,10 @@ namespace Equinox.MemoryStore
 
 open Equinox
 open Equinox.Core
-open Serilog
 open System.Runtime.InteropServices
 
 /// Equivalent to GetEventStore's in purpose; signals a conflict has been detected and reprocessing of the decision will be necessary
-exception private WrongVersionException of streamName: string * expected: int * value: obj
+exception private WrongVersionException of streamName: string * expected: int * value: FsCodec.ITimelineEvent<obj>[]
 
 /// Internal result used to reflect the outcome of syncing with the entry in the inner ConcurrentDictionary
 [<NoEquality; NoComparison>]
@@ -21,48 +20,29 @@ type ConcurrentArraySyncResult<'t> = Written of 't | Conflict of 't
 
 // Maintains a dictionary of boxed typed arrays, raising exceptions if an attempt to extract a value encounters a mismatched type
 type VolatileStore() =
-    let streams = System.Collections.Concurrent.ConcurrentDictionary<string,obj>()
-    let mkBadValueException (log : ILogger) streamName (value : obj) =
-        let desc = match value with null -> "null" | v -> v.GetType().FullName
-        let ex : exn = invalidOp (sprintf "Could not read stream %s, value was a: %s" streamName desc)
-        log.Error<_,_>(ex, "Read Bad Value {StreamName} {Value}", streamName, value)
-        ex
-    let mkWrongVersionException (log : ILogger) streamName (expected : int) (value: obj) =
-        let ex : exn = WrongVersionException (streamName, expected, value)
-        log.Warning<_,_,_>(ex, "Unexpected Stored Value {StreamName} {Expected} {Value}", streamName, expected, value)
-        ex
-    member private __.Unpack<'event> log streamName (x : obj): 'event array =
-        match x with
-        | :? ('event array) as value -> value
-        | value -> raise (mkBadValueException log streamName value)
-    member private __.Pack (events : 'event seq) : obj =
-        Array.ofSeq events |> box
+    let streams = System.Collections.Concurrent.ConcurrentDictionary<string,FsCodec.ITimelineEvent<obj>[]>()
 
     /// Loads state from a given stream
-    member __.TryLoad streamName log =
-        match streams.TryGetValue streamName with
-        | false, _ -> None
-        | true, packed -> __.Unpack log streamName packed |> Some
+    member __.TryLoad streamName = match streams.TryGetValue streamName with false, _ -> None | true, packed -> Some packed
 
     /// Attempts a synchronization operation - yields conflicting value if sync function decides there is a conflict
-    member __.TrySync streamName (log : ILogger) (trySyncValue : 'events array -> ConcurrentDictionarySyncResult<'event seq>) (events: 'event seq)
-        : ConcurrentArraySyncResult<'event array> =
-        let seedStream _streamName = __.Pack events
-        let updatePackedValue streamName (packedCurrentValue : obj) =
-            let currentValue = __.Unpack log streamName packedCurrentValue
+    member __.TrySync
+        (   streamName, trySyncValue : FsCodec.ITimelineEvent<obj>[] -> ConcurrentDictionarySyncResult<FsCodec.ITimelineEvent<obj>[]>,
+            events: FsCodec.ITimelineEvent<obj>[])
+        : ConcurrentArraySyncResult<FsCodec.ITimelineEvent<obj>[]> =
+        let seedStream _streamName = events
+        let updateValue streamName (currentValue : FsCodec.ITimelineEvent<obj>[]) =
             match trySyncValue currentValue with
-            | ConcurrentDictionarySyncResult.Conflict expectedVersion -> raise (mkWrongVersionException log streamName expectedVersion packedCurrentValue)
-            | ConcurrentDictionarySyncResult.Written value -> __.Pack value
-        try
-            let boxedSyncedValue = streams.AddOrUpdate(streamName, seedStream, updatePackedValue)
-            ConcurrentArraySyncResult.Written (unbox boxedSyncedValue)
-        with WrongVersionException(_, _, conflictingValue) ->
-            ConcurrentArraySyncResult.Conflict (unbox conflictingValue)
+            | ConcurrentDictionarySyncResult.Conflict expectedVersion -> raise <| WrongVersionException (streamName, expectedVersion, currentValue)
+            | ConcurrentDictionarySyncResult.Written value -> value
+        try streams.AddOrUpdate(streamName, seedStream, updateValue) |> Written
+        with WrongVersionException(_, _, conflictingValue) -> conflictingValue |> Conflict
 
 type Token = { streamVersion: int; streamName: string }
 
 /// Internal implementation detail of MemoryStreamStore
 module private Token =
+
     let private streamTokenOfIndex streamName (streamVersion : int) : StreamToken =
         {   value = box { streamName = streamName; streamVersion = streamVersion }
             version = int64 streamVersion }
@@ -70,36 +50,41 @@ module private Token =
     /// Represent a stream known to be empty
     let ofEmpty streamName initial = streamTokenOfIndex streamName -1, initial
     let tokenOfArray streamName (value: 'event array) = Array.length value - 1 |> streamTokenOfIndex streamName
+    let tokenOfSeq streamName (value: 'event seq) = Seq.length value - 1 |> streamTokenOfIndex streamName
     /// Represent a known array of events (without a known folded State)
     let ofEventArray streamName fold initial (events: 'event array) = tokenOfArray streamName events, fold initial (Seq.ofArray events)
     /// Represent a known array of Events together with the associated state
-    let ofEventArrayAndKnownState streamName fold (state: 'state) (events: 'event array) = tokenOfArray streamName events, fold state events
+    let ofEventArrayAndKnownState streamName fold (state: 'state) (events: 'event seq) = tokenOfSeq streamName events, fold state events
 
 /// Represents the state of a set of streams in a style consistent withe the concrete Store types - no constraints on memory consumption (but also no persistence!).
-type Category<'event, 'state, 'context>(store : VolatileStore, fold, initial) =
+type Category<'event, 'state, 'context>(store : VolatileStore, codec : FsCodec.IUnionEncoder<'event,obj,'context>, fold, initial) =
+    let (|Decode|) = Array.choose codec.TryDecode
     interface ICategory<'event, 'state, string, 'context> with
-        member __.Load(log, streamName, _opt) = async {
-            match store.TryLoad<'event> streamName log with
+        member __.Load(_log, streamName, _opt) = async {
+            match store.TryLoad streamName with
             | None -> return Token.ofEmpty streamName initial
-            | Some events -> return Token.ofEventArray streamName fold initial events }
-        member __.TrySync(log : ILogger, Token.Unpack token, state, events : 'event list, _context) = async {
+            | Some (Decode events) -> return Token.ofEventArray streamName fold initial events }
+        member __.TrySync(_log, Token.Unpack token, state, events : 'event list, context : 'context option) = async {
+            let inline map i (e : FsCodec.IEventData<obj>) =
+                FsCodec.Core.TimelineEvent.Create(int64 i,e.EventType,e.Data,e.Meta,e.CorrelationId,e.CausationId,e.Timestamp) :> FsCodec.ITimelineEvent<obj>
+            let encoded = events |> Seq.mapi (fun i e -> map (token.streamVersion+1) (codec.Encode(context,e))) |> Array.ofSeq
             let trySyncValue currentValue =
                 if Array.length currentValue <> token.streamVersion + 1 then ConcurrentDictionarySyncResult.Conflict (token.streamVersion)
-                else ConcurrentDictionarySyncResult.Written (Seq.append currentValue events)
-            match store.TrySync token.streamName (log : ILogger) trySyncValue events with
+                else ConcurrentDictionarySyncResult.Written (Seq.append currentValue encoded |> Array.ofSeq)
+            match store.TrySync(token.streamName, trySyncValue, encoded) with
             | ConcurrentArraySyncResult.Conflict conflictingEvents ->
                 let resync = async {
                     let version = Token.tokenOfArray token.streamName conflictingEvents
                     let successorEvents = conflictingEvents |> Seq.skip (token.streamVersion + 1) |> List.ofSeq
-                    return version, fold state (Seq.ofList successorEvents) }
+                    return version, fold state (successorEvents |> Seq.choose codec.TryDecode) }
                 return SyncResult.Conflict resync
-            | ConcurrentArraySyncResult.Written events -> return SyncResult.Written <| Token.ofEventArrayAndKnownState token.streamName fold state events }
+            | ConcurrentArraySyncResult.Written _ -> return SyncResult.Written <| Token.ofEventArrayAndKnownState token.streamName fold state events }
 
-type Resolver<'event, 'state, 'context>(store : VolatileStore, fold, initial) =
-    let category = Category<'event,'state,'context>(store, fold, initial)
+type Resolver<'event, 'state, 'context>(store : VolatileStore, codec : FsCodec.IUnionEncoder<'event,obj,'context>, fold, initial) =
+    let category = Category<'event,'state,'context>(store, codec, fold, initial)
     let resolveStream streamName context = Stream.create category streamName None context
     let resolveTarget = function AggregateId (cat,streamId) -> sprintf "%s-%s" cat streamId | StreamName streamName -> streamName
-    member __.Resolve(target : Target, [<Optional; DefaultParameterValue null>] ?option, [<Optional; DefaultParameterValue null>] ?context) =
+    member __.Resolve(target : Target, [<Optional; DefaultParameterValue null>] ?option, [<Optional; DefaultParameterValue null>] ?context : 'context) =
         match resolveTarget target, option with
         | sn,(None|Some AllowStale) -> resolveStream sn context
         | sn,Some AssumeEmpty -> Stream.ofMemento (Token.ofEmpty sn initial) (resolveStream sn context)
@@ -107,3 +92,6 @@ type Resolver<'event, 'state, 'context>(store : VolatileStore, fold, initial) =
     /// Resolve from a Memento being used in a Continuation [based on position and state typically from Stream.CreateMemento]
     member __.FromMemento(Token.Unpack stream as streamToken, state, ?context) =
         Stream.ofMemento (streamToken,state) (resolveStream stream.streamName context)
+
+type Resolver<'event, 'state when 'event :> TypeShape.UnionContract.IUnionContract>(store : VolatileStore, fold, initial) =
+    inherit Resolver<'event,'state,obj>(store, FsCodec.Box.Codec.Create<'event>(), fold, initial)

--- a/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
+++ b/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
@@ -7,7 +7,7 @@ let createMemoryStore () =
     new VolatileStore()
 
 let createServiceMemory log store =
-    let resolveStream (id,opt) = Resolver(store, Domain.Cart.Folds.fold, Domain.Cart.Folds.initial).Resolve(id,?option=opt)
+    let resolveStream (id,opt) = Resolver<_,_>(store, Domain.Cart.Folds.fold, Domain.Cart.Folds.initial).Resolve(id,?option=opt)
     Backend.Cart.Service(log, resolveStream)
 
 #nowarn "1182" // From hereon in, we may have some 'unused' privates (the tests)

--- a/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
+++ b/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
@@ -4,10 +4,10 @@ open Swensen.Unquote
 open Equinox.MemoryStore
 
 let createMemoryStore () =
-    new VolatileStore()
+    new VolatileStore<_>()
 
 let createServiceMemory log store =
-    let resolveStream (id,opt) = Resolver<_,_>(store, Domain.Cart.Folds.fold, Domain.Cart.Folds.initial).Resolve(id,?option=opt)
+    let resolveStream (id,opt) = Resolver(store, FsCodec.Box.Codec.Create(), Domain.Cart.Folds.fold, Domain.Cart.Folds.initial).Resolve(id,?option=opt)
     Backend.Cart.Service(log, resolveStream)
 
 #nowarn "1182" // From hereon in, we may have some 'unused' privates (the tests)


### PR DESCRIPTION
The current implementation of `MemoryStore` stores the events directly, as supplied, without any transformations being applied. One downside to this is that it does enable multiple 'aggregates' to share the same data but with different event Types (e.g. if one aggregate has a subset of the union cases of another).

This upgrades `MemoryStore` to admit a `codec` parameter, which makes it equivalent in facilities to the other stores, including support for metadata management.

relies on https://github.com/jet/FsCodec/pull/25
related: https://github.com/jet/FsCodec/pull/24