### PR TITLE
Add eqx dump cosmos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Fixed
 
+- `Cosmos`: fixed swapped `count` and `bytes` metrics fields
+
 <a name="2.0.0"></a>
 <a name="2.0.0-rc7"></a>
 ## [2.0.0-rc7] - 2019-10-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Cosmos`: Exposed a `Connector.CreateClient` for interop with V2 ChangeFeedProcessor and `Propulsion.Cosmos` [#171](https://github.com/jet/equinox/pull/171) 
 - `Cosmos`: Added `eqx stats` command to count streams/docs/events in a CosmosDb Container re [#127](https://github.com/jet/equinox/issues/127) [#176](https://github.com/jet/equinox/pull/176) 
 - `MemoryStore`: Supports custom Codec logic (can use `FsCodec.Box.Codec` as default) [#173](https://github.com/jet/equinox/pull/173) 
+- `eqx dump [store]`: Show event data from store [#177](https://github.com/jet/equinox/pull/177)
 
 ### Changed
 
@@ -27,7 +28,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Fixed
 
-- `Cosmos`: fixed swapped `count` and `bytes` metrics fields
+- `Cosmos`: fixed accidentally swapped `count` and `bytes` metrics field values
 
 <a name="2.0.0"></a>
 <a name="2.0.0-rc7"></a>

--- a/README.md
+++ b/README.md
@@ -311,12 +311,12 @@ While Equinox is implemented in F#, and F# is a great fit for writing event-sour
 <a name="sqlstreamstore"></a>
 9. Use [SqlStreamStore](https://github.com/SQLStreamStore/SQLStreamStore)
    
-   The SqlStreamStore consists of:
+  The SqlStreamStore consists of:
 
-   - being able to supply `ms`, `my`, `pg` flag to `eqx run`, e.g. `eqx run -t cart -f 50 -d 5 -C -U ms -c "sqlserverconnectionstring" -s schema`
-   - being able to supply `ms`, `my`, `pg` flag to `eqx dump`, e.g. `eqx dump -JC -S "Favoritesab25cc9f24464d39939000aeb37ea11a" ms -c "sqlserverconnectionstring" -s schema`
-   - being able to supply `ms`, `my`, `pg` flag to Web sample, e.g. `dotnet run -p samples/Web/ -- my -c "mysqlconnectionstring"`
-   - being able to supply `ms`, `my`, `pg` flag to new `eqx config` command e.g. `eqx config pg -c "postgresconnectionstring" -u p "usercredentialsNotToBeLogged" -s schema`
+  - being able to supply `ms`, `my`, `pg` flag to `eqx run`, e.g. `eqx run -t cart -f 50 -d 5 -C -U ms -c "sqlserverconnectionstring" -s schema`
+  - being able to supply `ms`, `my`, `pg` flag to `eqx dump`, e.g. `eqx dump -JC -S "Favoritesab25cc9f24464d39939000aeb37ea11a" ms -c "sqlserverconnectionstring" -s schema`
+  - being able to supply `ms`, `my`, `pg` flag to Web sample, e.g. `dotnet run -p samples/Web/ -- my -c "mysqlconnectionstring"`
+  - being able to supply `ms`, `my`, `pg` flag to new `eqx config` command e.g. `eqx config pg -c "postgresconnectionstring" -u p "usercredentialsNotToBeLogged" -s schema`
 
     ```powershell
     cd ~/code/equinox

--- a/README.md
+++ b/README.md
@@ -310,12 +310,13 @@ While Equinox is implemented in F#, and F# is a great fit for writing event-sour
 
 <a name="sqlstreamstore"></a>
 9. Use [SqlStreamStore](https://github.com/SQLStreamStore/SQLStreamStore)
+   
+   The SqlStreamStore consists of:
 
-    The SqlStreamStore consists of:
-
-    - being able to supply `ms`, `my`, `pg` flag to `eqx run`, e.g. `eqx run -t cart -f 50 -d 5 -C -U ms -c "sqlserverconnectionstring" -s schema`
-    - being able to supply `ms`, `my`, `pg` flag to Web sample, e.g. `dotnet run -p samples/Web/ -- my -c "mysqlconnectionstring"`
-    - being able to supply `ms`, `my`, `pg` flag to new `eqx config` command e.g. `eqx config pg -c "postgresconnectionstring" -u p "usercredentialsNotToBeLogged" -s schema`
+   - being able to supply `ms`, `my`, `pg` flag to `eqx run`, e.g. `eqx run -t cart -f 50 -d 5 -C -U ms -c "sqlserverconnectionstring" -s schema`
+   - being able to supply `ms`, `my`, `pg` flag to `eqx dump`, e.g. `eqx dump -JC -S "Favoritesab25cc9f24464d39939000aeb37ea11a" ms -c "sqlserverconnectionstring" -s schema`
+   - being able to supply `ms`, `my`, `pg` flag to Web sample, e.g. `dotnet run -p samples/Web/ -- my -c "mysqlconnectionstring"`
+   - being able to supply `ms`, `my`, `pg` flag to new `eqx config` command e.g. `eqx config pg -c "postgresconnectionstring" -u p "usercredentialsNotToBeLogged" -s schema`
 
     ```powershell
     cd ~/code/equinox

--- a/README.md
+++ b/README.md
@@ -273,9 +273,9 @@ While Equinox is implemented in F#, and F# is a great fit for writing event-sour
 
 7. Use `propulsion` tool to Run a CosmosDb ChangeFeedProcessor, emitting to a Kafka topic
 
-     ```powershell	
+    ```powershell	
     $env:PROPULSION_KAFKA_BROKER="instance.kafka.mysite.com:9092" # or use -b	
-     # `-v` for verbose logging	
+    # `-v` for verbose logging	
     # `projector3` represents the consumer group; >=1 are allowed, allowing multiple independent projections to run concurrently	
     # `-l 5` to report ChangeFeed lags every 5 minutes	
     # `kafka` specifies one wants to emit to Kafka	
@@ -321,23 +321,24 @@ While Equinox is implemented in F#, and F# is a great fit for writing event-sour
     cd ~/code/equinox
     
     # set up the DB/schema
-    & dotnet run -f netcoreapp2.1 -p tools/Equinox.Tool -- config pg -c "connectionstring" -p "u=un;p=password" -s "schema"
+    dotnet run -f netcoreapp2.1 -p tools/Equinox.Tool -- config pg -c "connectionstring" -p "u=un;p=password" -s "schema"
     
     # run a benchmark
-    & dotnet run -c Release -f netcoreapp2.1 -p tools/Equinox.Tool -- run -t saveforlater -f 50 -d 5 -C -U pg -c "connectionstring" -p "u=un;p=password" -s "schema"
+    dotnet run -c Release -f netcoreapp2.1 -p tools/Equinox.Tool -- run -t saveforlater -f 50 -d 5 -C -U pg -c "connectionstring" -p "u=un;p=password" -s "schema"
     
     # run the webserver, -A to autocreate schema on connection
-    & dotnet run -p samples/Web/ -- my -c "mysqlconnectionstring" -A
+    dotnet run -p samples/Web/ -- my -c "mysqlconnectionstring" -A
     
     #############################
     # TODO - NOTE NOT YET RELEASED
     ##############################
     
     # set up the DB/schema
-    & eqx config pg -c "connectionstring" -p "u=un;p=password" -s "schema"
+    eqx config pg -c "connectionstring" -p "u=un;p=password" -s "schema"
     
     # run a benchmark
-    & eqx run -t saveforlater -f 50 -d 5 -C -U pg -c "connectionstring" -p "u=un;p=password" -s "schema" 
+    eqx run -t saveforlater -f 50 -d 5 -C -U pg -c "connectionstring" -p "u=un;p=password" -s "schema" 
+    eqx dump -J -S "SavedForLater-ab25cc9f24464d39939000aeb37ea11a" pg # show stored JSON (Guid shown in eqx run output) 
     ```
 
 ### BENCHMARKS

--- a/README.md
+++ b/README.md
@@ -311,11 +311,11 @@ While Equinox is implemented in F#, and F# is a great fit for writing event-sour
 <a name="sqlstreamstore"></a>
 9. Use [SqlStreamStore](https://github.com/SQLStreamStore/SQLStreamStore)
 
-  The SqlStreamStore consists of:
+    The SqlStreamStore consists of:
 
-  - being able to supply `ms`, `my`, `pg` flag to `eqx run`, e.g. `eqx run -t cart -f 50 -d 5 -C -U ms -c "sqlserverconnectionstring" -s schema`
-  - being able to supply `ms`, `my`, `pg` flag to Web sample, e.g. `dotnet run -p samples/Web/ -- my -c "mysqlconnectionstring"`
-  - being able to supply `ms`, `my`, `pg` flag to new `eqx config` command e.g. `eqx config pg -c "postgresconnectionstring" -u p "usercredentialsNotToBeLogged" -s schema`
+    - being able to supply `ms`, `my`, `pg` flag to `eqx run`, e.g. `eqx run -t cart -f 50 -d 5 -C -U ms -c "sqlserverconnectionstring" -s schema`
+    - being able to supply `ms`, `my`, `pg` flag to Web sample, e.g. `dotnet run -p samples/Web/ -- my -c "mysqlconnectionstring"`
+    - being able to supply `ms`, `my`, `pg` flag to new `eqx config` command e.g. `eqx config pg -c "postgresconnectionstring" -u p "usercredentialsNotToBeLogged" -s schema`
 
     ```powershell
     cd ~/code/equinox
@@ -328,10 +328,6 @@ While Equinox is implemented in F#, and F# is a great fit for writing event-sour
     
     # run the webserver, -A to autocreate schema on connection
     dotnet run -p samples/Web/ -- my -c "mysqlconnectionstring" -A
-    
-    #############################
-    # TODO - NOTE NOT YET RELEASED
-    ##############################
     
     # set up the DB/schema
     eqx config pg -c "connectionstring" -p "u=un;p=password" -s "schema"

--- a/samples/Infrastructure/Storage.fs
+++ b/samples/Infrastructure/Storage.fs
@@ -73,7 +73,7 @@ module Cosmos =
     let private createGateway connection maxItems = Gateway(connection, BatchingPolicy(defaultMaxItems=maxItems))
     let connection (log: ILogger, storeLog: ILogger) (a : Info) =
         let (Discovery.UriAndKey (endpointUri,_)) as discovery = a.Connection|> Discovery.FromConnectionString
-        log.Information("CosmosDb {mode:l} {connection} Database {database:l} Container {container:l}",
+        log.Information("CosmosDb {mode} {connection} Database {database} Container {container}",
             a.Mode, endpointUri, a.Database, a.Container)
         log.Information("CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
             (let t = a.Timeout in t.TotalSeconds), a.Retries, let x = a.MaxRetryWaitTime in x.TotalSeconds)

--- a/samples/Infrastructure/Storage.fs
+++ b/samples/Infrastructure/Storage.fs
@@ -73,7 +73,7 @@ module Cosmos =
     let private createGateway connection maxItems = Gateway(connection, BatchingPolicy(defaultMaxItems=maxItems))
     let connection (log: ILogger, storeLog: ILogger) (a : Info) =
         let (Discovery.UriAndKey (endpointUri,_)) as discovery = a.Connection|> Discovery.FromConnectionString
-        log.Information("CosmosDb {mode} {connection} Database {database} Container {container}",
+        log.Information("CosmosDb {mode:l} {connection} Database {database:l} Container {container:l}",
             a.Mode, endpointUri, a.Database, a.Container)
         log.Information("CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
             (let t = a.Timeout in t.TotalSeconds), a.Retries, let x = a.MaxRetryWaitTime in x.TotalSeconds)

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -1,4 +1,4 @@
-﻿namespace Equinox.Cosmos.Store
+namespace Equinox.Cosmos.Store
 
 open Equinox.Core
 open FsCodec
@@ -583,7 +583,7 @@ module internal Tip =
     let private loggedGet (get : Container * string -> Position option -> Async<_>) (container,stream) (maybePos: Position option) (log: ILogger) = async {
         let log = log |> Log.prop "stream" stream
         let! t, (ru, res : ReadResult<Tip>) = get (container,stream) maybePos |> Stopwatch.Time
-        let log count bytes (f : Log.Measurement -> _) = log |> Log.event (f { stream = stream; interval = t; bytes = bytes; count = count; ru = ru })
+        let log bytes count (f : Log.Measurement -> _) = log |> Log.event (f { stream = stream; interval = t; bytes = bytes; count = count; ru = ru })
         match res with
         | ReadResult.NotModified ->
             (log 0 0 Log.TipNotModified).Information("EqxCosmos {action:l} {res} {ms}ms rc={ru}", "Tip", 302, (let e = t.Elapsed in e.TotalMilliseconds), ru)
@@ -1014,7 +1014,7 @@ type Resolver<'event, 'state, 'context>(context : Context, codec, fold, initial,
         | Some (AccessStrategy.Unfolded (isOrigin, unfold)) ->           isOrigin,         Choice2Of3 (fun _ state -> unfold state)
         | Some (AccessStrategy.Snapshot (isValid,generate)) ->           isValid,          Choice2Of3 (fun _ state -> generate state |> Seq.singleton)
         | Some (AccessStrategy.AnyKnownEventType) ->                     (fun _ -> true),  Choice2Of3 (fun events _ -> Seq.last events |> Seq.singleton)
-        | Some (AccessStrategy.RollingUnfolds (isOrigin,transmute)) -> isOrigin,         Choice3Of3 transmute
+        | Some (AccessStrategy.RollingUnfolds (isOrigin,transmute)) ->   isOrigin,         Choice3Of3 transmute
     let cosmosCat = Category<'event, 'state, 'context>(context.Gateway, codec)
     let folder = Folder<'event, 'state, 'context>(cosmosCat, fold, initial, isOrigin, mapUnfolds, ?readCache = readCacheOption)
     let category : ICategory<_, _, Container*string, 'context> =

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -346,7 +346,7 @@ module CosmosStats =
             ops |> Seq.map (fun (name,sql) -> async {
                     log.Debug("Running query: {sql}", sql)
                     let res = container.QueryValue<int>(sql, Microsoft.Azure.Documents.Client.FeedOptions(EnableCrossPartitionQuery=true))
-                    log.Information("{Stat:l}: {result:N0}", name, res)})
+                    log.Information("{stat}: {result:N0}", name, res)})
                 |> if inParallel then Async.Parallel else Async.ParallelThrottled 1 // TOCONSIDER replace with Async.Sequence when using new enough FSharp.Core
                 |> Async.Ignore
                 |> Async.RunSynchronously

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -255,7 +255,8 @@ module LoadTest =
             | None, None -> invalidOp "impossible None, None"
         let clients = Array.init (a.TestsPerSecond * 2) (fun _ -> % Guid.NewGuid())
 
-        log.ForContext("clientIds",if verboseConsole then Seq.ofArray clients else Seq.truncate 5 clients)
+        let renderedIds = clients |> Seq.map ClientId.toStringN |> if verboseConsole then id else Seq.truncate 5
+        log.ForContext((if verboseConsole then "clientIds" else "clientIdsExcerpt"),renderedIds)
             .Information("Running {test} for {duration} @ {tps} hits/s across {clients} clients; Max errors: {errorCutOff}, reporting intervals: {ri}, report file: {report}",
             test, a.Duration, a.TestsPerSecond, clients.Length, a.ErrorCutoff, a.ReportingIntervals, reportFilename)
         // Reset the start time based on which the shared global metrics will be computed

--- a/tools/Equinox.Tools.TestHarness/Aggregate.fs
+++ b/tools/Equinox.Tools.TestHarness/Aggregate.fs
@@ -99,7 +99,7 @@ module Observable =
     let logAggregate (log: ILogger) (source : IObservable<Envelope<TestResultAggregate>>) : IDisposable =
         source
         |> Observable.map TestResultAggregate.Render
-        |> Observable.subscribe (fun r -> log.Information("Aggregate: {result}",r))
+        |> Observable.subscribe (fun r -> log.Information("Aggregate: {result:l}",r))
 
     /// Logs load test events with provided log level
     let logEvents (log : ILogger) (events : IObservable<Envelope<LoadTestEvent>>) =


### PR DESCRIPTION
Adds an `eqx dump` command that can be used to inspect the raw [json] data of a specified stream from the console.

- [x] This initial implementation is only wired for `Equinox.Cosmos` (the unique need here is to easily render the compressed `u`nfolds field)

![image](https://user-images.githubusercontent.com/206668/68434820-d43f9f80-01b1-11ea-972c-991883cb12dd.png)
![image](https://user-images.githubusercontent.com/206668/68434886-fdf8c680-01b1-11ea-92bf-2ec5bb5e6f3d.png)

- `-vc` will trigger emitting storage logging
- `-v` adds detail to said logging

- [x] handle any store type