### PR TITLE
Update to EventStore.Client >= 20.06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
-- now targets `Microsoft.Azure.Cosmos` v `3.9.0` (instead of `Microsoft.Azure.DocumentDB`[`.Core`] v 2.x) [#144](https://github.com/jet/equinox/pull/144)
+- targets `Microsoft.Azure.Cosmos` v `3.9.0` (instead of `Microsoft.Azure.DocumentDB`[`.Core`] v 2.x) [#144](https://github.com/jet/equinox/pull/144)
+- targets `EventStore.Client` v `20.6` (instead of v `5.0.x`) [#224](https://github.com/jet/equinox/pull/224)
 
 ### Changed
 

--- a/src/Equinox.EventStore/Equinox.EventStore.fsproj
+++ b/src/Equinox.EventStore/Equinox.EventStore.fsproj
@@ -25,7 +25,7 @@
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' != 'netstandard2.0' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
 
-    <PackageReference Include="EventStore.Client" Version="[5.0.1,6)" />
+    <PackageReference Include="EventStore.Client" Version="20.6.0" />
     <PackageReference Include="FsCodec" Version="2.0.0" />
     <PackageReference Include="FSharp.Control.AsyncSeq" Version="2.0.23" />
   </ItemGroup>


### PR DESCRIPTION
Equinox.EventStore 2.x (released from `v2` branch) references EventStore.Client 5.x (see also #223, which pins the upper limit to < 6.x to prevent using 20.x)

Equinox.EventStore 3.x will from now depend on `EventStore.Client` v `>= 20.6`

Note [the `EventStore.Client` API is deprecated from an EventStore perspective](https://eventstore.com/blog/event-store-20.6.0-release/), and there'll likely be an `Equinox.EventStore.Grpc` that uses the new API in due course (WIP: https://github.com/jet/equinox/pull/196)