### PR TITLE
Apply updated resolve idiom

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -536,7 +536,7 @@ member __.Read(clientId) =
 <a name="commands"></a>
 # Command+Decision Handling functions
 
-Commands or Decisions are handled via `Equinox.Stream`'s `Transact' method
+Commands or Decisions are handled via `Equinox.Stream`'s `Transact` method
 
 ## Commands (`interpret` signature)
 

--- a/samples/Infrastructure/Services.fs
+++ b/samples/Infrastructure/Services.fs
@@ -30,17 +30,17 @@ type ServiceBuilder(storageConfig, handlerLog) =
      member __.CreateFavoritesService() =
         let fold, initial = Favorites.Fold.fold, Favorites.Fold.initial
         let snapshot = Favorites.Fold.isOrigin,Favorites.Fold.snapshot
-        Backend.Favorites.Service(handlerLog, resolver.Resolve(Favorites.Events.codec,fold,initial,snapshot))
+        Backend.Favorites.create handlerLog (resolver.Resolve(Favorites.Events.codec,fold,initial,snapshot))
 
      member __.CreateSaveForLaterService() =
         let fold, initial = SavedForLater.Fold.fold, SavedForLater.Fold.initial
         let snapshot = SavedForLater.Fold.isOrigin,SavedForLater.Fold.compact
-        Backend.SavedForLater.Service(handlerLog, resolver.Resolve(SavedForLater.Events.codec,fold,initial,snapshot), maxSavedItems=50)
+        Backend.SavedForLater.create 50 handlerLog (resolver.Resolve(SavedForLater.Events.codec,fold,initial,snapshot))
 
      member __.CreateTodosService() =
         let fold, initial = TodoBackend.Fold.fold, TodoBackend.Fold.initial
         let snapshot = TodoBackend.Fold.isOrigin, TodoBackend.Fold.snapshot
-        TodoBackend.Service(handlerLog, resolver.Resolve(TodoBackend.Events.codec,fold,initial,snapshot))
+        TodoBackend.create handlerLog (resolver.Resolve(TodoBackend.Events.codec,fold,initial,snapshot))
 
 let register (services : IServiceCollection, storageConfig, handlerLog) =
     let regF (factory : IServiceProvider -> 'T) = services.AddSingleton<'T>(fun (sp: IServiceProvider) -> factory sp) |> ignore

--- a/samples/Store/Backend/ContactPreferences.fs
+++ b/samples/Store/Backend/ContactPreferences.fs
@@ -2,18 +2,20 @@
 
 open Domain.ContactPreferences
 
-type Service(log, resolve, ?maxAttempts) =
-
-    let resolve (Events.ForClientId streamId) = Equinox.Stream(log, resolve streamId, defaultArg maxAttempts 3)
+type Service internal (resolve : Id -> Equinox.Stream<Events.Event, Fold.State>) =
 
     let update email value : Async<unit> =
         let stream = resolve email
-        let command = Update { email = email; preferences = value }
+        let command = let (Id email) = email in Update { email = email; preferences = value }
         stream.Transact(Commands.interpret command)
 
-    member __.Update email value =
+    member __.Update(email, value) =
         update email value
 
     member __.Read(email) =
         let stream = resolve email
         stream.Query id
+
+let create log resolve =
+    let resolve id = Equinox.Stream(log, resolve (streamName id), maxAttempts  = 3)
+    Service(resolve)

--- a/samples/Store/Backend/Favorites.fs
+++ b/samples/Store/Backend/Favorites.fs
@@ -1,11 +1,10 @@
 ﻿module Backend.Favorites
 
+open Domain
 open Domain.Favorites
 open System
 
-type Service(log, resolve, ?maxAttempts) =
-
-    let resolve (Events.ForClientId streamId) = Equinox.Stream(log, resolve streamId, defaultArg maxAttempts 2)
+type Service internal (resolve : ClientId -> Equinox.Stream<Events.Event, Fold.State>) =
 
     let execute clientId command : Async<unit> =
         let stream = resolve clientId
@@ -24,4 +23,8 @@ type Service(log, resolve, ?maxAttempts) =
         execute clientId (Command.Unfavorite skus)
 
     member __.List clientId : Async<Events.Favorited []> =
-        read clientId 
+        read clientId
+
+let create log resolve =
+    let resolve id = Equinox.Stream(log, resolve (streamName id), maxAttempts  = 3)
+    Service(resolve)

--- a/samples/Store/Backend/InventoryItem.fs
+++ b/samples/Store/Backend/InventoryItem.fs
@@ -1,10 +1,9 @@
 ﻿module Backend.InventoryItem
 
+open Domain
 open Domain.InventoryItem
 
-type Service(log, resolve, ?maxAttempts) =
-
-    let resolve (Events.ForInventoryItemId id) = Equinox.Stream(log, resolve id, defaultArg maxAttempts 3)
+type Service internal (resolve : InventoryItemId -> Equinox.Stream<Events.Event, Fold.State>) =
 
     member __.Execute(itemId, command) =
         let stream = resolve itemId
@@ -13,3 +12,8 @@ type Service(log, resolve, ?maxAttempts) =
     member __.Read(itemId) =
         let stream = resolve itemId
         stream.Query id
+
+let create resolve =
+    let resolve id =
+        Equinox.Stream(Serilog.Log.ForContext<Service>(), resolve (streamName id), maxAttempts = 3)
+    Service(resolve)

--- a/samples/Store/Domain/Cart.fs
+++ b/samples/Store/Domain/Cart.fs
@@ -1,9 +1,9 @@
 ﻿module Domain.Cart
 
+let streamName (id: CartId) = FsCodec.StreamName.create "Cart" (CartId.toString id)
+
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
-
-    let (|ForCartId|) (id: CartId) = FsCodec.StreamName.create "Cart" (CartId.toString id)
 
     type ContextInfo =              { time: System.DateTime; requestId: RequestId }
 
@@ -27,6 +27,7 @@ module Events =
     let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
 
 module Fold =
+
     type ItemInfo =                 { skuId: SkuId; quantity: int; returnsWaived: bool }
     type State =                    { items: ItemInfo list }
     module State =
@@ -79,4 +80,4 @@ module Commands =
                 match waived with
                 | Some waived when itemExistsWithDifferentWaiveStatus skuId waived ->
                      yield Events.ItemWaiveReturnsChanged { context = c; skuId = skuId; waived = waived }
-                | _ -> () ] 
+                | _ -> () ]

--- a/samples/Store/Domain/ContactPreferences.fs
+++ b/samples/Store/Domain/ContactPreferences.fs
@@ -1,11 +1,10 @@
 ﻿module Domain.ContactPreferences
 
 type Id = Id of email: string
+let streamName (Id email) = FsCodec.StreamName.create "ContactPreferences" email // TODO hash >> base64
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
-
-    let (|ForClientId|) (email: string) = FsCodec.StreamName.create "ContactPreferences" email // TODO hash >> base64
 
     type Preferences = { manyPromotions : bool; littlePromotions : bool; productReview : bool; quickSurveys : bool }
     type Value = { email : string; preferences : Preferences }
@@ -37,4 +36,4 @@ module Commands =
         match command with
         | Update ({ preferences = preferences } as value) ->
             if state = preferences then [] else
-            [ Events.Updated value ] 
+            [ Events.Updated value ]

--- a/samples/Store/Domain/Favorites.fs
+++ b/samples/Store/Domain/Favorites.fs
@@ -1,9 +1,9 @@
 ﻿module Domain.Favorites
 
+let streamName (id: ClientId) = FsCodec.StreamName.create "Favorites" (ClientId.toString id)
+
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
-
-    let (|ForClientId|) (id: ClientId) = FsCodec.StreamName.create "Favorites" (ClientId.toString id)
 
     type Favorited =                            { date: System.DateTimeOffset; skuId: SkuId }
     type Unfavorited =                          { skuId: SkuId }

--- a/samples/Store/Domain/InventoryItem.fs
+++ b/samples/Store/Domain/InventoryItem.fs
@@ -3,10 +3,10 @@ module Domain.InventoryItem
 
 open System
 
+let streamName (id : InventoryItemId) = FsCodec.StreamName.create "InventoryItem" (InventoryItemId.toString id)
+
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
-
-    let (|ForInventoryItemId|) (id : InventoryItemId) = FsCodec.StreamName.create "InventoryItem" (InventoryItemId.toString id)
 
     type Event =
         | Created of name: string
@@ -55,4 +55,4 @@ module Commands =
             [ Events.CheckedIn count ]
         | Deactivate ->
             if not state.active then invalidOp "Already deactivated"
-            [ Events.Deactivated ] 
+            [ Events.Deactivated ]

--- a/samples/Store/Domain/SavedForLater.fs
+++ b/samples/Store/Domain/SavedForLater.fs
@@ -3,10 +3,10 @@
 open System
 open System.Collections.Generic
 
+let streamName (id: ClientId) = FsCodec.StreamName.create "SavedForLater" (ClientId.toString id)
+
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
-
-    let (|ForClientId|) (id: ClientId) = FsCodec.StreamName.create "SavedForLater" (ClientId.toString id)
 
     type Item =             { skuId : SkuId; dateSaved : DateTimeOffset }
 
@@ -104,4 +104,4 @@ module Commands =
             let index = Index state
             let net = skus |> Array.filter (index.DoesNotAlreadyContainSameOrMoreRecent dateSaved)
             if Array.isEmpty net then true, []
-            else validateAgainstInvariants [ Events.Added { skus = net ; dateSaved = dateSaved } ] 
+            else validateAgainstInvariants [ Events.Added { skus = net ; dateSaved = dateSaved } ]

--- a/samples/Store/Integration/CartIntegration.fs
+++ b/samples/Store/Integration/CartIntegration.fs
@@ -15,7 +15,7 @@ let createMemoryStore () =
     // we want to validate that the JSON UTF8 is working happily
     VolatileStore<byte[]>()
 let createServiceMemory log store =
-    Backend.Cart.Service(log, fun (id,opt) -> MemoryStore.Resolver(store, Domain.Cart.Events.codec, fold, initial).Resolve(id,?option=opt))
+    Backend.Cart.create log (fun (id,opt) -> MemoryStore.Resolver(store, Domain.Cart.Events.codec, fold, initial).Resolve(id,?option=opt))
 
 let codec = Domain.Cart.Events.codec
 
@@ -58,7 +58,7 @@ type Tests(testOutputHelper) =
         let log = createLog ()
         let! conn = connect log
         let gateway = choose conn defaultBatchSize
-        return Backend.Cart.Service(log, resolve gateway) }
+        return Backend.Cart.create log (resolve gateway) }
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
     let ``Can roundtrip against EventStore, correctly folding the events without compaction semantics`` args = Async.RunSynchronously <| async {

--- a/samples/Store/Integration/FavoritesIntegration.fs
+++ b/samples/Store/Integration/FavoritesIntegration.fs
@@ -12,21 +12,21 @@ let snapshot = Domain.Favorites.Fold.isOrigin, Domain.Favorites.Fold.snapshot
 let createMemoryStore () =
     new MemoryStore.VolatileStore<_>()
 let createServiceMemory log store =
-    Backend.Favorites.Service(log, MemoryStore.Resolver(store, FsCodec.Box.Codec.Create(), fold, initial).Resolve)
+    Backend.Favorites.create log (MemoryStore.Resolver(store, FsCodec.Box.Codec.Create(), fold, initial).Resolve)
 
 let codec = Domain.Favorites.Events.codec
 let createServiceGes gateway log =
-    let resolve = EventStore.Resolver(gateway, codec, fold, initial, access = EventStore.AccessStrategy.RollingSnapshots snapshot).Resolve
-    Backend.Favorites.Service(log, resolve)
+    let resolver = EventStore.Resolver(gateway, codec, fold, initial, access = EventStore.AccessStrategy.RollingSnapshots snapshot)
+    Backend.Favorites.create log resolver.Resolve
 
 let createServiceCosmos gateway log =
-    let resolve = Cosmos.Resolver(gateway, codec, fold, initial, Cosmos.CachingStrategy.NoCaching, Cosmos.AccessStrategy.Snapshot snapshot).Resolve
-    Backend.Favorites.Service(log, resolve)
+    let resolver = Cosmos.Resolver(gateway, codec, fold, initial, Cosmos.CachingStrategy.NoCaching, Cosmos.AccessStrategy.Snapshot snapshot)
+    Backend.Favorites.create log resolver.Resolve
 
 let createServiceCosmosRollingState gateway log =
     let access = Cosmos.AccessStrategy.RollingState Domain.Favorites.Fold.snapshot
-    let resolve = Cosmos.Resolver(gateway, codec, fold, initial, Cosmos.CachingStrategy.NoCaching, access).Resolve
-    Backend.Favorites.Service(log, resolve)
+    let resolver = Cosmos.Resolver(gateway, codec, fold, initial, Cosmos.CachingStrategy.NoCaching, access)
+    Backend.Favorites.create log resolver.Resolve
 
 type Tests(testOutputHelper) =
     let testOutput = TestOutputAdapter testOutputHelper
@@ -66,7 +66,7 @@ type Tests(testOutputHelper) =
         let service = createServiceCosmos gateway log
         do! act service args
     }
-    
+
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let ``Can roundtrip against Cosmos, correctly folding the events with rolling unfolds`` args = Async.RunSynchronously <| async {
         let log = createLog ()

--- a/samples/Store/Integration/LogIntegration.fs
+++ b/samples/Store/Integration/LogIntegration.fs
@@ -111,7 +111,7 @@ type Tests() =
         let log = createLoggerWithMetricsExtraction buffer.Enqueue
         let! conn = connectToLocalEventStoreNode log
         let gateway = createGesGateway conn batchSize
-        let service = Backend.Cart.Service(log, CartIntegration.resolveGesStreamWithRollingSnapshots gateway)
+        let service = Backend.Cart.create log (CartIntegration.resolveGesStreamWithRollingSnapshots gateway)
         let itemCount = batchSize / 2 + 1
         let cartId = % Guid.NewGuid()
         do! act buffer service itemCount context cartId skuId "ReadStreamEventsBackwardAsync-Duration"
@@ -124,7 +124,7 @@ type Tests() =
         let log = createLoggerWithMetricsExtraction buffer.Enqueue
         let! conn = connectToSpecifiedCosmosOrSimulator log
         let gateway = createCosmosContext conn batchSize
-        let service = Backend.Cart.Service(log, CartIntegration.resolveCosmosStreamWithSnapshotStrategy gateway)
+        let service = Backend.Cart.create log (CartIntegration.resolveCosmosStreamWithSnapshotStrategy gateway)
         let itemCount = batchSize / 2 + 1
         let cartId = % Guid.NewGuid()
         do! act buffer service itemCount context cartId skuId "EqxCosmos Tip " // one is a 404, one is a 200

--- a/samples/TodoBackend/Todo.fs
+++ b/samples/TodoBackend/Todo.fs
@@ -1,13 +1,14 @@
-﻿namespace TodoBackend
+﻿module TodoBackend
 
 open Domain
 
+// The TodoBackend spec does not dictate having multiple lists, tenants or clients
+// Here, we implement such a discriminator in order to allow each virtual client to maintain independent state
+let Category = "Todos"
+let streamName (id : ClientId) = FsCodec.StreamName.create Category (ClientId.toString id)
+
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
-
-    // The TodoBackend spec does not dictate having multiple lists, tenants or clients
-    // Here, we implement such a discriminator in order to allow each virtual client to maintain independent state
-    let (|ForClientId|) (id : ClientId) = FsCodec.StreamName.create "Todos" (ClientId.toString id)
 
     type Todo =         { id: int; order: int; title: string; completed: bool }
     type Deleted =      { id: int }
@@ -49,9 +50,7 @@ module Commands =
         | Delete id -> if state.items |> List.exists (fun x -> x.id = id) then [Events.Deleted {id=id}] else []
         | Clear -> if state.items |> List.isEmpty then [] else [Events.Cleared]
 
-type Service(log, resolve, ?maxAttempts) =
-
-    let resolve (Events.ForClientId streamId) = Equinox.Stream(log, resolve streamId, maxAttempts = defaultArg maxAttempts 2)
+type Service internal (resolve : ClientId -> Equinox.Stream<Events.Event, Fold.State>) =
 
     let execute clientId command =
         let stream = resolve clientId
@@ -82,3 +81,5 @@ type Service(log, resolve, ?maxAttempts) =
     member __.Patch(clientId, item: Events.Todo) : Async<Events.Todo> = async {
         let! state' = handle clientId (Command.Update item)
         return List.find (fun x -> x.id = item.id) state' }
+
+let create log resolve = Service(fun id -> Equinox.Stream(log, resolve (streamName id), maxAttempts = 3))

--- a/samples/Tutorial/Gapless.fs
+++ b/samples/Tutorial/Gapless.fs
@@ -4,11 +4,11 @@ module Gapless
 
 open System
 
+let [<Literal>] Category = "Gapless"
+let streamName id = FsCodec.StreamName.create Category (SequenceId.toString id)
+
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
-
-    let [<Literal>] categoryId = "Gapless"
-    let (|ForSequenceId|) id = FsCodec.StreamName.create categoryId (SequenceId.toString id)
 
     type Item = { id : int64 }
     type Snapshotted = { reservations : int64[];  nextId : int64 }
@@ -54,9 +54,7 @@ let decideConfirm item (state : Fold.State) : Events.Event list =
 let decideRelease item (state : Fold.State) : Events.Event list =
     failwith "TODO"
 
-type Service(log, resolve, ?maxAttempts) =
-
-    let resolve (Events.ForSequenceId streamId) = Equinox.Stream(log, resolve streamId, defaultArg maxAttempts 3)
+type Service internal (resolve : SequenceId -> Equinox.Stream<Events.Event, Fold.State>) =
 
     member __.ReserveMany(series,count) : Async<int64 list> =
         let stream = resolve series
@@ -79,19 +77,22 @@ let [<Literal>] appName = "equinox-tutorial-gapless"
 module Cosmos =
 
     open Equinox.Cosmos
-    let private createService (context,cache,accessStrategy) =
+    let private create (context,cache,accessStrategy) =
         let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
-        let resolve = Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy).Resolve
-        Service(Serilog.Log.Logger, resolve)
+        let resolver = Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
+        let resolve sequenceId =
+            let streamName = streamName sequenceId
+            Equinox.Stream(Serilog.Log.Logger, resolver.Resolve streamName, maxAttempts = 3)
+        Service(resolve)
 
     module Snapshot =
 
-        let createService (context,cache) =
+        let create (context,cache) =
             let accessStrategy = AccessStrategy.Snapshot (Fold.isOrigin,Fold.snapshot)
-            createService(context,cache,accessStrategy)
+            create(context,cache,accessStrategy)
 
     module RollingUnfolds =
 
-        let createService (context,cache) =
+        let create (context,cache) =
             let accessStrategy = AccessStrategy.RollingState Fold.snapshot
-            createService(context,cache,accessStrategy)
+            create(context,cache,accessStrategy)

--- a/samples/Tutorial/Index.fs
+++ b/samples/Tutorial/Index.fs
@@ -1,10 +1,10 @@
 module Index
 
+let [<Literal>] Category = "Index"
+let streamName indexId = FsCodec.StreamName.create Category (IndexId.toString indexId)
+
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
-
-    let [<Literal>] categoryId = "Index"
-    let (|ForIndexId|) indexId = FsCodec.StreamName.create categoryId (IndexId.toString indexId)
 
     type ItemIds = { items : string[] }
     type Items<'v> = { items : Map<string,'v> }
@@ -38,30 +38,30 @@ let interpret add remove (state : Fold.State<'v>) =
         [   if adds.Length <> 0 then yield Events.Added { items = Map.ofSeq adds }
             if removes.Length <> 0 then yield Events.Deleted { items = removes } ]
 
-type Service<'t> internal (indexId, resolve, maxAttempts) =
-
-    let log = Serilog.Log.ForContext<Service<'t>>()
-    let resolve (Events.ForIndexId streamId) = Equinox.Stream(log, resolve streamId, maxAttempts)
-    let stream = resolve indexId
+type Service<'t> internal (stream : Equinox.Stream<Events.Event<'t>, Fold.State<'t>>) =
 
     member __.Ingest(adds : seq<string*'t>, removes : string seq) : Async<int*int> =
         stream.Transact(interpret adds removes)
     member __.Read() : Async<Map<string,'t>> =
         stream.Query id
 
-let create resolve indexId = Service(indexId, resolve, maxAttempts = 3)
+let create<'t> resolve indexId =
+    let log = Serilog.Log.ForContext<Service<'t>>()
+    let streamName = streamName indexId
+    let stream = Equinox.Stream(log, resolve streamName, maxAttempts = 3)
+    Service(stream)
 
 module Cosmos =
 
     open Equinox.Cosmos
-    let createService<'v> (context,cache) =
+    let create<'v> (context,cache) =
         let cacheStrategy = CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
         let accessStrategy = AccessStrategy.RollingState Fold.snapshot
-        let resolve = Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy).Resolve
-        create resolve
+        let resolver = Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
+        create resolver.Resolve
 
 module MemoryStore =
 
-    let createService store =
-        let resolve = Equinox.MemoryStore.Resolver(store, Events.codec, Fold.fold, Fold.initial).Resolve
-        create resolve
+    let create store =
+        let resolver = Equinox.MemoryStore.Resolver(store, Events.codec, Fold.fold, Fold.initial)
+        create resolver.Resolve

--- a/samples/Tutorial/Sequence.fs
+++ b/samples/Tutorial/Sequence.fs
@@ -4,6 +4,9 @@ module Sequence
 
 open System
 
+let [<Literal>] Category = "Sequence"
+let streamName id = FsCodec.StreamName.create Category (SequenceId.toString id)
+
 // shim for net461
 module Seq =
     let tryLast (source : seq<_>) =
@@ -17,9 +20,6 @@ module Seq =
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
-
-    let [<Literal>] categoryId = "Sequence"
-    let (|ForSequenceId|) id = FsCodec.StreamName.create categoryId (SequenceId.toString id)
 
     type Reserved = { next : int64 }
     type Event =
@@ -40,32 +40,34 @@ module Fold =
 let decideReserve (count : int) (state : Fold.State) : int64 * Events.Event list =
     state.next,[Events.Reserved { next = state.next + int64 count }]
 
-type Service internal (log, resolve, maxAttempts) =
-
-    let resolve (Events.ForSequenceId streamId) = Equinox.Stream(log, resolve streamId, maxAttempts)
+type Service internal (resolve : SequenceId -> Equinox.Stream<Events.Event, Fold.State>) =
 
     /// Reserves an id, yielding the reserved value. Optional <c>count</c> enables reserving more than the default count of <c>1</c> in a single transaction
     member __.Reserve(series,?count) : Async<int64> =
         let stream = resolve series
         stream.Transact(decideReserve (defaultArg count 1))
 
-let create resolve = Service(Serilog.Log.ForContext<Service>(), resolve, maxAttempts = 3)
+let create resolve =
+    let resolve sequenceId =
+        let streamName = streamName sequenceId
+        Equinox.Stream(Serilog.Log.ForContext<Service>(), resolve streamName, maxAttempts = 3)
+    Service(resolve)
 
 module Cosmos =
 
     open Equinox.Cosmos
-    let private createService (context,cache,accessStrategy) =
+    let private create (context,cache,accessStrategy) =
         let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
-        let resolve = Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy).Resolve
-        create resolve
+        let resolver = Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
+        create resolver.Resolve
 
     module LatestKnownEvent =
 
-        let createService (context,cache) =
+        let create (context,cache) =
             let accessStrategy = AccessStrategy.LatestKnownEvent
-            createService (context,cache,accessStrategy)
+            create (context,cache,accessStrategy)
 
     module RollingUnfolds =
 
-        let createService (context,cache) =
-            createService (context,cache,AccessStrategy.RollingState Fold.snapshot)
+        let create (context,cache) =
+            create (context,cache,AccessStrategy.RollingState Fold.snapshot)

--- a/samples/Tutorial/Upload.fs
+++ b/samples/Tutorial/Upload.fs
@@ -1,8 +1,21 @@
 /// Simple example of how one might have multiple uploaders agree/share a common UploadId for a given OrderId
 module Upload
 
-open System
 open FSharp.UMX
+open System
+
+type PurchaseOrderId = int<purchaseOrderId>
+and [<Measure>] purchaseOrderId
+module PurchaseOrderId =
+    let toString (value : PurchaseOrderId) : string = string %value
+
+type CompanyId = string<companyId>
+and [<Measure>] companyId
+module CompanyId =
+    let toString (value : CompanyId) : string = %value
+
+let [<Literal>] Category = "Upload"
+let streamName (companyId, purchaseOrderId) = FsCodec.StreamName.compose Category [PurchaseOrderId.toString purchaseOrderId; CompanyId.toString companyId]
 
 // shim for net461
 module Seq =
@@ -15,16 +28,6 @@ module Seq =
         else
             None
 
-type PurchaseOrderId = int<purchaseOrderId>
-and [<Measure>] purchaseOrderId
-module PurchaseOrderId =
-    let toString (value : PurchaseOrderId) : string = string %value
-
-type CompanyId = string<companyId>
-and [<Measure>] companyId
-module CompanyId =
-    let toString (value : CompanyId) : string = %value
-
 type UploadId = string<uploadId>
 and [<Measure>] uploadId
 module UploadId =
@@ -32,9 +35,6 @@ module UploadId =
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
-
-    let [<Literal>] categoryId = "Upload"
-    let (|ForCompanyAndPurchaseOrder|) (companyId, purchaseOrderId) = FsCodec.StreamName.compose categoryId [PurchaseOrderId.toString purchaseOrderId; CompanyId.toString companyId]
 
     type IdAssigned = { value : UploadId }
     type Event =
@@ -56,26 +56,28 @@ let decide (value : UploadId) (state : Fold.State) : Choice<UploadId,UploadId> *
     | None -> Choice1Of2 value, [Events.IdAssigned { value = value}]
     | Some value -> Choice2Of2 value, []
 
-type Service internal (log, resolve, maxAttempts) =
-
-    let resolve (Events.ForCompanyAndPurchaseOrder streamId) = Equinox.Stream(log, resolve streamId, maxAttempts)
+type Service internal (resolve : CompanyId * PurchaseOrderId -> Equinox.Stream<Events.Event, Fold.State>) =
 
     member __.Sync(companyId, purchaseOrderId, value) : Async<Choice<UploadId,UploadId>> =
         let stream = resolve (companyId, purchaseOrderId)
         stream.Transact(decide value)
 
-let create resolve = Service(Serilog.Log.ForContext<Service>(), resolve, 3)
+let create resolve =
+    let resolve ids =
+        let streamName = streamName ids
+        Equinox.Stream(Serilog.Log.ForContext<Service>(), resolve streamName, maxAttempts = 3)
+    Service(resolve)
 
 module Cosmos =
 
     open Equinox.Cosmos
-    let createService (context,cache) =
+    let create (context,cache) =
         let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
-        let resolve = Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, AccessStrategy.LatestKnownEvent).Resolve
-        create resolve
+        let resolver = Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, AccessStrategy.LatestKnownEvent)
+        create resolver.Resolve
 
 module EventStore =
     open Equinox.EventStore
-    let createService context =
-        let resolve = Resolver(context, Events.codec, Fold.fold, Fold.initial, access=AccessStrategy.LatestKnownEvent).Resolve
-        create resolve
+    let create context =
+        let resolver = Resolver(context, Events.codec, Fold.fold, Fold.initial, access=AccessStrategy.LatestKnownEvent)
+        create resolver.Resolve

--- a/tests/Equinox.Cosmos.Integration/CosmosIntegration.fs
+++ b/tests/Equinox.Cosmos.Integration/CosmosIntegration.fs
@@ -15,42 +15,42 @@ module Cart =
     let createServiceWithoutOptimization connection batchSize log =
         let store = createCosmosContext connection batchSize
         let resolve (id,opt) = Resolver(store, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.Unoptimized).Resolve(id,?option=opt)
-        Backend.Cart.Service(log, resolve)
+        Backend.Cart.create log resolve
     let projection = "Compacted",snd snapshot
     /// Trigger looking in Tip (we want those calls to occur, but without leaning on snapshots, which would reduce the paths covered)
     let createServiceWithEmptyUnfolds connection batchSize log =
         let store = createCosmosContext connection batchSize
         let unfArgs = Domain.Cart.Fold.isOrigin, fun _ -> Seq.empty
         let resolve (id,opt) = Resolver(store, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.MultiSnapshot unfArgs).Resolve(id,?option=opt)
-        Backend.Cart.Service(log, resolve)
+        Backend.Cart.create log resolve
     let createServiceWithSnapshotStrategy connection batchSize log =
         let store = createCosmosContext connection batchSize
         let resolve (id,opt) = Resolver(store, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.Snapshot snapshot).Resolve(id,?option=opt)
-        Backend.Cart.Service(log, resolve)
+        Backend.Cart.create log resolve
     let createServiceWithSnapshotStrategyAndCaching connection batchSize log cache =
         let store = createCosmosContext connection batchSize
         let sliding20m = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
         let resolve (id,opt) = Resolver(store, codec, fold, initial, sliding20m, AccessStrategy.Snapshot snapshot).Resolve(id,?option=opt)
-        Backend.Cart.Service(log, resolve)
+        Backend.Cart.create log resolve
     let createServiceWithRollingState connection log =
         let store = createCosmosContext connection 1
         let access = AccessStrategy.RollingState Domain.Cart.Fold.snapshot
         let resolve (id,opt) = Resolver(store, codec, fold, initial, CachingStrategy.NoCaching, access).Resolve(id,?option=opt)
-        Backend.Cart.Service(log, resolve)
+        Backend.Cart.create log resolve
 
 module ContactPreferences =
     let fold, initial = Domain.ContactPreferences.Fold.fold, Domain.ContactPreferences.Fold.initial
     let codec = Domain.ContactPreferences.Events.codec
     let createServiceWithoutOptimization createGateway defaultBatchSize log _ignoreWindowSize _ignoreCompactionPredicate =
         let gateway = createGateway defaultBatchSize
-        let resolve = Resolver(gateway, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.Unoptimized).Resolve
-        Backend.ContactPreferences.Service(log, resolve)
+        let resolver = Resolver(gateway, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.Unoptimized)
+        Backend.ContactPreferences.create log resolver.Resolve
     let createService log createGateway =
-        let resolve = Resolver(createGateway 1, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.LatestKnownEvent).Resolve
-        Backend.ContactPreferences.Service(log, resolve)
+        let resolver = Resolver(createGateway 1, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.LatestKnownEvent)
+        Backend.ContactPreferences.create log resolver.Resolve
     let createServiceWithLatestKnownEvent createGateway log cachingStrategy =
-        let resolve = Resolver(createGateway 1, codec, fold, initial, cachingStrategy, AccessStrategy.LatestKnownEvent).Resolve
-        Backend.ContactPreferences.Service(log, resolve)
+        let resolver = Resolver(createGateway 1, codec, fold, initial, cachingStrategy, AccessStrategy.LatestKnownEvent)
+        Backend.ContactPreferences.create log resolver.Resolve
 
 #nowarn "1182" // From hereon in, we may have some 'unused' privates (the tests)
 
@@ -197,19 +197,19 @@ type Tests(testOutputHelper) =
         let! conn = connectToSpecifiedCosmosOrSimulator log
         let service = ContactPreferences.createService log (createCosmosContext conn)
 
-        let email = let g = System.Guid.NewGuid() in g.ToString "N"
+        let id = ContactPreferences.Id (let g = System.Guid.NewGuid() in g.ToString "N")
         //let (Domain.ContactPreferences.Id email) = id ()
         // Feed some junk into the stream
         for i in 0..11 do
             let quickSurveysValue = i % 2 = 0
-            do! service.Update email { value with quickSurveys = quickSurveysValue }
+            do! service.Update(id, { value with quickSurveys = quickSurveysValue })
         // Ensure there will be something to be changed by the Update below
-        do! service.Update email { value with quickSurveys = not value.quickSurveys }
+        do! service.Update(id, { value with quickSurveys = not value.quickSurveys })
 
         capture.Clear()
-        do! service.Update email value
+        do! service.Update(id, value)
 
-        let! result = service.Read email
+        let! result = service.Read id
         test <@ value = result @>
 
         test <@ [EqxAct.Tip; EqxAct.Append; EqxAct.Tip] = capture.ExternalCalls @>
@@ -220,18 +220,18 @@ type Tests(testOutputHelper) =
         let! conn = connectToSpecifiedCosmosOrSimulator log
         let service = ContactPreferences.createServiceWithLatestKnownEvent (createCosmosContext conn) log CachingStrategy.NoCaching
 
-        let email = let g = System.Guid.NewGuid() in g.ToString "N"
+        let id = ContactPreferences.Id (let g = System.Guid.NewGuid() in g.ToString "N")
         // Feed some junk into the stream
         for i in 0..11 do
             let quickSurveysValue = i % 2 = 0
-            do! service.Update email { value with quickSurveys = quickSurveysValue }
+            do! service.Update(id, { value with quickSurveys = quickSurveysValue })
         // Ensure there will be something to be changed by the Update below
-        do! service.Update email { value with quickSurveys = not value.quickSurveys }
+        do! service.Update(id, { value with quickSurveys = not value.quickSurveys })
 
         capture.Clear()
-        do! service.Update email value
+        do! service.Update(id, value)
 
-        let! result = service.Read email
+        let! result = service.Read id
         test <@ value = result @>
 
         test <@ [EqxAct.Tip; EqxAct.Append; EqxAct.Tip] = capture.ExternalCalls @>

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -51,26 +51,27 @@ module Cart =
     let codec = Domain.Cart.Events.codec
     let snapshot = Domain.Cart.Fold.isOrigin, Domain.Cart.Fold.snapshot
     let createServiceWithoutOptimization log gateway =
-        Backend.Cart.Service(log, fun (id,opt) -> Resolver(gateway, Domain.Cart.Events.codec, fold, initial).Resolve(id,?option=opt))
+        let resolve (id,opt) = Resolver(gateway, Domain.Cart.Events.codec, fold, initial).Resolve(id,?option=opt)
+        Backend.Cart.create log resolve
     let createServiceWithCompaction log gateway =
         let resolve (id,opt) = Resolver(gateway, codec, fold, initial, access = AccessStrategy.RollingSnapshots snapshot).Resolve(id,?option=opt)
-        Backend.Cart.Service(log, resolve)
+        Backend.Cart.create log resolve
     let createServiceWithCaching log gateway cache =
         let sliding20m = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        Backend.Cart.Service(log, fun (id,opt) -> Resolver(gateway, codec, fold, initial, sliding20m).Resolve(id,?option=opt))
+        Backend.Cart.create log (fun (id,opt) -> Resolver(gateway, codec, fold, initial, sliding20m).Resolve(id,?option=opt))
     let createServiceWithCompactionAndCaching log gateway cache =
         let sliding20m = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        Backend.Cart.Service(log, fun (id,opt) -> Resolver(gateway, codec, fold, initial, sliding20m, AccessStrategy.RollingSnapshots snapshot).Resolve(id,?option=opt))
+        Backend.Cart.create log (fun (id,opt) -> Resolver(gateway, codec, fold, initial, sliding20m, AccessStrategy.RollingSnapshots snapshot).Resolve(id,?option=opt))
 
 module ContactPreferences =
     let fold, initial = Domain.ContactPreferences.Fold.fold, Domain.ContactPreferences.Fold.initial
     let codec = Domain.ContactPreferences.Events.codec
     let createServiceWithoutOptimization log connection =
         let gateway = createGesGateway connection defaultBatchSize
-        Backend.ContactPreferences.Service(log, Resolver(gateway, codec, fold, initial).Resolve)
+        Backend.ContactPreferences.create log (Resolver(gateway, codec, fold, initial).Resolve)
     let createService log connection =
-        let resolve = Resolver(createGesGateway connection 1, codec, fold, initial, access = AccessStrategy.LatestKnownEvent).Resolve
-        Backend.ContactPreferences.Service(log, resolve)
+        let resolver = Resolver(createGesGateway connection 1, codec, fold, initial, access = AccessStrategy.LatestKnownEvent)
+        Backend.ContactPreferences.create log resolver.Resolve
 
 #nowarn "1182" // From hereon in, we may have some 'unused' privates (the tests)
 
@@ -259,18 +260,17 @@ type Tests(testOutputHelper) =
         let! conn = connectToLocalStore log
         let service = ContactPreferences.createService log conn
 
-        let (Domain.ContactPreferences.Id email) = id
         // Feed some junk into the stream
         for i in 0..11 do
             let quickSurveysValue = i % 2 = 0
-            do! service.Update email { value with quickSurveys = quickSurveysValue }
+            do! service.Update(id, { value with quickSurveys = quickSurveysValue })
         // Ensure there will be something to be changed by the Update below
-        do! service.Update email { value with quickSurveys = not value.quickSurveys }
+        do! service.Update(id, { value with quickSurveys = not value.quickSurveys })
 
         capture.Clear()
-        do! service.Update email value
+        do! service.Update(id, value)
 
-        let! result = service.Read email
+        let! result = service.Read id
         test <@ value = result @>
 
         test <@ batchBackwardsAndAppend @ singleBatchBackwards = capture.ExternalCalls @>

--- a/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
+++ b/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
@@ -4,11 +4,12 @@ open Swensen.Unquote
 open Equinox.MemoryStore
 
 let createMemoryStore () =
-    new VolatileStore<_>()
+    VolatileStore<_>()
 
 let createServiceMemory log store =
-    let resolve (id,opt) = Resolver(store, FsCodec.Box.Codec.Create(), Domain.Cart.Fold.fold, Domain.Cart.Fold.initial).Resolve(id,?option=opt)
-    Backend.Cart.Service(log, resolve)
+    let resolver = Resolver(store, FsCodec.Box.Codec.Create(), Domain.Cart.Fold.fold, Domain.Cart.Fold.initial)
+    let resolve (id,opt) = resolver.Resolve(id,?option=opt)
+    Backend.Cart.create log resolve
 
 #nowarn "1182" // From hereon in, we may have some 'unused' privates (the tests)
 


### PR DESCRIPTION
This PR applies the updated `Category`/`streamName`/`Service`/`create`/`resolve` signatures/idioms throughout the tests, sample aggregates and DOCUMENTATION.md
Related: https://github.com/jet/dotnet-templates/pull/53 https://github.com/jet/dotnet-templates/pull/54
@ylibrach @fnipo