### PR TITLE
Cosmos: Enable uncompressed unfolds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - `Cosmos`: Support Serverless Account Mode in `eqx init`; default RU/s to 400 if unspecified [#244](https://github.com/jet/equinox/pull/244) :pray: [@OmnipotentOwl](https://github.com/OmnipotentOwl)
-- `Cosmos`: Added ability to turn off compression of Unfolds [#248](https://github.com/jet/equinox/pull/246) :pray: [@ylibrach](https://github.com/ylibrach)
+- `Cosmos`: Added ability to turn off compression of Unfolds [#249](https://github.com/jet/equinox/pull/249) :pray: [@ylibrach](https://github.com/ylibrach)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - `Cosmos`: Support Serverless Account Mode in `eqx init`; default RU/s to 400 if unspecified [#244](https://github.com/jet/equinox/pull/244) :pray: [@OmnipotentOwl](https://github.com/OmnipotentOwl)
+- `Cosmos`: Added ability to turn off compression of Unfolds [#248](https://github.com/jet/equinox/pull/246) :pray: [@ylibrach](https://github.com/ylibrach)
 
 ### Changed
 

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -110,8 +110,7 @@ and Base64MaybeDeflateUtf8JsonConverter() =
         use output = new MemoryStream()
         decompressor.CopyTo(output)
         output.ToArray()
-
-    static member Compress (input : byte[]) : byte[] =
+    static member Compress(input : byte[]) : byte[] =
         if input = null || input.Length = 0 then null else
 
         use output = new System.IO.MemoryStream()
@@ -120,7 +119,6 @@ and Base64MaybeDeflateUtf8JsonConverter() =
         compressor.Close()
         String.Concat("\"", System.Convert.ToBase64String(output.ToArray()), "\"")
         |> System.Text.Encoding.UTF8.GetBytes
-
     override __.CanConvert(objectType) =
         typeof<byte[]>.Equals(objectType)
     override __.ReadJson(reader, _, _, serializer) =
@@ -131,7 +129,7 @@ and Base64MaybeDeflateUtf8JsonConverter() =
     override __.WriteJson(writer, value, serializer) =
         let array = value :?> byte[]
         if array = null || array.Length = 0 then serializer.Serialize(writer, null)
-        else array |> System.Text.Encoding.UTF8.GetString |> writer.WriteRawValue
+        else System.Text.Encoding.UTF8.GetString array |> writer.WriteRawValue
 
 /// The special-case 'Pending' Batch Format used to read the currently active (and mutable) document
 /// Stored representation has the following diffs vs a 'normal' (frozen/completed) Batch: a) `id` = `-1` b) contains unfolds (`u`)
@@ -1199,8 +1197,8 @@ type AccessStrategy<'event,'state> =
 
 type Resolver<'event, 'state, 'context>
     (   context : Context, codec, fold, initial, caching, access,
-        /// Compress Unfolds in Tip. Default: true.
-        /// NOTE when set to <c>false</c>, requires Equinox.Cosmos / Equinox.CosmosStore Version >= 2.3.0 to be able to read
+        /// Compress Unfolds in Tip. Default: <c>true<c>.
+        /// NOTE when set to <c>false</c>, requires Equinox.Cosmos Version >= 2.3.0 to be able to read
         ?compressUnfolds) =
     let compressUnfolds = defaultArg compressUnfolds true
     let readCacheOption =

--- a/tests/Equinox.Cosmos.Integration/CosmosCoreIntegration.fs
+++ b/tests/Equinox.Cosmos.Integration/CosmosCoreIntegration.fs
@@ -54,7 +54,7 @@ type Tests(testOutputHelper) =
         test <@ AppendResult.Ok 6L = res @>
         test <@ [EqxAct.Append] = capture.ExternalCalls @>
         // We didnt request small batches or splitting so it's not dramatically more expensive to write N events
-        verifyRequestChargesMax 39 // 38.74 // was 11
+        verifyRequestChargesMax 41 // 40.68 // was 11
     }
 
     // It's conceivable that in the future we might allow zero-length batches as long as a sync mechanism leveraging the etags and unfolds update mechanisms
@@ -149,7 +149,7 @@ type Tests(testOutputHelper) =
         let extrasCount = match extras with x when x > 50 -> 5000 | x when x < 1 -> 1 | x -> x*100
         let! _pos = ctx.NonIdempotentAppend(stream, TestEvents.Create (int pos,extrasCount))
         test <@ [EqxAct.Append] = capture.ExternalCalls @>
-        verifyRequestChargesMax 149 // 148.11 // 463.01 observed
+        verifyRequestChargesMax 448 // 447.5 // 463.01 observed
         capture.Clear()
 
         let! pos = ctx.Sync(stream,?position=None)

--- a/tests/Equinox.Cosmos.Integration/JsonConverterTests.fs
+++ b/tests/Equinox.Cosmos.Integration/JsonConverterTests.fs
@@ -18,36 +18,38 @@ let defaultSettings = FsCodec.NewtonsoftJson.Settings.CreateDefault()
 type Base64ZipUtf8Tests() =
     let eventCodec = FsCodec.NewtonsoftJson.Codec.Create(defaultSettings)
 
-    [<Fact>]
-    let ``serializes, achieving compression`` () =
-        let encoded = eventCodec.Encode(None,A { embed = String('x',5000) })
+    let ser eventType data =
         let e : Store.Unfold =
             {   i = 42L
-                c = encoded.EventType
-                d = encoded.Data
+                c = eventType
+                d = data
                 m = null
                 t = DateTimeOffset.MinValue }
-        let res = JsonConvert.SerializeObject e
-        test <@ res.Contains("\"d\":\"") && res.Length < 128 @>
+        JsonConvert.SerializeObject e
+
+    [<Fact>]
+    let ``serializes, achieving expected compression`` () =
+        let encoded = eventCodec.Encode(None,A { embed = String('x',5000) })
+        let res = ser encoded.EventType (Store.Base64MaybeDeflateUtf8JsonConverter.Compress encoded.Data)
+        test <@ res.Contains("\"d\":\"") && res.Length < 138 @>
 
     [<Property>]
-    let roundtrips value =
-        let hasNulls =
-            match value with
-            | A x | B x when obj.ReferenceEquals(null, x) -> true
-            | A { embed = x } | B { embed = x } -> obj.ReferenceEquals(null, x)
-        if hasNulls then () else
-
-        let encoded = eventCodec.Encode(None,value)
-        let e : Store.Unfold =
-            {   i = 42L
-                c = encoded.EventType
-                d = encoded.Data
-                m = null
-                t = DateTimeOffset.MinValue }
-        let ser = JsonConvert.SerializeObject(e)
-        test <@ ser.Contains("\"d\":\"") @>
+    let roundtrips compress value =
+        let encoded = eventCodec.Encode(None, value)
+        let maybeCompressor = if compress then Store.Base64MaybeDeflateUtf8JsonConverter.Compress else id
+        let actualData = maybeCompressor encoded.Data
+        let ser = ser encoded.EventType actualData
+        test <@ if compress then ser.Contains("\"d\":\"")
+                else ser.Contains("\"d\":{") @>
         let des = JsonConvert.DeserializeObject<Store.Unfold>(ser)
         let d = FsCodec.Core.TimelineEvent.Create(-1L, des.c, des.d)
         let decoded = eventCodec.TryDecode d |> Option.get
         test <@ value = decoded @>
+
+    [<Theory; InlineData false; InlineData true>]
+    let handlesNulls compress =
+        let maybeCompressor = if compress then Store.Base64MaybeDeflateUtf8JsonConverter.Compress else id
+        let maybeCompressed = maybeCompressor null
+        let ser = ser "AnEventType" maybeCompressed
+        let des = JsonConvert.DeserializeObject<Store.Unfold>(ser)
+        test <@ null = des.d @>


### PR DESCRIPTION
Port of @ylibrach's https://github.com/jet/equinox/pull/206 to work with `Newtonsoft.Json`
Enables a `Cosmos.Resolver` to inhibit compressing of Unfolds (Snapshot bodies) stored in Tip by adding `, compressUnfolds=false`

CAUTION: Use with care: readers with older versions of `Equinox.Cosmos` will choke on uncompressed values