### PR TITLE
Pin EventStore.Client to [5.0.1,6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+- `EventStore`: Pin `EventStore.Client` to `[5.0.1,6)` to reject conflicting changes in `EventStore.Client` v `20.06` [#223](https://github.com/jet/equinox/pull/223)
+
 <a name="2.1.0"></a>
 ## [2.1.0] - 2020-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
-- `EventStore`: Pin `EventStore.Client` to `[5.0.1,6)` to reject conflicting changes in `EventStore.Client` v `20.06` [#223](https://github.com/jet/equinox/pull/223)
+- `EventStore`: Pin `EventStore.Client` to `[5.0.1,6)` to avoid conflicting changes in `EventStore.Client` v `20.06` [#223](https://github.com/jet/equinox/pull/223)
 
 <a name="2.1.0"></a>
 ## [2.1.0] - 2020-05-22

--- a/src/Equinox.EventStore/Equinox.EventStore.fsproj
+++ b/src/Equinox.EventStore/Equinox.EventStore.fsproj
@@ -25,7 +25,7 @@
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' != 'netstandard2.0' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
 
-    <PackageReference Include="EventStore.Client" Version="5.0.1" />
+    <PackageReference Include="EventStore.Client" Version="[5.0.1,6)" />
     <PackageReference Include="FsCodec" Version="2.0.0" />
     <PackageReference Include="FSharp.Control.AsyncSeq" Version="2.0.23" />
   </ItemGroup>


### PR DESCRIPTION
The next version (`20.6`) brings breaking changes - this will go first to `master`, and then will be cherry-picked onto the `v2` branch