### PR TITLE
Add AsyncBatchingGate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
+- Add `AsyncBatchingGate` [#228](https://github.com/jet/equinox/pull/228)
 - now targets `Microsoft.Azure.Cosmos` v `3.9.0` (instead of `Microsoft.Azure.DocumentDB`[`.Core`] v 2.x) [#144](https://github.com/jet/equinox/pull/144)
 
 ### Changed

--- a/src/Equinox.Core/AsyncBatchingGate.fs
+++ b/src/Equinox.Core/AsyncBatchingGate.fs
@@ -1,0 +1,55 @@
+namespace Equinox.Core
+
+/// Thread-safe coordinator that batches concurrent requests for a single <c>dispatch</> invocation such that:
+/// - requests arriving together can be coalesced into the batch during the linger period via TryAdd
+/// - callers that have had items admitted can concurrently await the shared fate of the dispatch via AwaitResult
+/// - callers whose TryAdd has been denied can await the completion of the in-flight batch via AwaitCompletion
+type internal AsyncBatch<'Req, 'Res>(dispatch : 'Req[] -> Async<'Res>, linger : System.TimeSpan) =
+    let lingerMs = int linger.TotalMilliseconds
+    // Yes, naive impl in the absence of a cleaner way to have callers sharing the AwaitCompletion coordinate the adding
+    do if lingerMs < 5 then invalidArg "linger" "must be >= 5ms"
+    let queue = new System.Collections.Concurrent.BlockingCollection<'Req>()
+    let dispatch = async {
+        do! Async.Sleep lingerMs
+        queue.CompleteAdding()
+        let reqs = queue.ToArray()
+        return! dispatch reqs
+    }
+    let task = lazy (Async.StartAsTask dispatch)
+
+    /// Attempt to add a request to the flight
+    /// Succeeds during linger interval (which commences when the first caller triggers the dispatch via AwaitResult)
+    /// Fails if this flight has closed (caller should generate a fresh, potentially after awaiting this.AwaitCompletion)
+    member __.TryAdd(item) =
+        if queue.IsAddingCompleted then false else
+
+        // there's a race between the IsAddingCompleted check outcome and the CompleteAdding
+        // sadly there's no way to detect without a try/catch
+        try queue.TryAdd(item)
+        with :? System.InvalidOperationException -> false
+
+    /// Await the outcome of dispatching the batch (on the basis that the caller has contributed a request to it)
+    member __.AwaitResult() = Async.AwaitTaskCorrect task.Value
+
+    /// Wait for dispatch to conclude (for any reason: ok/exn/cancel; we only care about the channel being clear)
+    member __.AwaitCompletion() =
+        Async.FromContinuations(fun (cont, _, _) ->
+            task.Value.ContinueWith(fun (_ : System.Threading.Tasks.Task<'Res>) -> cont ())
+            |> ignore)
+
+/// Manages concurrent work such that requests arriving while a batch is in flight converge to wait for the next window
+type AsyncBatchingGate<'Req, 'Res>(dispatch : 'Req[] -> Async<'Res>, ?linger) =
+    let mkBatch () = AsyncBatch(dispatch, defaultArg linger (System.TimeSpan.FromMilliseconds 5.))
+    let mutable cell = mkBatch()
+
+    member __.Execute req = async {
+        let current = cell
+        // If current has not yet been dispatched, hop on and join
+        if current.TryAdd req then
+            return! current.AwaitResult()
+        else // Any thread that discovers a batch in flight, needs to wait for it to conclude first
+            do! current.AwaitCompletion()
+            // where competing threads discover a closed flight, we only want a single one to regenerate it
+            let _ = System.Threading.Interlocked.CompareExchange(&cell, mkBatch (), current)
+            return! __.Execute req
+    }

--- a/src/Equinox.Core/AsyncBatchingGate.fs
+++ b/src/Equinox.Core/AsyncBatchingGate.fs
@@ -7,7 +7,7 @@ namespace Equinox.Core
 type internal AsyncBatch<'Req, 'Res>(dispatch : 'Req[] -> Async<'Res>, linger : System.TimeSpan) =
     let lingerMs = int linger.TotalMilliseconds
     // Yes, naive impl in the absence of a cleaner way to have callers sharing the AwaitCompletion coordinate the adding
-    do if lingerMs < 5 then invalidArg "linger" "must be >= 5ms"
+    do if lingerMs < 1 then invalidArg "linger" "must be >= 1ms"
     let queue = new System.Collections.Concurrent.BlockingCollection<'Req>()
     let workflow = async {
         do! Async.Sleep lingerMs

--- a/src/Equinox.Core/Equinox.Core.fsproj
+++ b/src/Equinox.Core/Equinox.Core.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="Retry.fs" />
     <Compile Include="AsyncCacheCell.fs" />
     <Compile Include="Cache.fs" />
+    <Compile Include="AsyncBatchingGate.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Equinox.Cosmos.Integration/AsyncBatchingGateTests.fs
+++ b/tests/Equinox.Cosmos.Integration/AsyncBatchingGateTests.fs
@@ -1,0 +1,50 @@
+module Equinox.CosmosStore.Integration.AsyncBatchingGateTests
+
+open System
+open System.Collections.Concurrent
+open System.Threading.Tasks
+open Equinox.Core
+open FsCheck.Xunit
+open Swensen.Unquote
+open System.Threading
+open Xunit
+
+[<Fact>]
+let ``AsyncBatchingGate correctness`` () = async {
+    let batches, active = ref 0, ref 0
+    let dispatch (reqs : int[]) = async {
+        let concurrency = Interlocked.Increment active
+        1 =! concurrency
+        Interlocked.Increment batches |> ignore
+        do! Async.Sleep(10 * reqs.Length)
+        let concurrency = Interlocked.Decrement active
+        0 =! concurrency
+        return reqs
+    }
+    let cell = AsyncBatchingGate dispatch
+    let! results = [1 .. 100] |> Seq.map cell.Execute |> Async.Parallel
+    test <@ set (Seq.collect id results) = set [1 .. 100] @>
+    // Default linger of 5ms makes this tend strongly to only be 1 batch
+    test <@ !batches < 2 @>
+}
+
+[<Property>]
+let ``AsyncBatchingGate error handling`` shouldFail = Async.RunSynchronously <| async {
+    let fails = ConcurrentBag() // Could be a ResizeArray per spec, but this removes all doubt
+    let dispatch (reqs : int[]) = async {
+        if shouldFail () then
+            reqs |> Seq.iter fails.Add
+            failwithf "failing %A" reqs
+        return reqs
+    }
+    let cell = AsyncBatchingGate dispatch
+    let input = [1 .. 100]
+    let! results = input |> Seq.map (cell.Execute >> Async.Catch) |> Async.Parallel
+    let oks = results |> Array.choose (function Choice1Of2 r -> Some r | _ -> None)
+    // Note extraneous exceptions we encounter (e.g. if we remove the catch in TryAdd)
+    let cancels = results |> Array.choose (function Choice2Of2 e when not (e.Message.Contains "failing") -> Some e | _ -> None)
+    let inputs, outputs = set input, set (Seq.collect id oks |> Seq.append fails)
+    test <@ inputs.Count = outputs.Count
+            && Array.isEmpty cancels
+            && inputs = outputs @>
+}

--- a/tests/Equinox.Cosmos.Integration/Equinox.Cosmos.Integration.fsproj
+++ b/tests/Equinox.Cosmos.Integration/Equinox.Cosmos.Integration.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="CosmosCoreIntegration.fs" />
     <Compile Include="JsonConverterTests.fs" />
     <Compile Include="CacheCellTests.fs" />
+    <Compile Include="AsyncBatchingGateTests.fs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Helper primitive that can be used to constrain contention where multiple threads are targeting a single upstream.

The specific need at hand is where multiple threads in a projector are transacting against the same aggregate. In such a case the duelling transactions trigger `Equinox.Cosmos` `Resync` operations / ESDB `WrongExpectedVersion` which increases load for the upstream, in addition to increasing latency due to having to retry.

-----
Like `AsyncCacheCell` (although that's slightly more justifiable given its used in the impl of Equinox.Cosmos), these helpers are generic; the happen to be useful in typical Concurrent Transaction processing work, but are not "part of Equinox". Hosting this in Equinox.Core is thus not a long term plan - ideally these primitives ultimately end up with their own home at some point (not dissimilar to how Equinox.Codec moved out to FsCodec).