### PR TITLE
feat(EventStoreDb): Add AccessStrategy.CustomOrigin

### DIFF
--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -446,6 +446,9 @@ type AccessStrategy<'event,'state> =
     /// Scanning for events concludes when any event passes the <c>isOrigin</c> test.
     /// See https://eventstore.org/docs/event-sourcing-basics/rolling-snapshots/index.html
     | RollingSnapshots of isOrigin : ('event -> bool) * toSnapshot : ('state -> 'event)
+    /// Customize the loading process, walking events toward the the oldest one (in batches)
+    /// Short-circuits if the supplied `isOrigin` identifies the given event as being a valid alternate starting point
+    | CustomOrigin of isOrigin : ('event -> bool)
 
 type private CompactionContext(eventsLen : int, capacityBeforeCompaction : int) =
     /// Determines whether writing a Compaction event is warranted (based on the existing state and the current accumulated changes)
@@ -456,22 +459,21 @@ type private Category<'event, 'state, 'context>(context : Context, codec : FsCod
 
     let compactionPredicate =
         match access with
-        | None -> None
+        | None | Some (AccessStrategy.CustomOrigin _) -> None
         | Some AccessStrategy.LatestKnownEvent -> Some (fun _ -> true)
         | Some (AccessStrategy.RollingSnapshots (isValid, _)) -> Some isValid
 
     let isOrigin =
         match access with
         | None | Some AccessStrategy.LatestKnownEvent -> fun _ -> true
-        | Some (AccessStrategy.RollingSnapshots (isValid, _)) -> isValid
+        | Some (AccessStrategy.RollingSnapshots (isValid, _)) | Some (AccessStrategy.CustomOrigin isValid) -> isValid
 
     let loadAlgorithm load streamName initial log =
         let batched = load initial (context.LoadBatched streamName log (tryDecode,None))
         let compacted = load initial (context.LoadBackwardsStoppingAtCompactionEvent streamName log (tryDecode, isOrigin))
         match access with
         | None -> batched
-        | Some AccessStrategy.LatestKnownEvent
-        | Some (AccessStrategy.RollingSnapshots _) -> compacted
+        | Some AccessStrategy.LatestKnownEvent | Some (AccessStrategy.RollingSnapshots _) | Some (AccessStrategy.CustomOrigin _) -> compacted
 
     let load (fold : 'state -> 'event seq -> 'state) initial f = async {
         let! token, events = f
@@ -489,7 +491,7 @@ type private Category<'event, 'state, 'context>(context : Context, codec : FsCod
         let encode e = codec.Encode(ctx, e)
         let events =
             match access with
-            | None | Some AccessStrategy.LatestKnownEvent -> events
+            | None | Some AccessStrategy.LatestKnownEvent | Some (AccessStrategy.CustomOrigin _) -> events
             | Some (AccessStrategy.RollingSnapshots (_, compact)) ->
                 let cc = CompactionContext(List.length events, pos.batchCapacityLimit.Value)
                 if cc.IsCompactionDue then events @ [fold state events |> compact] else events


### PR DESCRIPTION
Provides a `Equinox.EventStore.AccessStrategy.CustomOrigin` which would be useful in the context of https://github.com/jet/dotnet-templates/pull/40 to enable a custom lookback on a long-running stream (without employing the snapshots strategy).

🤔 Still mulling over whether this is truly a good idea to expose in Equinox