### PR TITLE
Added missing FSCodec reference in Favorites.fsx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ packages.config
 
 # CodeRush
 .cr/
+
+#Ionide
+.ionide/

--- a/samples/Tutorial/Favorites.fsx
+++ b/samples/Tutorial/Favorites.fsx
@@ -5,6 +5,7 @@
 #r "Serilog.Sinks.Console.dll"
 #r "Equinox.dll"
 #r "Equinox.MemoryStore.dll"
+#r "FSCodec.dll"
 
 (*
  * EVENTS


### PR DESCRIPTION
While going through the Document.md and following Favorites.fsx, F# interactive had issues running the code because it did not recognize FSCodec. The missing reference has been added to the top. 

Also, .ionide has been added to .gitignore