### PR TITLE
Expand on Query/Interpret/Decide docs

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -639,8 +639,8 @@ In some cases, a Command is logically composed of separable actions against the 
 There's an example of such a case in the [Cart's Domain Service](https://github.com/jet/equinox/blob/master/samples/Store/Backend/Cart.fs#L53):-
 
 ```fsharp
-let interpretMany fold interprets (state : 'state) : 'state * 'event list =
-    ((state,[]),interprets)
+let interpretMany fold interpreters (state : 'state) : 'state * 'event list =
+    ((state,[]),interpreters)
     ||> Seq.fold (fun (state : 'state, acc : 'event list) interpret ->
         let events = interpret state
         let state' = fold state events

--- a/samples/Store/Backend/Cart.fs
+++ b/samples/Store/Backend/Cart.fs
@@ -36,8 +36,8 @@ type Accumulator<'event, 'state>(fold : 'state -> 'event seq -> 'state, originSt
         accumulated.AddRange newEvents
         return result }
 #else
-let interpretMany fold interprets (state : 'state) : 'state * 'event list =
-    ((state,[]),interprets)
+let interpretMany fold interpreters (state : 'state) : 'state * 'event list =
+    ((state,[]),interpreters)
     ||> Seq.fold (fun (state : 'state, acc : 'event list) interpret ->
         let events = interpret state
         let state' = fold state events


### PR DESCRIPTION
In response to a question, this attempts to clarify why Transact has two overloads by expanding the Command Handling Dos and Donts section.

I'm not sure it's actually better as by definition, good examples of valid mixing Commands and Queries is a very specific and subjective case.