### PR TITLE
Fix compressUnfolds defaulting for C#

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+- `Cosmos`: Fix defaulting for `compressUnfolds` in C# [#261](https://github.com/jet/equinox/pull/261)
+
 <a name="2.3.0"></a>
 ## [2.3.0] - 2020-11-04
 

--- a/src/Equinox.Cosmos/Cosmos.fs
+++ b/src/Equinox.Cosmos/Cosmos.fs
@@ -1199,7 +1199,7 @@ type Resolver<'event, 'state, 'context>
     (   context : Context, codec, fold, initial, caching, access,
         /// Compress Unfolds in Tip. Default: <c>true<c>.
         /// NOTE when set to <c>false</c>, requires Equinox.Cosmos Version >= 2.3.0 to be able to read
-        ?compressUnfolds) =
+        [<O; D null>]?compressUnfolds) =
     let compressUnfolds = defaultArg compressUnfolds true
     let readCacheOption =
         match caching with


### PR DESCRIPTION
Adds a missing `DefaultValueAttribute`, as evidenced by https://github.com/jet/dotnet-templates/commit/72209da1f2435325b6794e09014d8f9073f5ead4#diff-8c764ce44d257e5ae802cde1162c04cecdd6b005c1ebfe0e799415c4f626f2d0R79