### PR TITLE
Tip compression toggle through optional argument

### DIFF
--- a/src/Equinox.Core/Stream.fs
+++ b/src/Equinox.Core/Stream.fs
@@ -2,15 +2,15 @@
 module Equinox.Core.Stream
 
 /// Represents a specific stream in a ICategory
-type private Stream<'event, 'state, 'streamId, 'context>(category : ICategory<'event, 'state, 'streamId, 'context>, streamId: 'streamId, opt, context) =
+type private Stream<'event, 'state, 'streamId, 'context>(category : ICategory<'event, 'state, 'streamId, 'context>, streamId: 'streamId, opt, context, compress) =
     interface IStream<'event, 'state> with
         member __.Load log =
             category.Load(log, streamId, opt)
 
         member __.TrySync(log: Serilog.ILogger, token: StreamToken, originState: 'state, events: 'event list) =
-            category.TrySync(log, token, originState, events, context)
+            category.TrySync(log, token, originState, events, context, compress)
 
-let create (category : ICategory<'event, 'state, 'streamId, 'context>) streamId opt context : IStream<'event, 'state> = Stream(category, streamId, opt, context) :> _
+let create (category : ICategory<'event, 'state, 'streamId, 'context>) streamId opt context compress : IStream<'event, 'state> = Stream(category, streamId, opt, context, compress) :> _
 
 /// Handles case where some earlier processing has loaded or determined a the state of a stream, allowing us to avoid a read roundtrip
 type private InitializedStream<'event, 'state>(inner : IStream<'event, 'state>, memento : StreamToken * 'state) =

--- a/src/Equinox.Core/Types.fs
+++ b/src/Equinox.Core/Types.fs
@@ -15,7 +15,7 @@ type ICategory<'event, 'state, 'streamId, 'context> =
     /// - Conflict: signifies the sync failed, and the proposed decision hence needs to be reconsidered in light of the supplied conflicting Stream State
     /// NB the central precondition upon which the sync is predicated is that the stream has not diverged from the `originState` represented by `token`
     ///    where the precondition is not met, the SyncResult.Conflict bears a [lazy] async result (in a specific manner optimal for the store)
-    abstract TrySync : log: ILogger * StreamToken * 'state * events: 'event list * 'context option -> Async<SyncResult<'state>>
+    abstract TrySync : log: ILogger * StreamToken * 'state * events: 'event list * 'context option * compress: bool -> Async<SyncResult<'state>>
 
 /// Represents a time measurement of a computation that includes stopwatch tick metadata
 [<NoEquality; NoComparison>]

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -1140,7 +1140,7 @@ type Resolver<'event, 'state, 'context>(context : Context, codec, fold, initial,
         (   streamName : StreamName,
             [<O; D null>]?option,
             [<O; D null>]?context,
-            /// Determines whether the data and metadata payloads on the Tip document are base64 encoded and compressed; defaults to true
+            /// Determines whether the data and metadata payloads of the `u`nfolds in the Tip document are base64 encoded and compressed; defaults to true
             [<O; D true>]?compress) =
         let compress = defaultArg compress true
         match resolveTarget streamName, option with
@@ -1151,7 +1151,7 @@ type Resolver<'event, 'state, 'context>(context : Context, codec, fold, initial,
     member __.FromMemento
         (   Token.Unpack (container,stream,_pos) as streamToken,
             state,
-            /// Determines whether the data and metadata payloads on the Tip document are base64 encoded and compressed; defaults to true
+            /// Determines whether the data and metadata payloads of the `u`nfolds in the Tip document are base64 encoded and compressed; defaults to true
             [<O; D true>]?compress) =
         let skipInitialization = None
         Stream.ofMemento (streamToken,state) (resolveStream ((container,stream),skipInitialization) None None (defaultArg compress true))

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -546,13 +546,14 @@ module Sync =
             u = Array.ofSeq unfolds }
 
     let mkUnfold compress baseIndex (unfolds: IEventData<_> seq) : Unfold seq =
+        let compressor = if compress then JsonCompressedBase64Converter.Compress else id
         unfolds
         |> Seq.mapi (fun offset x ->
             {
                 i = baseIndex + int64 offset
                 c = x.EventType
-                d = x.Data |> if compress then JsonCompressedBase64Converter.Compress else id
-                m = x.Meta |> if compress then JsonCompressedBase64Converter.Compress else id
+                d = compressor x.Data
+                m = compressor x.Meta
                 t = DateTimeOffset.UtcNow
             } : Unfold)
 

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -1136,14 +1136,23 @@ type Resolver<'event, 'state, 'context>(context : Context, codec, fold, initial,
     let resolveTarget = function
         | StreamName.CategoryAndId (categoryName, streamId) -> context.ResolveContainerStream(categoryName, streamId)
 
-    member __.Resolve(streamName : StreamName, [<O; D null>]?option, [<O; D null>]?context, [<O; D true>]?compress) =
+    member __.Resolve
+        (   streamName : StreamName,
+            [<O; D null>]?option,
+            [<O; D null>]?context,
+            /// Determines whether the data and metadata payloads on the Tip document are base64 encoded and compressed; defaults to true
+            [<O; D true>]?compress) =
         let compress = defaultArg compress true
         match resolveTarget streamName, option with
         | streamArgs,(None|Some AllowStale) -> resolveStream streamArgs option context compress
         | (containerStream,maybeInit),Some AssumeEmpty ->
             Stream.ofMemento (Token.create containerStream Position.fromKnownEmpty,initial) (resolveStream (containerStream,maybeInit) option context compress)
 
-    member __.FromMemento(Token.Unpack (container,stream,_pos) as streamToken,state, [<O; D true>]?compress) =
+    member __.FromMemento
+        (   Token.Unpack (container,stream,_pos) as streamToken,
+            state,
+            /// Determines whether the data and metadata payloads on the Tip document are base64 encoded and compressed; defaults to true
+            [<O; D true>]?compress) =
         let skipInitialization = None
         Stream.ofMemento (streamToken,state) (resolveStream ((container,stream),skipInitialization) None None (defaultArg compress true))
 

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -517,8 +517,8 @@ module Caching =
             member __.Load(log, streamName : string, opt) : Async<StreamToken * 'state> =
                 loadAndIntercept (inner.Load(log, streamName, opt)) streamName
 
-            member __.TrySync(log : ILogger, (Token.StreamPos (stream,_) as token), state, events : 'event list, context) : Async<SyncResult<'state>> = async {
-                let! syncRes = inner.TrySync(log, token, state, events, context)
+            member __.TrySync(log : ILogger, (Token.StreamPos (stream,_) as token), state, events : 'event list, context, compress) : Async<SyncResult<'state>> = async {
+                let! syncRes = inner.TrySync(log, token, state, events, context, compress)
                 match syncRes with
                 | SyncResult.Conflict resync -> return SyncResult.Conflict (loadAndIntercept resync stream.name)
                 | SyncResult.Written (token', state') ->
@@ -548,7 +548,7 @@ type private Folder<'event, 'state, 'context>(category : Category<'event, 'state
                 | Some tokenAndState when opt = Some AllowStale -> return tokenAndState
                 | Some (token, state) -> return! category.LoadFromToken fold state streamName token log }
 
-        member __.TrySync(log : ILogger, token, initialState, events : 'event list, context) : Async<SyncResult<'state>> = async {
+        member __.TrySync(log : ILogger, token, initialState, events : 'event list, context, _compress) : Async<SyncResult<'state>> = async {
             let! syncRes = category.TrySync(log, fold, token, initialState, events, context)
             match syncRes with
             | SyncResult.Conflict resync ->         return SyncResult.Conflict resync
@@ -596,12 +596,12 @@ type Resolver<'event, 'state, 'context>
 
     member __.Resolve(streamName : FsCodec.StreamName, [<O; D null>] ?option, [<O; D null>] ?context) =
         match FsCodec.StreamName.toString streamName, option with
-        | sn, (None|Some AllowStale) -> resolveStream sn option context
-        | sn, Some AssumeEmpty -> Stream.ofMemento (loadEmpty sn) (resolveStream sn option context)
+        | sn, (None|Some AllowStale) -> resolveStream sn option context true
+        | sn, Some AssumeEmpty -> Stream.ofMemento (loadEmpty sn) (resolveStream sn option context true)
 
     /// Resolve from a Memento being used in a Continuation [based on position and state typically from Stream.CreateMemento]
     member __.FromMemento(Token.Unpack token as streamToken, state, ?context) =
-        Stream.ofMemento (streamToken, state) (resolveStream token.stream.name context None)
+        Stream.ofMemento (streamToken, state) (resolveStream token.stream.name context None true)
 
 type private SerilogAdapter(log : ILogger) =
     interface EventStore.ClientAPI.ILogger with

--- a/src/Equinox.MemoryStore/MemoryStore.fs
+++ b/src/Equinox.MemoryStore/MemoryStore.fs
@@ -64,7 +64,7 @@ type Category<'event, 'state, 'context, 'Format>(store : VolatileStore<'Format>,
             match store.TryLoad streamName with
             | None -> return Token.ofEmpty streamName initial
             | Some (Decode events) -> return Token.ofEventArray streamName fold initial events }
-        member __.TrySync(_log, Token.Unpack token, state, events : 'event list, context : 'context option) = async {
+        member __.TrySync(_log, Token.Unpack token, state, events : 'event list, context : 'context option, _compress) = async {
             let inline map i (e : FsCodec.IEventData<'Format>) =
                 FsCodec.Core.TimelineEvent.Create(int64 i, e.EventType, e.Data, e.Meta, e.EventId, e.CorrelationId, e.CausationId, e.Timestamp)
             let encoded : FsCodec.ITimelineEvent<_>[] = events |> Seq.mapi (fun i e -> map (token.streamVersion+i) (codec.Encode(context,e))) |> Array.ofSeq
@@ -82,7 +82,7 @@ type Category<'event, 'state, 'context, 'Format>(store : VolatileStore<'Format>,
 
 type Resolver<'event, 'state, 'Format, 'context>(store : VolatileStore<'Format>, codec : FsCodec.IEventCodec<'event,'Format,'context>, fold, initial) =
     let category = Category<'event, 'state, 'context, 'Format>(store, codec, fold, initial)
-    let resolveStream streamName context = Stream.create category streamName None context
+    let resolveStream streamName context = Stream.create category streamName None context true
     member __.Resolve(streamName : FsCodec.StreamName, [<Optional; DefaultParameterValue null>] ?option, [<Optional; DefaultParameterValue null>] ?context : 'context) =
         match FsCodec.StreamName.toString streamName, option with
         | sn, (None|Some AllowStale) -> resolveStream sn context

--- a/src/Equinox.SqlStreamStore/SqlStreamStore.fs
+++ b/src/Equinox.SqlStreamStore/SqlStreamStore.fs
@@ -474,8 +474,8 @@ module Caching =
         interface ICategory<'event, 'state, string, 'context> with
             member __.Load(log, streamName : string, opt) : Async<StreamToken * 'state> =
                 loadAndIntercept (inner.Load(log, streamName, opt)) streamName
-            member __.TrySync(log : ILogger, (Token.StreamPos (stream,_) as token), state, events : 'event list, context) : Async<SyncResult<'state>> = async {
-                let! syncRes = inner.TrySync(log, token, state, events, context)
+            member __.TrySync(log : ILogger, (Token.StreamPos (stream,_) as token), state, events : 'event list, context, compress) : Async<SyncResult<'state>> = async {
+                let! syncRes = inner.TrySync(log, token, state, events, context, compress)
                 match syncRes with
                 | SyncResult.Conflict resync -> return SyncResult.Conflict (loadAndIntercept resync stream.name)
                 | SyncResult.Written (token',state') ->
@@ -504,7 +504,7 @@ type private Folder<'event, 'state, 'context>(category : Category<'event, 'state
                 | None -> return! batched log streamName
                 | Some tokenAndState when opt = Some AllowStale -> return tokenAndState
                 | Some (token, state) -> return! category.LoadFromToken fold state streamName token log }
-        member __.TrySync(log : ILogger, token, initialState, events : 'event list, context) : Async<SyncResult<'state>> = async {
+        member __.TrySync(log : ILogger, token, initialState, events : 'event list, context, _compress) : Async<SyncResult<'state>> = async {
             let! syncRes = category.TrySync(log, fold, token, initialState, events, context)
             match syncRes with
             | SyncResult.Conflict resync ->         return SyncResult.Conflict resync
@@ -547,12 +547,12 @@ type Resolver<'event, 'state, 'context>
     let loadEmpty sn = context.LoadEmpty sn,initial
     member __.Resolve(streamName : FsCodec.StreamName, [<O; D null>]?option, [<O; D null>]?context) =
         match FsCodec.StreamName.toString streamName, option with
-        | sn, (None|Some AllowStale) -> resolveStream sn option context
-        | sn, Some AssumeEmpty -> Stream.ofMemento (loadEmpty sn) (resolveStream sn option context)
+        | sn, (None|Some AllowStale) -> resolveStream sn option context true
+        | sn, Some AssumeEmpty -> Stream.ofMemento (loadEmpty sn) (resolveStream sn option context true)
 
     /// Resolve from a Memento being used in a Continuation [based on position and state typically from Stream.CreateMemento]
     member __.FromMemento(Token.Unpack token as streamToken, state, ?context) =
-        Stream.ofMemento (streamToken,state) (resolveStream token.stream.name context None)
+        Stream.ofMemento (streamToken,state) (resolveStream token.stream.name context None true)
 
 [<AbstractClass>]
 type ConnectorBase([<O; D(null)>]?readRetryPolicy, [<O; D(null)>]?writeRetryPolicy) =

--- a/tests/Equinox.Cosmos.Integration/JsonConverterTests.fs
+++ b/tests/Equinox.Cosmos.Integration/JsonConverterTests.fs
@@ -1,6 +1,7 @@
 ﻿module Equinox.Cosmos.Integration.JsonConverterTests
 
 open Equinox.Cosmos
+open Equinox.Cosmos.Store
 open FsCheck.Xunit
 open Swensen.Unquote
 open System
@@ -18,20 +19,29 @@ let defaultOptions = FsCodec.SystemTextJson.Options.Create()
 type Base64ZipUtf8Tests() =
     let eventCodec = FsCodec.SystemTextJson.Codec.Create<Union>(defaultOptions)
 
-    [<Fact>]
-    let ``serializes, achieving compression`` () =
-        let encoded = eventCodec.Encode(None,A { embed = String('x',5000) })
+    [<Property>]
+    let ``Can read compressed`` value =
+        let hasNulls =
+            match value with
+            | A x | B x when obj.ReferenceEquals(null, x) -> true
+            | A { embed = x } | B { embed = x } -> obj.ReferenceEquals(null, x)
+        if hasNulls then () else
+
+        let encoded = eventCodec.Encode(None,value)
         let e : Store.Unfold =
             {   i = 42L
                 c = encoded.EventType
-                d = encoded.Data
+                d = JsonCompressedBase64Converter.Compress encoded.Data
                 m = Unchecked.defaultof<JsonElement>
                 t = DateTimeOffset.MinValue }
-        let res = FsCodec.SystemTextJson.Serdes.Serialize(e, defaultOptions)
-        test <@ res.Contains("\"d\":\"") && res.Length < 138 @>
+        let ser = FsCodec.SystemTextJson.Serdes.Serialize(e, defaultOptions)
+        let des = FsCodec.SystemTextJson.Serdes.Deserialize<Store.Unfold>(ser, defaultOptions)
+        let d = FsCodec.Core.TimelineEvent.Create(-1L, des.c, des.d)
+        let decoded = eventCodec.TryDecode d |> Option.get
+        test <@ value = decoded @>
 
     [<Property>]
-    let roundtrips value =
+    let ``Can read uncompressed`` value =
         let hasNulls =
             match value with
             | A x | B x when obj.ReferenceEquals(null, x) -> true
@@ -46,7 +56,6 @@ type Base64ZipUtf8Tests() =
                 m = Unchecked.defaultof<JsonElement>
                 t = DateTimeOffset.MinValue }
         let ser = FsCodec.SystemTextJson.Serdes.Serialize(e, defaultOptions)
-        test <@ ser.Contains("\"d\":\"") @>
         let des = FsCodec.SystemTextJson.Serdes.Deserialize<Store.Unfold>(ser, defaultOptions)
         let d = FsCodec.Core.TimelineEvent.Create(-1L, des.c, des.d)
         let decoded = eventCodec.TryDecode d |> Option.get

--- a/tests/Equinox.Cosmos.Integration/JsonConverterTests.fs
+++ b/tests/Equinox.Cosmos.Integration/JsonConverterTests.fs
@@ -20,7 +20,7 @@ type Base64ZipUtf8Tests() =
     let eventCodec = FsCodec.SystemTextJson.Codec.Create<Union>(defaultOptions)
 
     [<Property>]
-    let ``Can read compressed`` value =
+    let ``Can read uncompressed and compressed`` compress value =
         let hasNulls =
             match value with
             | A x | B x when obj.ReferenceEquals(null, x) -> true
@@ -28,31 +28,11 @@ type Base64ZipUtf8Tests() =
         if hasNulls then () else
 
         let encoded = eventCodec.Encode(None,value)
+        let compressor = if compress then JsonCompressedBase64Converter.Compress else id
         let e : Store.Unfold =
             {   i = 42L
                 c = encoded.EventType
-                d = JsonCompressedBase64Converter.Compress encoded.Data
-                m = Unchecked.defaultof<JsonElement>
-                t = DateTimeOffset.MinValue }
-        let ser = FsCodec.SystemTextJson.Serdes.Serialize(e, defaultOptions)
-        let des = FsCodec.SystemTextJson.Serdes.Deserialize<Store.Unfold>(ser, defaultOptions)
-        let d = FsCodec.Core.TimelineEvent.Create(-1L, des.c, des.d)
-        let decoded = eventCodec.TryDecode d |> Option.get
-        test <@ value = decoded @>
-
-    [<Property>]
-    let ``Can read uncompressed`` value =
-        let hasNulls =
-            match value with
-            | A x | B x when obj.ReferenceEquals(null, x) -> true
-            | A { embed = x } | B { embed = x } -> obj.ReferenceEquals(null, x)
-        if hasNulls then () else
-
-        let encoded = eventCodec.Encode(None,value)
-        let e : Store.Unfold =
-            {   i = 42L
-                c = encoded.EventType
-                d = encoded.Data
+                d = compressor encoded.Data
                 m = Unchecked.defaultof<JsonElement>
                 t = DateTimeOffset.MinValue }
         let ser = FsCodec.SystemTextJson.Serdes.Serialize(e, defaultOptions)


### PR DESCRIPTION
This PR adds an optional `compress` argument to the `Resolver`'s `Resolve` method, which defaults to `true`. Setting it to `false` will make it so that the data and metadata payloads of the `Unfold` within the `Tip` are stored in CosmosDB as uncompressed and unencoded.