### PR TITLE
CosmosStore: BatchingPolicy -> TipOptions + QueryOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
         - Rename `Equinox.Cosmos.Connector` -> `Equinox.CosmosStore.CosmosStoreClientFactory`
     - Reorganized `QueryRetryPolicy` to handle `IAsyncEnumerable` coming in Cosmos SDK V4 [#246](https://github.com/jet/equinox/pull/246) :pray: [@ylibrach](https://github.com/ylibrach)
     - Added Secondary store fallback for Event loading, enabling Streams to be hot-migrated (archived to a secondary/clone, then pruned from the primary/active) between Primary and Secondary stores [#247](https://github.com/jet/equinox/pull/247)
+    - Replaced `BatchingPolicy`, `RetryPolicy` with `TipOptions`, `QueryOptions` to better align with Cosmos SDK V4 [#253](https://github.com/jet/equinox/pull/253)
 - target `EventStore.Client` v `20.6` (instead of v `5.0.x`) [#224](https://github.com/jet/equinox/pull/224)
 - Retarget `netcoreapp2.1` apps to `netcoreapp3.1` with `SystemTextJson`
 - Retarget Todobackend to `aspnetcore` v `3.1`

--- a/samples/Store/Integration/CartIntegration.fs
+++ b/samples/Store/Integration/CartIntegration.fs
@@ -70,7 +70,7 @@ type Tests(testOutputHelper) =
 
     let arrangeCosmos connect resolve =
         let log = createLog ()
-        let ctx : CosmosStore.CosmosStoreContext = connect log defaultBatchSize
+        let ctx : CosmosStore.CosmosStoreContext = connect log defaultQueryMaxItems
         Backend.Cart.create log (resolve ctx)
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]

--- a/samples/Store/Integration/ContactPreferencesIntegration.fs
+++ b/samples/Store/Integration/ContactPreferencesIntegration.fs
@@ -61,14 +61,14 @@ type Tests(testOutputHelper) =
         do! act service args
     }
 
-    let arrangeCosmos connect resolve batchSize =
+    let arrangeCosmos connect resolve queryMaxItems =
         let log = createLog ()
-        let ctx: CosmosStore.CosmosStoreContext = connect log batchSize
+        let ctx: CosmosStore.CosmosStoreContext = connect log queryMaxItems
         Backend.ContactPreferences.create log (resolve ctx)
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let ``Can roundtrip against Cosmos, correctly folding the events with Unoptimized semantics`` args = Async.RunSynchronously <| async {
-        let service = arrangeCosmos createPrimaryContext resolveStreamCosmosUnoptimized defaultBatchSize
+        let service = arrangeCosmos createPrimaryContext resolveStreamCosmosUnoptimized defaultQueryMaxItems
         do! act service args
     }
 
@@ -80,6 +80,6 @@ type Tests(testOutputHelper) =
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let ``Can roundtrip against Cosmos, correctly folding the events with RollingUnfold semantics`` args = Async.RunSynchronously <| async {
-        let service = arrangeCosmos createPrimaryContext resolveStreamCosmosRollingUnfolds defaultBatchSize
+        let service = arrangeCosmos createPrimaryContext resolveStreamCosmosRollingUnfolds defaultQueryMaxItems
         do! act service args
     }

--- a/samples/Store/Integration/FavoritesIntegration.fs
+++ b/samples/Store/Integration/FavoritesIntegration.fs
@@ -60,7 +60,7 @@ type Tests(testOutputHelper) =
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let ``Can roundtrip against Cosmos, correctly folding the events`` args = Async.RunSynchronously <| async {
         let log = createLog ()
-        let context = createPrimaryContext log defaultBatchSize
+        let context = createPrimaryContext log defaultQueryMaxItems
         let service = createServiceCosmos log context
         do! act service args
     }
@@ -68,7 +68,7 @@ type Tests(testOutputHelper) =
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let ``Can roundtrip against Cosmos, correctly folding the events with rolling unfolds`` args = Async.RunSynchronously <| async {
         let log = createLog ()
-        let context = createPrimaryContext log defaultBatchSize
+        let context = createPrimaryContext log defaultQueryMaxItems
         let service = createServiceCosmosRollingState log context
         do! act service args
     }

--- a/samples/Store/Integration/LogIntegration.fs
+++ b/samples/Store/Integration/LogIntegration.fs
@@ -122,12 +122,12 @@ type Tests() =
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let ``Can roundtrip against Cosmos, hooking, extracting and substituting metrics in the logging information`` cartContext skuId = Async.RunSynchronously <| async {
-        let batchSize = defaultBatchSize
+        let queryMaxItems = defaultQueryMaxItems
         let buffer = ConcurrentQueue<string>()
         let log = createLoggerWithMetricsExtraction buffer.Enqueue
-        let context = createPrimaryContext log batchSize
+        let context = createPrimaryContext log queryMaxItems
         let service = Backend.Cart.create log (CartIntegration.resolveCosmosStreamWithSnapshotStrategy context)
-        let itemCount = batchSize / 2 + 1
+        let itemCount = queryMaxItems / 2 + 1
         let cartId = % Guid.NewGuid()
         do! act buffer service itemCount cartContext cartId skuId "EqxCosmos Tip " // one is a 404, one is a 200
     }

--- a/samples/Web/Startup.fs
+++ b/samples/Web/Startup.fs
@@ -62,7 +62,6 @@ type Startup() =
         let storeConfig, storeLog : Storage.StorageConfig * ILogger =
             let options = args.GetResults Cached @ args.GetResults Unfolds
             let unfolds = options |> List.exists (function Unfolds -> true | _ -> false)
-            let defaultBatchSize = 500
             let log = Log.ForContext<App>()
 
             let cache = if options |> List.exists (function Cached -> true | _ -> false) then Equinox.Cache(Storage.appName, sizeMb = 50) |> Some else None
@@ -70,20 +69,20 @@ type Startup() =
             | Some (Cosmos sargs) ->
                 let storeLog = createStoreLog <| sargs.Contains Storage.Cosmos.Arguments.VerboseStore
                 log.Information("CosmosDB Storage options: {options:l}", options)
-                Storage.Cosmos.config log (cache, unfolds, defaultBatchSize) (Storage.Cosmos.Info sargs), storeLog
+                Storage.Cosmos.config log (cache, unfolds) (Storage.Cosmos.Info sargs), storeLog
             | Some (Es sargs) ->
                 let storeLog = createStoreLog <| sargs.Contains Storage.EventStore.Arguments.VerboseStore
                 log.Information("EventStoreDB Storage options: {options:l}", options)
-                Storage.EventStore.config (log,storeLog) (cache, unfolds, defaultBatchSize) sargs, storeLog
+                Storage.EventStore.config (log,storeLog) (cache, unfolds) sargs, storeLog
             | Some (MsSql sargs) ->
                 log.Information("SqlStreamStore MsSql Storage options: {options:l}", options)
-                Storage.Sql.Ms.config log (cache, unfolds, defaultBatchSize) sargs, log
+                Storage.Sql.Ms.config log (cache, unfolds) sargs, log
             | Some (MySql sargs) ->
                 log.Information("SqlStreamStore MySql Storage options: {options:l}", options)
-                Storage.Sql.My.config log (cache, unfolds, defaultBatchSize) sargs, log
+                Storage.Sql.My.config log (cache, unfolds) sargs, log
             | Some (Postgres sargs) ->
                 log.Information("SqlStreamStore Postgres Storage options: {options:l}", options)
-                Storage.Sql.Pg.config log (cache, unfolds, defaultBatchSize) sargs, log
+                Storage.Sql.Pg.config log (cache, unfolds) sargs, log
             | _  | Some (Memory _) ->
                 log.Fatal("Web App is using Volatile Store; Storage options: {options:l}", options)
                 Storage.MemoryStore.config (), log

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -1018,7 +1018,7 @@ module Internal =
 
 /// Defines the policies in force regarding how to split up calls when loading Event Batches via queries
 type QueryOptions
-    (   /// Max Batches to request in query response. Defaults: 10.
+    (   /// Max number of Batches to return per paged query response. Default: 10.
         [<O; D(null)>]?defaultMaxItems : int,
         /// Dynamic version of `defaultMaxItems`, allowing one to react to dynamic configuration changes. Default: use `defaultMaxItems` value.
         [<O; D(null)>]?getDefaultMaxItems : unit -> int,
@@ -1403,7 +1403,7 @@ type EventsContext internal
         /// Logger to write to - see https://github.com/serilog/serilog/wiki/Provided-Sinks for how to wire to your logger
         log : Serilog.ILogger,
         /// Optional maximum number of Store.Batch records to retrieve as a set (how many Events are placed therein is controlled by average batch size when appending events
-        /// Defaults to 10
+        /// Default: 10
         [<Optional; DefaultParameterValue(null)>]?defaultMaxItems,
         /// Alternate way of specifying defaultMaxItems that facilitates reading it from a cached dynamic configuration
         [<Optional; DefaultParameterValue(null)>]?getDefaultMaxItems) =

--- a/tests/Equinox.CosmosStore.Integration/CosmosCoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosCoreIntegration.fs
@@ -29,9 +29,8 @@ type Tests(testOutputHelper) =
     let (|TestStream|) (name: Guid) =
         incr testIterations
         sprintf "events-%O-%i" name !testIterations
-    let mkContextWithItemLimit log batchSize =
-        createPrimaryEventsContext log batchSize
-    let mkContext log = mkContextWithItemLimit log None
+    let mkContextWithItemLimit log maxItems =
+        createPrimaryEventsContext log (Some maxItems)
 
     let verifyRequestChargesMax rus =
         let tripRequestCharges = [ for e, c in capture.RequestCharges -> sprintf "%A" e, c ]
@@ -39,14 +38,14 @@ type Tests(testOutputHelper) =
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let append (TestStream streamName) = Async.RunSynchronously <| async {
-        let ctx = mkContext log
+        let ctx = createPrimaryEventsContext log (Some 10)
         capture.Clear()
 
         let index = 0L
         let! res = Events.append ctx streamName index <| TestEvents.Create(0,1)
         test <@ AppendResult.Ok 1L = res @>
         test <@ [EqxAct.Append] = capture.ExternalCalls @>
-        verifyRequestChargesMax 34 // 33.07 // WAS 10
+        verifyRequestChargesMax 34 // 33.07
         // Clear the counters
         capture.Clear()
 
@@ -54,14 +53,14 @@ type Tests(testOutputHelper) =
         test <@ AppendResult.Ok 6L = res @>
         test <@ [EqxAct.Append] = capture.ExternalCalls @>
         // We didnt request small batches or splitting so it's not dramatically more expensive to write N events
-        verifyRequestChargesMax 41 // 40.68 // was 11
+        verifyRequestChargesMax 41 // 40.68
     }
 
     // It's conceivable that in the future we might allow zero-length batches as long as a sync mechanism leveraging the etags and unfolds update mechanisms
     // As it stands with the NoTipEvents stored proc, permitting empty batches a) yields an invalid state b) provides no conceivable benefit
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let ``append Throws when passed an empty batch`` (TestStream streamName) = Async.RunSynchronously <| async {
-        let ctx = mkContext log
+        let ctx = mkContextWithItemLimit log 10
 
         let index = 0L
         let! res = Events.append ctx streamName index (TestEvents.Create(0,0)) |> Async.Catch
@@ -78,17 +77,19 @@ type Tests(testOutputHelper) =
         let sx,sy = stringOfUtf8 x, stringOfUtf8 y
         test <@ ignore i; blobEquals x y || "" = xmlDiff sx sy @>
 
-    let add6EventsIn2Batches ctx streamName = async {
+    let add6EventsIn2BatchesEx ctx streamName splitAt = async {
         let index = 0L
-        let! res = Events.append ctx streamName index <| TestEvents.Create(0,1)
+        let! res = Events.append ctx streamName index <| TestEvents.Create(0, splitAt)
 
-        test <@ AppendResult.Ok 1L = res @>
-        let! res = Events.append ctx streamName 1L <| TestEvents.Create(1,5)
+        test <@ AppendResult.Ok (int64 splitAt) = res @>
+        let! res = Events.append ctx streamName (int64 splitAt) <| TestEvents.Create(splitAt, 6 - splitAt)
         test <@ AppendResult.Ok 6L = res @>
         // Only start counting RUs from here
         capture.Clear()
         return TestEvents.Create(0,6)
     }
+
+    let add6EventsIn2Batches ctx streamName = add6EventsIn2BatchesEx ctx streamName 1
 
     let verifyCorrectEventsEx direction baseIndex (expected: IEventData<_>[]) (xs: ITimelineEvent<byte[]>[]) =
         let xs, baseIndex =
@@ -106,7 +107,8 @@ type Tests(testOutputHelper) =
         // If a fail triggers a rerun, we need to dump the previous log entries captured
         capture.Clear()
 
-        let ctx = mkContextWithItemLimit log (Some 1)
+        let ctx = createPrimaryEventsContext log (Some 1)
+        let ctx = mkContextWithItemLimit log 1
 
         let! pos = Events.getNextIndex ctx streamName
         test <@ [EqxAct.TipNotFound] = capture.ExternalCalls @>
@@ -133,7 +135,7 @@ type Tests(testOutputHelper) =
         pos <- pos + 42L
         pos =! res
         test <@ [EqxAct.Append] = capture.ExternalCalls @>
-        verifyRequestChargesMax 50 // 49.74 // WAS 20
+        verifyRequestChargesMax 50 // 49.74
         capture.Clear()
 
         let! res = Events.getNextIndex ctx streamName
@@ -164,7 +166,7 @@ type Tests(testOutputHelper) =
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let ``append - fails on non-matching`` (TestStream streamName) = Async.RunSynchronously <| async {
         capture.Clear()
-        let ctx = mkContext log
+        let ctx = createPrimaryEventsContext log (Some 10)
 
         // Attempt to write, skipping Index 0
         let! res = Events.append ctx streamName 1L <| TestEvents.Create(0,1)
@@ -172,40 +174,31 @@ type Tests(testOutputHelper) =
         test <@ [EqxAct.Resync] = capture.ExternalCalls @>
         // The response aligns with a normal conflict in that it passes the entire set of conflicting events ()
         test <@ AppendResult.Conflict (0L,[||]) = res @>
-        verifyRequestChargesMax 6 // 5.5 // WAS 5
+        verifyRequestChargesMax 12 // 11.18
         capture.Clear()
 
         // Now write at the correct position
-        let expected = TestEvents.Create(1,1)
+        let expected = TestEvents.Create(0,1)
         let! res = Events.append ctx streamName 0L expected
         test <@ AppendResult.Ok 1L = res @>
         test <@ [EqxAct.Append] = capture.ExternalCalls @>
-        verifyRequestChargesMax 36 // 35.78 WAS 11 // 10.33
+        verifyRequestChargesMax 40 // 39.39
         capture.Clear()
 
         // Try overwriting it (a competing consumer would see the same)
         let! res = Events.append ctx streamName 0L <| TestEvents.Create(-42,2)
         // This time we get passed the conflicting events - we pay a little for that, but that's unavoidable
-        match res with
-#if EVENTS_IN_TIP
-        | AppendResult.Conflict (1L, e) -> verifyCorrectEvents 0L expected e
-#else
-        | AppendResult.ConflictUnknown 1L -> ()
-#endif
+        match res, capture.ExternalCalls with
+        | AppendResult.ConflictUnknown 1L, [EqxAct.Conflict] ->
+            verifyRequestChargesMax 12 // 11.9
         | x -> x |> failwithf "Unexpected %A"
-#if EVENTS_IN_TIP
-        test <@ [EqxAct.Resync] = capture.ExternalCalls @>
-#else
-        test <@ [EqxAct.Conflict] = capture.ExternalCalls @>
-#endif
-        verifyRequestChargesMax 6 // 5.63 // 6.64
     }
 
     (* Forward *)
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let get (TestStream streamName) = Async.RunSynchronously <| async {
-        let ctx = mkContextWithItemLimit log (Some 3)
+        let ctx = createPrimaryEventsContext log (Some 3)
 
         // We're going to ignore the first, to prove we can
         let! expected = add6EventsIn2Batches ctx streamName
@@ -221,9 +214,9 @@ type Tests(testOutputHelper) =
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let ``get in 2 batches`` (TestStream streamName) = Async.RunSynchronously <| async {
-        let ctx = mkContextWithItemLimit log (Some 1)
+        let ctx = createPrimaryEventsContext log (Some 1)
 
-        let! expected = add6EventsIn2Batches ctx streamName
+        let! expected = add6EventsIn2BatchesEx ctx streamName 2
         let expected = expected |> Array.take 3
 
         let! res = Events.get ctx streamName 0L 3
@@ -237,9 +230,9 @@ type Tests(testOutputHelper) =
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let ``get Lazy`` (TestStream streamName) = Async.RunSynchronously <| async {
-        let ctx = mkContextWithItemLimit log (Some 1)
+        let ctx = createPrimaryEventsContext log (Some 1)
 
-        let! expected = add6EventsIn2Batches ctx streamName
+        let! expected = add6EventsIn2BatchesEx ctx streamName 3
 
         let! res = Events.getAll ctx streamName 0L 1 |> AsyncSeq.concatSeq |> AsyncSeq.takeWhileInclusive (fun _ -> false) |> AsyncSeq.toArrayAsync
         let expected = expected |> Array.take 1
@@ -249,16 +242,16 @@ type Tests(testOutputHelper) =
         let queryRoundTripsAndItemCounts = function
             | EqxEvent (Equinox.CosmosStore.Core.Log.Event.Query (Equinox.CosmosStore.Core.Direction.Forward, responses, { count = c })) -> Some (responses,c)
             | _ -> None
-        // validate that, despite only requesting max 1 item, we only needed one trip (which contained only one item)
-        [1,1] =! capture.ChooseCalls queryRoundTripsAndItemCounts
-        verifyRequestChargesMax 4 // 3.23 // WAS 3 // 2.97
+        // validate that, because we stopped after 1 item, we only needed one trip (which contained 3 events)
+        [1,3] =! capture.ChooseCalls queryRoundTripsAndItemCounts
+        verifyRequestChargesMax 4 // 3.06
     }
 
     (* Backward *)
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let getBackwards (TestStream streamName) = Async.RunSynchronously <| async {
-        let ctx = mkContextWithItemLimit log (Some 1)
+        let ctx = createPrimaryEventsContext log (Some 1)
 
         let! expected = add6EventsIn2Batches ctx streamName
 
@@ -270,14 +263,14 @@ type Tests(testOutputHelper) =
         verifyCorrectEventsBackward 4L expected res
 
         test <@ [EqxAct.ResponseBackward; EqxAct.QueryBackward] = capture.ExternalCalls @>
-        verifyRequestChargesMax 4 // 3.24 // WAS 3
+        verifyRequestChargesMax 3
     }
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let ``getBackwards in 2 batches`` (TestStream streamName) = Async.RunSynchronously <| async {
-        let ctx = mkContextWithItemLimit log (Some 1)
+        let ctx = createPrimaryEventsContext log (Some 1)
 
-        let! expected = add6EventsIn2Batches ctx streamName
+        let! expected = add6EventsIn2BatchesEx ctx streamName 2
 
         // We want to skip reading the last two, which means getting both, but disregarding some of the second batch
         let expected = Array.take 4 expected
@@ -292,34 +285,35 @@ type Tests(testOutputHelper) =
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let ``getBackwards Lazy`` (TestStream streamName) = Async.RunSynchronously <| async {
-        let ctx = mkContextWithItemLimit log (Some 1)
+        let ctx = createPrimaryEventsContext log (Some 1)
 
-        let! expected = add6EventsIn2Batches ctx streamName
+        let! expected = add6EventsIn2BatchesEx ctx streamName 4
 
         let! res =
             Events.getAllBackwards ctx streamName 10L 1
             |> AsyncSeq.concatSeq
-            |> AsyncSeq.takeWhileInclusive (fun x -> x.Index <> 2L)
+            |> AsyncSeq.takeWhileInclusive (fun x -> x.Index <> 4L)
             |> AsyncSeq.toArrayAsync
-        let expected = expected |> Array.skip 2 // omit index 0, 1 as we vote to finish at 2L
+        let expected = expected |> Array.skip 4 // omit index 0, 1 as we vote to finish at 2L
 
         verifyCorrectEventsBackward 5L expected res
         // only 1 request of 1 item triggered
-        test <@ [EqxAct.ResponseBackward; EqxAct.QueryBackward] = capture.ExternalCalls @>
+        let pages = 1 // in V2 (and V3 master for now), Tip gets filtered out of the querying explicitly
+        test <@ [yield! Seq.replicate pages EqxAct.ResponseBackward; EqxAct.QueryBackward] = capture.ExternalCalls @>
         // validate that, despite only requesting max 1 item, we only needed one trip, bearing 5 items (from which one item was omitted)
         let queryRoundTripsAndItemCounts = function
             | EqxEvent (Equinox.CosmosStore.Core.Log.Event.Query (Equinox.CosmosStore.Core.Direction.Backward, responses, { count = c })) -> Some (responses,c)
             | _ -> None
-        [1,5] =! capture.ChooseCalls queryRoundTripsAndItemCounts
-        verifyRequestChargesMax 4 // 3.24 // WAS 3 // 2.98
+        let expectedPagesAndEvents = [pages, 2]
+        expectedPagesAndEvents =! capture.ChooseCalls queryRoundTripsAndItemCounts
+        verifyRequestChargesMax 6 // 5.66
     }
 
     (* Prune *)
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let prune (TestStream streamName) = Async.RunSynchronously <| async {
-        let ctx = mkContextWithItemLimit log None
-
+        let ctx = createPrimaryEventsContext log (Some 10)
         let! expected = add6EventsIn2Batches ctx streamName
 
         // Trigger deletion of first batch
@@ -412,7 +406,7 @@ type Tests(testOutputHelper) =
         // TODO demonstrate Primary read is only of Tip when using snapshots
         capture.Clear()
         let! res = Events.get ctx12 streamName 0L Int32.MaxValue
-//        test <@ [EqxAct.ResponseForward; EqxAct.QueryForward; EqxAct.ResponseForward; EqxAct.QueryForward] = capture.ExternalCalls @>
+        test <@ [EqxAct.ResponseForward; EqxAct.QueryForward; EqxAct.ResponseForward; EqxAct.QueryForward] = capture.ExternalCalls @>
         verifyCorrectEvents 0L expected res
         verifyRequestChargesMax 7 // 2.99+3.09
 

--- a/tests/Equinox.CosmosStore.Integration/CosmosFixtures.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosFixtures.fs
@@ -43,31 +43,31 @@ let connectWithFallback log =
     let client = createClient log name discovery
     CosmosStoreConnection(client, databaseId, containerId, containerId2 = containerId2)
 
-let createPrimaryContext log batchSize =
+let createPrimaryContext log queryMaxItems =
     let conn = connectPrimary log
-    CosmosStoreContext(conn, defaultMaxItems = batchSize)
+    CosmosStoreContext(conn, queryMaxItems = queryMaxItems)
 
-let createSecondaryContext log batchSize =
+let createSecondaryContext log queryMaxItems =
     let conn = connectSecondary log
-    CosmosStoreContext(conn, defaultMaxItems = batchSize)
+    CosmosStoreContext(conn, queryMaxItems = queryMaxItems)
 
-let createFallbackContext log batchSize =
+let createFallbackContext log queryMaxItems =
     let conn = connectWithFallback log
-    CosmosStoreContext(conn, defaultMaxItems = batchSize)
+    CosmosStoreContext(conn, queryMaxItems = queryMaxItems)
 
-let defaultBatchSize = 500
+let defaultQueryMaxItems = 10
 
-let createPrimaryEventsContext log batchSize =
-    let batchSize = defaultArg batchSize defaultBatchSize
-    let context = createPrimaryContext log batchSize
-    Equinox.CosmosStore.Core.EventsContext(context, log, defaultMaxItems = batchSize)
+let createPrimaryEventsContext log queryMaxItems =
+    let queryMaxItems = defaultArg queryMaxItems defaultQueryMaxItems
+    let context = createPrimaryContext log queryMaxItems
+    Equinox.CosmosStore.Core.EventsContext(context, log, defaultMaxItems = queryMaxItems)
 
-let createSecondaryEventsContext log batchSize =
-    let batchSize = defaultArg batchSize defaultBatchSize
-    let ctx = createSecondaryContext log batchSize
-    Equinox.CosmosStore.Core.EventsContext(ctx, log, defaultMaxItems = batchSize)
+let createSecondaryEventsContext log queryMaxItems =
+    let queryMaxItems = defaultArg queryMaxItems defaultQueryMaxItems
+    let ctx = createSecondaryContext log queryMaxItems
+    Equinox.CosmosStore.Core.EventsContext(ctx, log, defaultMaxItems = queryMaxItems)
 
-let createFallbackEventsContext log batchSize =
-    let batchSize = defaultArg batchSize defaultBatchSize
-    let ctx = createFallbackContext log batchSize
-    Equinox.CosmosStore.Core.EventsContext(ctx, log, defaultMaxItems = batchSize)
+let createFallbackEventsContext log queryMaxItems =
+    let queryMaxItems = defaultArg queryMaxItems defaultQueryMaxItems
+    let ctx = createFallbackContext log queryMaxItems
+    Equinox.CosmosStore.Core.EventsContext(ctx, log, defaultMaxItems = queryMaxItems)


### PR DESCRIPTION
Replace/renames/reorganizes the `BatchingPolicy` and `RetryPolicy` constructs in the CosmosStore API with two new elements:
- `TipOptions` - policies regarding how we manage the `Tip` document (only)
- `QueryOptions` - policies regarding the loading of events via CosmosDB queries

This is motivated by:
- having a logical place to add options pertaining to the management of events being retained in Tip in #251
- removing an over-generalization in the V1/2 API design/naming: the notion of there being a 'batch size' measured in events when querying events (which works well for ESDB and SSS, but only applies for CosmosDB if you have a one-event-per-Document schema)
- aligning with the API style that's being used for `Azure.Cosmos` aka the V4 SDK (similar `Options` naming) re #197
- handling the fact that query retry policies will necessarily be handled differently when we consume queries via `IAsyncEnumerable` as forced by V4