### PR TITLE
feat(CosmosStore): Expose ISyncContext.SessionToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - now targets `Microsoft.Azure.Cosmos` v `3.1.1` (instead of `Microsoft.Azure.DocumentDB`[`.Core`] v 2.x) [#144](https://github.com/jet/equinox/pull/144)
+- `Core.ISyncContext.SessionToken`: Allows one to inspect the `SessionToken` for relevant stores (i.e., `CosmosDB`), after loading and/or syncing has concluded [#195](https://github.com/jet/equinox/pull/195) 
 
 ### Changed
 

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -752,8 +752,9 @@ module internal Tip =
 type [<NoComparison>] Token = { container: Container; stream: string; pos: Position }
 module Token =
     let create (container,stream) pos : StreamToken =
-        {  value = box { container = container; stream = stream; pos = pos }
-           version = pos.index }
+        {   value = box { container = container; stream = stream; pos = pos }
+            version = pos.index
+            sessionToken = null }
     let (|Unpack|) (token: StreamToken) : Container*string*Position = let t = unbox<Token> token.value in t.container,t.stream,t.pos
     let supersedes (Unpack (_,_,currentPos)) (Unpack (_,_,xPos)) =
         let currentVersion, newVersion = currentPos.index, xPos.index

--- a/src/Equinox.Cosmos/Equinox.Cosmos.fsproj
+++ b/src/Equinox.Cosmos/Equinox.Cosmos.fsproj
@@ -19,7 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.0.0" PrivateAssets="All" />
 

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -317,7 +317,8 @@ module Token =
         {   value = box {
                 stream = { name = streamName}
                 pos = { streamVersion = streamVersion; compactionEventNumber = compactionEventNumber; batchCapacityLimit = batchCapacityLimit } }
-            version = streamVersion }
+            version = streamVersion
+            sessionToken = null }
 
     /// No batching / compaction; we only need to retain the StreamVersion
     let ofNonCompacting streamName streamVersion : StreamToken =

--- a/src/Equinox.MemoryStore/MemoryStore.fs
+++ b/src/Equinox.MemoryStore/MemoryStore.fs
@@ -45,7 +45,8 @@ module private Token =
 
     let private streamTokenOfIndex streamName (streamVersion : int) : StreamToken =
         {   value = box { streamName = streamName; streamVersion = streamVersion }
-            version = int64 streamVersion }
+            version = int64 streamVersion
+            sessionToken = null }
     let (|Unpack|) (token: StreamToken) : Token = unbox<Token> token.value
     /// Represent a stream known to be empty
     let ofEmpty streamName initial = streamTokenOfIndex streamName -1, initial

--- a/src/Equinox.SqlStreamStore/SqlStreamStore.fs
+++ b/src/Equinox.SqlStreamStore/SqlStreamStore.fs
@@ -298,7 +298,8 @@ module Token =
         {   value = box {
                 stream = { name = streamName}
                 pos = { streamVersion = streamVersion; compactionEventNumber = compactionEventNumber; batchCapacityLimit = batchCapacityLimit } }
-            version = streamVersion }
+            version = streamVersion
+            sessionToken = null }
     /// No batching / compaction; we only need to retain the StreamVersion
     let ofNonCompacting streamName streamVersion : StreamToken =
         create None None streamName streamVersion


### PR DESCRIPTION
This PR exposes a `SessionToken` on `Equinox.Core.ISyncState`, which enables logic in a `Service` to access that (along with the `Version` plumbed in #194) via the `QueryEx` and `TransactAsyncEx` APIs. More importantly, it enables one to flow the `SessionToken` out to the caller in order to enable Read-Your-Writes guarantees for a system's overall client session.

This could be merged in the 2.0 timeframe, but leaving it in the 3.0 milestone for now as doing so only makes sense if `Equinox.Cosmos` (or another store) actually wires through the `SessionToken` correctly, which involves addressing #192:
- [ ] when creating the `Equinox.Stream`, one needs to be able to supply the incoming `SessionToken` (maybe add a `sessionToken` argument in `Resolve`?
- [ ] when running a `Load` internally, the suplied token needs to be passed in the Options
- [ ] the stored procedure and/or the invocation logic needs to surface the SessionToken at the conclusion of the Sync operation
- [ ] the SessionToken needs to flow back into the `StreamToken` that's yielded back

cc @thednaz @ylibrach