### PR TITLE
Simplify AsyncCacheCell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - Remove `module Commands` convention from in examples
 - Revise semantics of Cart Sample Command handling
 - `Cosmos:` Removed [warmup call](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/1436)
-- Simplify `AsyncCacheCell`
+- Simplify `AsyncCacheCell` [#229](https://github.com/jet/equinox/pull/229)
 
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - Remove `module Commands` convention from in examples
 - Revise semantics of Cart Sample Command handling
 - `Cosmos:` Removed [warmup call](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/1436)
+- Simplify `AsyncCacheCell`
 
 ### Removed
 ### Fixed

--- a/src/Equinox.Core/AsyncCacheCell.fs
+++ b/src/Equinox.Core/AsyncCacheCell.fs
@@ -7,8 +7,6 @@ type AsyncLazy<'T>(workflow : Async<'T>) =
     member __.AwaitValue() = Async.AwaitTaskCorrect task.Value
     // Used to rule out values where the computation yielded an exception or the result has now expired
     member internal this.TryValidate(?isExpired) : Async<'T option> = async {
-        if not task.IsValueCreated then return None else
-
         // Determines if the last attempt completed, but failed; For TMI see https://stackoverflow.com/a/33946166/11635
         let value = task.Value
         if value.IsCompleted && value.Status <> System.Threading.Tasks.TaskStatus.RanToCompletion then return None else

--- a/src/Equinox.Core/AsyncCacheCell.fs
+++ b/src/Equinox.Core/AsyncCacheCell.fs
@@ -1,47 +1,37 @@
 namespace Equinox.Core
 
-/// Asynchronous Lazy<'T> that guarantees workflow will be executed at most once.
+/// Asynchronous Lazy<'T> used to gate a workflow to ensure at most one in-flight computation.
 type AsyncLazy<'T>(workflow : Async<'T>) =
-    let task = lazy(Async.StartAsTask workflow)
+    let task = lazy (Async.StartAsTask workflow)
+
     member __.AwaitValue() = Async.AwaitTaskCorrect task.Value
-    member internal __.PeekInternalTask = task
+    // Used to rule out values where the computation yielded an exception or the result has now expired
+    member internal this.TryValidate(?isExpired) : Async<'T option> = async {
+        if not task.IsValueCreated then return None else
+
+        // Determines if the last attempt completed, but failed; For TMI see https://stackoverflow.com/a/33946166/11635
+        let value = task.Value
+        if value.IsCompleted && value.Status <> System.Threading.Tasks.TaskStatus.RanToCompletion then return None else
+
+        let! result = this.AwaitValue()
+        match isExpired with
+        | Some f when f result -> return None
+        | _ -> return Some result
+    }
 
 /// Generic async lazy caching implementation that admits expiration/recomputation semantics
 /// If `workflow` fails, all readers entering while the load/refresh is in progress will share the failure
 type AsyncCacheCell<'T>(workflow : Async<'T>, ?isExpired : 'T -> bool) =
-    let mutable currentCell = AsyncLazy workflow
-
-    let initializationFailed (value : System.Threading.Tasks.Task<_>) =
-        // for TMI on this, see https://stackoverflow.com/a/33946166/11635
-        value.IsCompleted && value.Status <> System.Threading.Tasks.TaskStatus.RanToCompletion
-
-    let update cell = async {
-        // avoid unnecessary recomputation in cases where competing threads detect expiry;
-        // the first write attempt wins, and everybody else reads off that value
-        let _ = System.Threading.Interlocked.CompareExchange(&currentCell, AsyncLazy workflow, cell)
-        return! currentCell.AwaitValue()
-    }
-
-    /// Enables callers to short-circuit the gate by checking whether a value has been computed
-    member __.PeekIsValid() =
-        let cell = currentCell
-        let currentState = cell.PeekInternalTask
-        if not currentState.IsValueCreated then false else
-
-        let value = currentState.Value
-        not (initializationFailed value)
-        && (match isExpired with Some f -> not (f value.Result) | _ -> false)
+    let mutable cell = AsyncLazy workflow
 
     /// Gets or asynchronously recomputes a cached value depending on expiry and availability
     member __.AwaitValue() = async {
-        let cell = currentCell
-        let currentState = cell.PeekInternalTask
-        // If the last attempt completed, but failed, we need to treat it as expired
-        if currentState.IsValueCreated && initializationFailed currentState.Value then
-            return! update cell
-        else
-            let! current = cell.AwaitValue()
-            match isExpired with
-            | Some f when f current -> return! update cell
-            | _ -> return current
+        let current = cell
+        match! current.TryValidate(?isExpired=isExpired) with
+        | Some res -> return res
+        | None ->
+            // avoid unnecessary recomputation in cases where competing threads detect expiry;
+            // the first write attempt wins, and everybody else reads off that value
+            let _ = System.Threading.Interlocked.CompareExchange(&cell, AsyncLazy workflow, current)
+            return! cell.AwaitValue()
     }

--- a/src/Equinox.Core/AsyncCacheCell.fs
+++ b/src/Equinox.Core/AsyncCacheCell.fs
@@ -1,10 +1,13 @@
 namespace Equinox.Core
 
-/// Asynchronous Lazy<'T> used to gate a workflow to ensure at most one in-flight computation.
+/// Asynchronous Lazy<'T> used to gate a workflow to ensure at most once execution of a computation.
 type AsyncLazy<'T>(workflow : Async<'T>) =
     let task = lazy (Async.StartAsTask workflow)
 
+    /// Await the outcome of the computation.
+    /// NOTE due to `Lazy<T>` semantics, failed attempts will cache any exception; AsyncCacheCell compensates for this
     member __.AwaitValue() = Async.AwaitTaskCorrect task.Value
+
     /// Synchronously check whether the value has been computed (and/or remains valid)
     member this.IsValid(?isExpired) =
         if not task.IsValueCreated then false else
@@ -17,7 +20,7 @@ type AsyncLazy<'T>(workflow : Async<'T>) =
         | _ -> true
 
     /// Used to rule out values where the computation yielded an exception or the result has now expired
-    member internal this.TryValidate(?isExpired) : Async<'T option> = async {
+    member this.TryAwaitValid(?isExpired) : Async<'T option> = async {
         // Determines if the last attempt completed, but failed; For TMI see https://stackoverflow.com/a/33946166/11635
         if task.Value.IsFaulted then return None else
 
@@ -27,8 +30,9 @@ type AsyncLazy<'T>(workflow : Async<'T>) =
         | _ -> return Some result
     }
 
-/// Generic async lazy caching implementation that admits expiration/recomputation semantics
+/// Generic async lazy caching implementation that admits expiration/recomputation/retry on exception semantics.
 /// If `workflow` fails, all readers entering while the load/refresh is in progress will share the failure
+/// The first caller through the gate triggers a recomputation attempt if the previous attempt ended in failure
 type AsyncCacheCell<'T>(workflow : Async<'T>, ?isExpired : 'T -> bool) =
     let mutable cell = AsyncLazy workflow
 
@@ -37,7 +41,7 @@ type AsyncCacheCell<'T>(workflow : Async<'T>, ?isExpired : 'T -> bool) =
     /// Gets or asynchronously recomputes a cached value depending on expiry and availability
     member __.AwaitValue() = async {
         let current = cell
-        match! current.TryValidate(?isExpired=isExpired) with
+        match! current.TryAwaitValid(?isExpired=isExpired) with
         | Some res -> return res
         | None ->
             // avoid unnecessary recomputation in cases where competing threads detect expiry;

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -945,7 +945,7 @@ type private ContainerWrapper(container : Container, ?initContainer : Container 
     let initGuard = initContainer |> Option.map (fun init -> AsyncCacheCell<unit>(init container))
 
     member __.Container = container
-    member internal __.InitializationGate = match initGuard with Some g when g.PeekIsValid() |> not -> Some g.AwaitValue | _ -> None
+    member internal __.InitializationGate = match initGuard with Some g -> Some g.AwaitValue | _ -> None
 
 /// Defines a process for mapping from a Stream Name to the appropriate storage area, allowing control over segregation / co-locating of data
 type Containers(categoryAndIdToDatabaseContainerStream : string -> string -> string*string*string, [<O; D(null)>]?disableInitialization) =

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -945,7 +945,7 @@ type private ContainerWrapper(container : Container, ?initContainer : Container 
     let initGuard = initContainer |> Option.map (fun init -> AsyncCacheCell<unit>(init container))
 
     member __.Container = container
-    member internal __.InitializationGate = match initGuard with Some g -> Some g.AwaitValue | _ -> None
+    member internal __.InitializationGate = match initGuard with Some g when not (g.IsValid()) -> Some g.AwaitValue | _ -> None
 
 /// Defines a process for mapping from a Stream Name to the appropriate storage area, allowing control over segregation / co-locating of data
 type Containers(categoryAndIdToDatabaseContainerStream : string -> string -> string*string*string, [<O; D(null)>]?disableInitialization) =

--- a/tests/Equinox.Cosmos.Integration/CacheCellTests.fs
+++ b/tests/Equinox.Cosmos.Integration/CacheCellTests.fs
@@ -1,6 +1,5 @@
 ﻿module Equinox.Cosmos.Integration.CacheCellTests
 
-open Domain.ContactPreferences.Events
 open Equinox.Core
 open Swensen.Unquote
 open System
@@ -13,9 +12,10 @@ let ``AsyncLazy correctness`` () = async {
     let count = ref 0
     let cell = AsyncLazy (async { return Interlocked.Increment count })
     false =! cell.IsValid()
-    let! accessResult = [|1 .. 100|] |> Array.map (fun i -> cell.AwaitValue ()) |> Async.Parallel
+    let! accessResult = [|1 .. 100|] |> Array.map (fun _ -> cell.AwaitValue()) |> Async.Parallel
     true =! cell.IsValid()
-    test <@ accessResult |> Array.forall ((=) 1) @> }
+    test <@ accessResult |> Array.forall ((=) 1) @>
+}
 
 [<Fact>]
 let ``AsyncCacheCell correctness`` () = async {
@@ -25,13 +25,13 @@ let ``AsyncCacheCell correctness`` () = async {
     let cell = AsyncCacheCell (async { return Interlocked.Increment state }, fun value -> value <> !expectedValue)
     false =! cell.IsValid()
 
-    let! accessResult = [|1 .. 100|] |> Array.map (fun _i -> cell.AwaitValue ()) |> Async.Parallel
+    let! accessResult = [|1 .. 100|] |> Array.map (fun _i -> cell.AwaitValue()) |> Async.Parallel
     test <@ accessResult |> Array.forall ((=) 1) @>
     true =! cell.IsValid()
 
     incr expectedValue
 
-    let! accessResult = [|1 .. 100|] |> Array.map (fun _i -> cell.AwaitValue ()) |> Async.Parallel
+    let! accessResult = [|1 .. 100|] |> Array.map (fun _i -> cell.AwaitValue()) |> Async.Parallel
     test <@ accessResult |> Array.forall ((=) 2) @>
     true =! cell.IsValid()
 }
@@ -56,7 +56,7 @@ let ``AsyncCacheCell correctness with throwing`` initiallyThrowing = async {
     // If the runner is throwing, we want to be sure it doesn't place us in a failed state forever, per the semantics of Lazy<T>
     // However, we _do_ want to be sure that the function only runs once
     if initiallyThrowing then
-        let! accessResult = [|1 .. 10|] |> Array.map (fun _ -> cell.AwaitValue () |> Async.Catch) |> Async.Parallel
+        let! accessResult = [|1 .. 10|] |> Array.map (fun _ -> cell.AwaitValue() |> Async.Catch) |> Async.Parallel
         test <@ accessResult |> Array.forall (function Choice2Of2 (:? InvalidOperationException) -> true | _ -> false) @>
         throwing <- false
         false =! cell.IsValid()
@@ -67,7 +67,7 @@ let ``AsyncCacheCell correctness with throwing`` initiallyThrowing = async {
 
     incr expectedValue
 
-    let! accessResult = [|1 .. 100|] |> Array.map (fun _ -> cell.AwaitValue ()) |> Async.Parallel
+    let! accessResult = [|1 .. 100|] |> Array.map (fun _ -> cell.AwaitValue()) |> Async.Parallel
     test <@ accessResult |> Array.forall ((=) 2) @>
     true =! cell.IsValid()
 
@@ -77,7 +77,7 @@ let ``AsyncCacheCell correctness with throwing`` initiallyThrowing = async {
     // but make the computation ultimately fail
     throwing <- true
     // All share the failure
-    let! accessResult = [|1 .. 10|] |> Array.map (fun _ -> cell.AwaitValue () |> Async.Catch) |> Async.Parallel
+    let! accessResult = [|1 .. 10|] |> Array.map (fun _ -> cell.AwaitValue() |> Async.Catch) |> Async.Parallel
     test <@ accessResult |> Array.forall (function Choice2Of2 (:? InvalidOperationException) -> true | _ -> false) @>
     // Restore normality
     throwing <- false
@@ -85,7 +85,7 @@ let ``AsyncCacheCell correctness with throwing`` initiallyThrowing = async {
 
     incr expectedValue
 
-    let! accessResult = [|1 .. 10|] |> Array.map (fun _ -> cell.AwaitValue ()) |> Async.Parallel
+    let! accessResult = [|1 .. 10|] |> Array.map (fun _ -> cell.AwaitValue()) |> Async.Parallel
     test <@ accessResult |> Array.forall ((=) 4) @>
     true =! cell.IsValid()
 }

--- a/tests/Equinox.Cosmos.Integration/CacheCellTests.fs
+++ b/tests/Equinox.Cosmos.Integration/CacheCellTests.fs
@@ -2,9 +2,9 @@
 
 open Equinox.Core
 open Swensen.Unquote
+open System
 open System.Threading
 open Xunit
-open System
 
 [<Fact>]
 let ``AsyncLazy correctness`` () = async {
@@ -54,7 +54,7 @@ let ``AsyncCacheCell correctness with throwing`` initiallyThrowing = async {
     else
         let! r = cell.AwaitValue()
         test <@ 1 = r @>
-    
+
     incr expectedValue
 
     let! accessResult = [|1 .. 100|] |> Array.map (fun _ -> cell.AwaitValue ()) |> Async.Parallel
@@ -62,7 +62,7 @@ let ``AsyncCacheCell correctness with throwing`` initiallyThrowing = async {
 
     // invalidate the cached value
     incr expectedValue
-    // but make the comptutation ultimately fail
+    // but make the computation ultimately fail
     throwing <- true
     // All share the failure
     let! accessResult = [|1 .. 10|] |> Array.map (fun _ -> cell.AwaitValue () |> Async.Catch) |> Async.Parallel


### PR DESCRIPTION
The initial impl of AsyncCacheCell passes the tests and fulfilled the need in the context that it was written (an initialization gating device in `Equinox.Cosmos`)

However the `PeekIsValid` perf tweak is a messy ad-hoc thing, so as precursor to https://github.com/jet/equinox/pull/228 I clarified and simplified the logic