### PR TITLE
Add CachingStrategy.FixedTimeSpan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `CachingStrategy.FixedTimeSpan`: Support for fixed caching periods [#252](https://github.com/jet/equinox/pull/252)
+
 ### Changed
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
-- `CachingStrategy.FixedTimeSpan`: Support for fixed caching periods [#252](https://github.com/jet/equinox/pull/252)
+- `CachingStrategy.FixedTimeSpan`: Support for fixed caching periods [#255](https://github.com/jet/equinox/pull/255)
 
 ### Changed
 ### Removed

--- a/src/Equinox.Core/Cache.fs
+++ b/src/Equinox.Core/Cache.fs
@@ -37,8 +37,8 @@ type Cache(name, sizeMb : int) =
 
     let toPolicy (cacheItemOption: CacheItemOptions) =
         match cacheItemOption with
-        | AbsoluteExpiration absolute -> new CacheItemPolicy(AbsoluteExpiration = absolute)
-        | RelativeExpiration relative -> new CacheItemPolicy(SlidingExpiration = relative)
+        | AbsoluteExpiration absolute -> CacheItemPolicy(AbsoluteExpiration = absolute)
+        | RelativeExpiration relative -> CacheItemPolicy(SlidingExpiration = relative)
 
     interface ICache with
         member __.UpdateIfNewer(key, options, entry) = async {

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -1215,7 +1215,7 @@ type Resolver<'event, 'state, 'context>
         match caching with
         | CachingStrategy.NoCaching -> None
         | CachingStrategy.SlidingWindow (cache, _)
-        | CachingStrategy.FixedTimeSpan (cache, _) -> Some(cache, null)
+        | CachingStrategy.FixedTimeSpan (cache, _) -> Some (cache, null)
     let isOrigin, mapUnfolds =
         match access with
         | AccessStrategy.Unoptimized ->                      (fun _ -> false), Choice1Of3 ()

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -596,8 +596,8 @@ type Resolver<'event, 'state, 'context>
         match caching with
         | None -> None
         | Some (CachingStrategy.SlidingWindow (cache, _))
-        | Some (CachingStrategy.FixedTimeSpan (cache, _)) -> Some(cache, null)
-        | Some (CachingStrategy.SlidingWindowPrefixed (cache, _, prefix)) -> Some(cache, prefix)
+        | Some (CachingStrategy.FixedTimeSpan (cache, _)) -> Some (cache, null)
+        | Some (CachingStrategy.SlidingWindowPrefixed (cache, _, prefix)) -> Some (cache, prefix)
 
     let folder = Folder<'event, 'state, 'context>(inner, fold, initial, ?readCache = readCacheOption)
 

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -536,6 +536,19 @@ module Caching =
         let addOrUpdateSlidingExpirationCacheEntry streamName value = cache.UpdateIfNewer(prefix + streamName, options, mkCacheEntry value)
         CategoryTee<'event, 'state, 'context>(category, addOrUpdateSlidingExpirationCacheEntry) :> _
 
+    let applyCacheUpdatesWithFixedTimeSpan
+            (cache : ICache)
+            (prefix : string)
+            (lifetime : TimeSpan)
+            (category : ICategory<'event, 'state, string, 'context>)
+            : ICategory<'event, 'state, string, 'context> =
+        let mkCacheEntry (initialToken : StreamToken, initialState : 'state) = CacheEntry<'state>(initialToken, initialState, Token.supersedes)
+        let addOrUpdateFixedLifetimeCacheEntry streamName value =
+            let expirationPoint = let creationDate = DateTimeOffset.UtcNow in creationDate.Add lifetime
+            let options = CacheItemOptions.AbsoluteExpiration expirationPoint
+            cache.UpdateIfNewer(prefix + streamName, options, mkCacheEntry value)
+        CategoryTee<'event, 'state, 'context>(category, addOrUpdateFixedLifetimeCacheEntry) :> _
+
 type private Folder<'event, 'state, 'context>(category : Category<'event, 'state, 'context>, fold: 'state -> 'event seq -> 'state, initial: 'state, ?readCache) =
     let batched log streamName = category.Load fold initial streamName log
     interface ICategory<'event, 'state, string, 'context> with
@@ -557,6 +570,10 @@ type private Folder<'event, 'state, 'context>(category : Category<'event, 'state
 [<NoComparison; NoEquality; RequireQualifiedAccess>]
 type CachingStrategy =
     | SlidingWindow of ICache * window : TimeSpan
+    /// Retain a single 'state per streamName
+    /// Upon expiration of the span, a reload is triggered
+    /// Typically combined with `Equinox.ResolveOption.AllowStale` to minimize loads
+    | FixedTimeSpan of ICache * span: TimeSpan
     /// Prefix is used to segregate multiple folds per stream when they are stored in the cache
     | SlidingWindowPrefixed of ICache * window : TimeSpan * prefix : string
 
@@ -578,8 +595,9 @@ type Resolver<'event, 'state, 'context>
     let readCacheOption =
         match caching with
         | None -> None
-        | Some (CachingStrategy.SlidingWindow(cache, _)) -> Some(cache, null)
-        | Some (CachingStrategy.SlidingWindowPrefixed(cache, _, prefix)) -> Some(cache, prefix)
+        | Some (CachingStrategy.SlidingWindow (cache, _))
+        | Some (CachingStrategy.FixedTimeSpan (cache, _)) -> Some(cache, null)
+        | Some (CachingStrategy.SlidingWindowPrefixed (cache, _, prefix)) -> Some(cache, prefix)
 
     let folder = Folder<'event, 'state, 'context>(inner, fold, initial, ?readCache = readCacheOption)
 
@@ -588,6 +606,8 @@ type Resolver<'event, 'state, 'context>
         | None -> folder :> _
         | Some (CachingStrategy.SlidingWindow(cache, window)) ->
             Caching.applyCacheUpdatesWithSlidingExpiration cache null window folder
+        | Some (CachingStrategy.FixedTimeSpan (cache, span)) ->
+            Caching.applyCacheUpdatesWithFixedTimeSpan cache null span folder
         | Some (CachingStrategy.SlidingWindowPrefixed(cache, window, prefix)) ->
             Caching.applyCacheUpdatesWithSlidingExpiration cache prefix window folder
 

--- a/src/Equinox.SqlStreamStore/SqlStreamStore.fs
+++ b/src/Equinox.SqlStreamStore/SqlStreamStore.fs
@@ -554,8 +554,8 @@ type Resolver<'event, 'state, 'context>
         match caching with
         | None -> None
         | Some (CachingStrategy.SlidingWindow (cache, _))
-        | Some (CachingStrategy.FixedTimeSpan (cache, _)) -> Some(cache, null)
-        | Some (CachingStrategy.SlidingWindowPrefixed(cache, _, prefix)) -> Some(cache, prefix)
+        | Some (CachingStrategy.FixedTimeSpan (cache, _)) -> Some (cache, null)
+        | Some (CachingStrategy.SlidingWindowPrefixed(cache, _, prefix)) -> Some (cache, prefix)
     let folder = Folder<'event, 'state, 'context>(inner, fold, initial, ?readCache = readCacheOption)
     let category : ICategory<_,_,_,'context> =
         match caching with

--- a/src/Equinox.SqlStreamStore/SqlStreamStore.fs
+++ b/src/Equinox.SqlStreamStore/SqlStreamStore.fs
@@ -526,14 +526,21 @@ type private Folder<'event, 'state, 'context>(category : Category<'event, 'state
             | SyncResult.Conflict resync ->         return SyncResult.Conflict resync
             | SyncResult.Written (token',state') -> return SyncResult.Written (token',state') }
 
+/// For SqlStreamStore, caching is less critical than it is for e.g. CosmosDB
+/// As such, it can often be omitted, particularly if streams are short, or events are small and/or database latency aligns with request latency requirements
 [<NoComparison; NoEquality; RequireQualifiedAccess>]
 type CachingStrategy =
+    /// Retain a single 'state per streamName.
+    /// Each cache hit for a stream renews the retention period for the defined <c>window</c>.
+    /// Upon expiration of the defined <c>window</c> from the point at which the cache was entry was last used, a full reload is triggered.
+    /// Unless <c>ResolveOption.AllowStale</c> is used, each cache hit still incurs a roundtrip to load any subsequently-added events.
     | SlidingWindow of ICache * window: TimeSpan
     /// Retain a single 'state per streamName
-    /// Upon expiration of the span, a reload is triggered
-    /// Typically combined with `Equinox.ResolveOption.AllowStale` to minimize loads
+    /// Upon expiration of the defined <c>span</c>, a full reload is triggered.
+    /// Unless <c>ResolveOption.AllowStale</c> is used, each cache hit still incurs a roundtrip to load any subsequently-added events.
     | FixedTimeSpan of ICache * span: TimeSpan
-    /// Prefix is used to segregate multiple folds per stream when they are stored in the cache
+    /// Prefix is used to segregate multiple folds per stream when they are stored in the cache.
+    /// Semantics are identical to <c>SlidingWindow</c>.
     | SlidingWindowPrefixed of ICache * window: TimeSpan * prefix: string
 
 type Resolver<'event, 'state, 'context>


### PR DESCRIPTION
resolves #254 

NOTE when using this, you need to opt out of the db roundtrip (even with a cache hit) by changing calls to `category.Resolve streamName` to `category.Resolve(streamName, Equinox.AllowStale)`