### PR TITLE
Primary-Secondary Fallback 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Cosmos`: Reorganize Sync log message text, merge with Sync Conflict message [#241](https://github.com/jet/equinox/pull/241)
 - `Cosmos`: Converge Stored Procedure Impl with `tip-isa-batch` impl from V3 (minor Request Charges cost reduction) [#242](https://github.com/jet/equinox/pull/242)
 
-- Fork `Equinox.Cosmos` to `Equinox.CosmosStore`
+- Fork `Equinox.Cosmos` to `Equinox.CosmosStore`:
     - target `Microsoft.Azure.Cosmos` v `3.9.0` (instead of `Microsoft.Azure.DocumentDB`[`.Core`] v 2.x) [#144](https://github.com/jet/equinox/pull/144)
     - Removed [warmup call](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/1436)
     - Rename `Equinox.Cosmos` DLL and namespace to `Equinox.CosmosStore` [#243](https://github.com/jet/equinox/pull/243)
@@ -31,6 +31,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
         - Rename `Equinox.Cosmos.Resolver` -> `Equinox.CosmosStore.CosmosStoreCategory`
         - Rename `Equinox.Cosmos.Connector` -> `Equinox.CosmosStore.CosmosStoreClientFactory`
     - Reorganized `QueryRetryPolicy` to handle `IAsyncEnumerable` coming in Cosmos SDK V4 [#246](https://github.com/jet/equinox/pull/246) :pray: [@ylibrach](https://github.com/ylibrach)
+    - Added Secondary store fallback for Event loading, enabling Streams to be hot-migrated (archived to a secondary/clone, then pruned from the primary/active) between Primary and Secondary stores [#247](https://github.com/jet/equinox/pull/247)
 - target `EventStore.Client` v `20.6` (instead of v `5.0.x`) [#224](https://github.com/jet/equinox/pull/224)
 - Retarget `netcoreapp2.1` apps to `netcoreapp3.1` with `SystemTextJson`
 - Retarget Todobackend to `aspnetcore` v `3.1`

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -813,9 +813,9 @@ module internal Tip =
                 | Some mr when i+1 >= mr -> batchLog.Information "batch Limit exceeded"; invalidOp "batch Limit exceeded"
                 | _ -> ()
 
-                match! e.MoveNext() |> Stopwatch.Time with
-                | _t, None -> ok <- false
-                | t, Some (events, _pos, rus) ->
+                match! e.MoveNext() with
+                | None -> ok <- false // rest of block does not happen, while exits
+                | Some (events, _pos, rus) ->
 
                 ru <- ru + rus
                 allEvents.AddRange(events)

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -1037,7 +1037,7 @@ type StoreClient(container : Container, fallback : Container option, batching : 
         let walkFallback =
             match fallback with
             | None -> None
-            | Some f -> walk (log |> Log.prop "Secondary" true) f |> Some
+            | Some f -> walk (log |> Log.prop "secondary" true) f |> Some
 
         let log = log |> Log.prop "stream" stream
         let! pos, events = Query.load log (minIndex, maxIndex) tip (walk log container) walkFallback

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -681,7 +681,7 @@ module internal Tip =
                 let notTip = sprintf "c.id!=\"%s\"" Tip.WellKnownDocumentId // until tip-isa-batch, we have a guarantee there are no events in Tip
                 let conditions = Seq.map fst args
                 String.Join(" AND ", if includeTip then conditions else Seq.append conditions (Seq.singleton notTip))
-            let queryString = sprintf "SELECT c.id, c.i, c._etag, c.n, c.e FROM c WHERE %s ORDER BY c.i %s" whereClause order
+            let queryString = sprintf "SELECT c.id, c.i, c._etag, c.n, c.e FROM c WHERE %s ORDER BY c.i %s" (if whereClause.Length = 0 then "1=1" else whereClause) order
             let prams = Seq.map snd args
             (QueryDefinition queryString, prams) ||> Seq.fold (fun q wp -> q |> wp)
         let qro = QueryRequestOptions(PartitionKey=Nullable (PartitionKey stream), MaxItemCount=Nullable maxItems)

--- a/tests/Equinox.CosmosStore.Integration/CosmosCoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosCoreIntegration.fs
@@ -358,3 +358,62 @@ type Tests(testOutputHelper) =
         test <@ [EqxAct.PruneResponse; EqxAct.Prune] = capture.ExternalCalls @>
         verifyRequestChargesMax 3 // 2.83
     }
+
+    (* Fallback *)
+
+    [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
+    let fallback (TestStream streamName) = Async.RunSynchronously <| async {
+        let ctx1 = createPrimaryEventsContext log None
+        let ctx2 = createSecondaryEventsContext log None
+        let ctx12 = createFallbackEventsContext log None
+
+        let! expected = add6EventsIn2Batches ctx1 streamName
+        // Add the same events to the secondary container
+        let! _ = add6EventsIn2Batches ctx2 streamName
+
+        // Trigger deletion of first batch from primary
+        let! deleted, deferred, trimmedPos = Events.prune ctx1 streamName 5L
+        test <@ deleted = 1 && deferred = 4 && trimmedPos = 1L @>
+
+        // Prove it's gone
+        capture.Clear()
+        let! res = Events.get ctx1 streamName 0L Int32.MaxValue
+        test <@ [EqxAct.ResponseForward; EqxAct.QueryForward] = capture.ExternalCalls @>
+        verifyCorrectEvents 1L (Array.skip 1 expected) res
+        verifyRequestChargesMax 4 // 3.04
+
+        // Prove the full set exists in the secondary
+        capture.Clear()
+        let! res = Events.get ctx2 streamName 0L Int32.MaxValue
+        test <@ [EqxAct.ResponseForward; EqxAct.QueryForward] = capture.ExternalCalls @>
+        verifyCorrectEvents 0L expected res
+        verifyRequestChargesMax 4 // 3.09
+
+        // Prove we can fallback with full set in secondary
+        capture.Clear()
+        let! res = Events.get ctx12 streamName 0L Int32.MaxValue
+        test <@ [EqxAct.ResponseForward; EqxAct.QueryForward; EqxAct.ResponseForward; EqxAct.QueryForward] = capture.ExternalCalls @>
+        verifyCorrectEvents 0L expected res
+        verifyRequestChargesMax 7 // 3.04 + 3.06
+
+        // Delete second batch in primary
+        capture.Clear()
+        let! deleted, deferred, trimmedPos = Events.prune ctx1 streamName 6L
+        test <@ deleted = 5 && deferred = 0 && trimmedPos = 6L @>
+
+        // Nothing left in primary
+        capture.Clear()
+        let! res = Events.get ctx1 streamName 0L Int32.MaxValue
+        test <@ [EqxAct.ResponseForward; EqxAct.QueryForward] = capture.ExternalCalls @>
+        test <@ [||] = res @>
+        verifyRequestChargesMax 3 // 2.99
+
+        // Fallback still does two queries (the first one is empty) // TODO demonstrate Primary read is only of Tip when using snapshots
+        capture.Clear()
+        let! res = Events.get ctx12 streamName 0L Int32.MaxValue
+//        test <@ [EqxAct.ResponseForward; EqxAct.QueryForward; EqxAct.ResponseForward; EqxAct.QueryForward] = capture.ExternalCalls @>
+        verifyCorrectEvents 0L expected res
+        verifyRequestChargesMax 7 // 2.99+3.09
+
+        // NOTE lazy variants don't presently apply fallback logic
+    }

--- a/tests/Equinox.CosmosStore.Integration/CosmosFixturesInfrastructure.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosFixturesInfrastructure.fs
@@ -124,6 +124,7 @@ type TestsWithLogCapture(testOutputHelper) =
         let capture = LogCaptureBuffer()
         let logger =
             Serilog.LoggerConfiguration()
+                .MinimumLevel.Debug()
                 .WriteTo.Seq("http://localhost:5341")
                 .WriteTo.Sink(testOutput)
                 .WriteTo.Sink(capture)

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -320,7 +320,7 @@ module CosmosInit =
     open Equinox.CosmosStore.Core.Initialization
 
     let conn log (sargs : ParseResults<Storage.Cosmos.Arguments>) =
-        Storage.Cosmos.conn log (Storage.Cosmos.Info sargs)
+        Storage.Cosmos.conn log (Storage.Cosmos.Info sargs) |> fst
 
     let containerAndOrDb log (iargs: ParseResults<InitArguments>) = async {
         match iargs.TryGetSubCommand() with


### PR DESCRIPTION
As part of #226, implements automated reading from a secondary/fallback Container in cases when the Primary stream has been pruned re #226 

- [x] Reorganize code to facilitate consistent application of fallback
- [x] Implement support for fallback in `eqx dump`

    ```
    dotnet run -- -VC dump -s LokiDcTransmissions-0 -PU cosmos -m gateway -c thor-loki-pruned -c2 thor-loki-archive
    ```
    ![image](https://user-images.githubusercontent.com/206668/94833766-6c1c2c80-0407-11eb-89a7-9fd717afaf39.png)
- [x] Add docs to README #quickstart

replaces #238 which was implemented on top of the Cosmos SDK v4 preview