### PR TITLE
Expose pre-state Version via TransactEx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,12 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - Remove separated `Backend` project from examples (support for architecturally separating all domain logic from Equinox and Domain Service logic from Concrete Stores remains)
 - Revise semantics of Cart Sample Command handling
 - Simplify `AsyncCacheCell` [#229](https://github.com/jet/equinox/pull/229)
+- Extend `Decider.TransactEx` signature to expose `ISyncContext` to `decide` functions [#263](https://github.com/jet/equinox/pull/263)
 
 ### Removed
+
+- Remove `Decider.TransactAsyncEx` (`TransactEx` provides superset) [#263](https://github.com/jet/equinox/pull/263)
+
 ### Fixed
 
 - change `createAttemptsExhaustedException` to allow any `exn`-derived `type` [#275](https://github.com/jet/equinox/pull/275)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,12 +44,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - Remove separated `Backend` project from examples (support for architecturally separating all domain logic from Equinox and Domain Service logic from Concrete Stores remains)
 - Revise semantics of Cart Sample Command handling
 - Simplify `AsyncCacheCell` [#229](https://github.com/jet/equinox/pull/229)
-- Extend `Decider.TransactEx` signature to expose `ISyncContext` to `decide` functions [#263](https://github.com/jet/equinox/pull/263)
+- Replace `Decider.TransactAsyncEx` with `TransactEx`, providing an extended signature to expose the `ISyncContext` to `decide` [#263](https://github.com/jet/equinox/pull/263)
 
 ### Removed
-
-- Remove `Decider.TransactAsyncEx` (`TransactEx` provides superset) [#263](https://github.com/jet/equinox/pull/263)
-
 ### Fixed
 
 - change `createAttemptsExhaustedException` to allow any `exn`-derived `type` [#275](https://github.com/jet/equinox/pull/275)

--- a/src/Equinox/Decider.fs
+++ b/src/Equinox/Decider.fs
@@ -23,29 +23,37 @@ type Decider<'event, 'state>
     /// 1a. (if events yielded) Attempt to sync the yielded events events to the stream
     /// 1b. Tries up to <c>maxAttempts</c> times in the case of a conflict, throwing <c>MaxResyncsExhaustedException</c> to signal failure.
     member __.Transact(interpret : 'state -> 'event list) : Async<unit> =
-        transact (fun state -> async { return (), interpret state }) (fun () _context -> ())
+        transact (fun context -> async { return (), interpret context.State }) (fun () _context -> ())
 
     /// 0.  Invoke the supplied <c>decide</c> function with the present state, holding the <c>'result</c>
     /// 1a. (if events yielded) Attempt to sync the yielded events events to the stream
     /// 1b. Tries up to <c>maxAttempts</c> times in the case of a conflict, throwing <c>MaxResyncsExhaustedException</c> to signal failure.
     /// 2.  Yield result
     member __.Transact(decide : 'state -> 'result * 'event list) : Async<'result> =
-        transact (fun state -> async { return decide state }) (fun result _context -> result)
+        transact (fun context -> async { return decide context.State }) (fun result _context -> result)
 
     /// 0.  Invoke the supplied <c>_Async_</c> <c>decide</c> function with the present state, holding the <c>'result</c>
     /// 1a. (if events yielded) Attempt to sync the yielded events events to the stream
     /// 1b. Tries up to <c>maxAttempts</c> times in the case of a conflict, throwing <c>MaxResyncsExhaustedException</c> to signal failure.
     /// 2.  Yield result
     member __.TransactAsync(decide : 'state -> Async<'result * 'event list>) : Async<'result> =
-        transact decide (fun result _context -> result)
+        transact (fun context -> async { return! decide context.State }) (fun result _context -> result)
+
+    /// 0.  Invoke the supplied <c>_Async_</c> <c>decide</c> function with the present state (including extended context), holding the <c>'result</c>
+    /// 1a. (if events yielded) Attempt to sync the yielded events events to the stream
+    /// 1b. Tries up to <c>maxAttempts</c> times in the case of a conflict, throwing <c>MaxResyncsExhaustedException</c> to signal failure.
+    /// 2.  Uses <c>mapResult</c> to render the final outcome from the <c>'result</c> and/or the final <c>ISyncContext</c>
+    /// 3.  Yields the outcome
+    member __.TransactEx(decide : ISyncContext<'state> -> Async<'result * 'event list>, mapResult : 'result -> ISyncContext<'state> -> 'resultEx) : Async<'resultEx> =
+        transact decide mapResult
 
     /// 0.  Invoke the supplied <c>_Async_</c> <c>decide</c> function with the present state, holding the <c>'result</c>
     /// 1a. (if events yielded) Attempt to sync the yielded events events to the stream
     /// 1b. Tries up to <c>maxAttempts</c> times in the case of a conflict, throwing <c>MaxResyncsExhaustedException</c> to signal failure.
     /// 2.  Uses <c>mapResult</c> to render the final outcome from the <c>'result</c> and/or the final <c>ISyncContext</c>
     /// 3.  Yields the outcome
-    member __.TransactAsyncEx(decide : 'state -> Async<'result * 'event list>, mapResult : 'result -> ISyncContext<'state> -> 'result) : Async<'result> =
-        transact decide mapResult
+    member __.TransactAsyncEx(decide : 'state -> Async<'result * 'event list>, mapResult : 'result -> ISyncContext<'state> -> 'view) : Async<'view> =
+        transact (fun context -> async { return! decide context.State }) mapResult
 
     /// Project from the folded <c>'state</c>, without executing a decision flow as <c>Transact</c> does
     member __.Query(projection : 'state -> 'view) : Async<'view> =

--- a/src/Equinox/Decider.fs
+++ b/src/Equinox/Decider.fs
@@ -15,7 +15,7 @@ type Decider<'event, 'state>
 
     let transact decide mapResult =
         let resyncPolicy = defaultArg resyncPolicy (fun _log _attemptNumber resyncF -> async { return! resyncF })
-        let inline createDefaultAttemptsExhaustedException attempts : exn = MaxResyncsExhaustedException attempts :> exn
+        let createDefaultAttemptsExhaustedException attempts : exn = MaxResyncsExhaustedException attempts :> exn
         let createAttemptsExhaustedException = defaultArg createAttemptsExhaustedException createDefaultAttemptsExhaustedException
         Flow.transact (maxAttempts, resyncPolicy, createAttemptsExhaustedException) (stream, log) decide mapResult
 
@@ -37,27 +37,19 @@ type Decider<'event, 'state>
     /// 1b. Tries up to <c>maxAttempts</c> times in the case of a conflict, throwing <c>MaxResyncsExhaustedException</c> to signal failure.
     /// 2.  Yield result
     member __.TransactAsync(decide : 'state -> Async<'result * 'event list>) : Async<'result> =
-        transact (fun context -> async { return! decide context.State }) (fun result _context -> result)
+        transact (fun context -> decide context.State) (fun result _context -> result)
 
     /// 0.  Invoke the supplied <c>_Async_</c> <c>decide</c> function with the present state (including extended context), holding the <c>'result</c>
     /// 1a. (if events yielded) Attempt to sync the yielded events events to the stream
     /// 1b. Tries up to <c>maxAttempts</c> times in the case of a conflict, throwing <c>MaxResyncsExhaustedException</c> to signal failure.
     /// 2.  Uses <c>mapResult</c> to render the final outcome from the <c>'result</c> and/or the final <c>ISyncContext</c>
     /// 3.  Yields the outcome
-    member __.TransactEx(decide : ISyncContext<'state> -> Async<'result * 'event list>, mapResult : 'result -> ISyncContext<'state> -> 'resultEx) : Async<'resultEx> =
+    member __.TransactEx(decide : ISyncContext<'state> -> Async<'result * 'event list>, mapResult : 'result -> ISyncContext<'state> -> 'view) : Async<'view> =
         transact decide mapResult
-
-    /// 0.  Invoke the supplied <c>_Async_</c> <c>decide</c> function with the present state, holding the <c>'result</c>
-    /// 1a. (if events yielded) Attempt to sync the yielded events events to the stream
-    /// 1b. Tries up to <c>maxAttempts</c> times in the case of a conflict, throwing <c>MaxResyncsExhaustedException</c> to signal failure.
-    /// 2.  Uses <c>mapResult</c> to render the final outcome from the <c>'result</c> and/or the final <c>ISyncContext</c>
-    /// 3.  Yields the outcome
-    member __.TransactAsyncEx(decide : 'state -> Async<'result * 'event list>, mapResult : 'result -> ISyncContext<'state> -> 'view) : Async<'view> =
-        transact (fun context -> async { return! decide context.State }) mapResult
 
     /// Project from the folded <c>'state</c>, without executing a decision flow as <c>Transact</c> does
     member __.Query(projection : 'state -> 'view) : Async<'view> =
-        Flow.query (stream, log, fun syncState -> projection (syncState :> ISyncContext<'state>).State)
+        Flow.query (stream, log, fun context -> projection (context :> ISyncContext<'state>).State)
 
     /// Project from the stream's <c>'state<c> (including extended context), without executing a decision flow as <c>Transact<c> does
     member __.QueryEx(projection : ISyncContext<'state> -> 'view) : Async<'view> =

--- a/src/Equinox/Flow.fs
+++ b/src/Equinox/Flow.fs
@@ -79,7 +79,7 @@ module internal Flow =
     /// 2b. if conflicting changes, retry by recommencing at step 1 with the updated state
     let run (log : ILogger) (maxSyncAttempts : int, resyncRetryPolicy, createMaxAttemptsExhaustedException)
         (context : SyncContext<'event, 'state>)
-        (decide : 'state -> Async<'result * 'event list>)
+        (decide : ISyncContext<'state> -> Async<'result * 'event list>)
         (mapResult : 'result -> SyncContext<'event, 'state> -> 'view)
         : Async<'view> =
 
@@ -88,7 +88,7 @@ module internal Flow =
         /// Run a decision cycle - decide what events should be appended given the presented state
         let rec loop attempt : Async<'view> = async {
             let log = if attempt = 1 then log else log.ForContext("syncAttempt", attempt)
-            let! result, events = decide ((context :> ISyncContext<'state>).State)
+            let! result, events = decide (context :> ISyncContext<'state>)
             if List.isEmpty events then
                 log.Debug "No events generated"
                 return mapResult result context


### PR DESCRIPTION
At present, the `Equinox.Decider` interface only exposes the outgoing `Version`, which means the only way to determine the incoming Version is by indirect means such as:
- checking the `Index` of the freshest event (can be incorrect if an Event that's not in the DU is encountered)
- inferring it based on the post-`Version` passed to the `mapResult` (won't work well with transmute operations or rolling snapshots)

This proposal provides the incoming extended state via a new `TransactEx` API, enabling one to process the value directly.

As this is only for V3, it makes sense to remove `TransactAsyncEx` as both APIs are likely extremely rare, and having 2 mysteriously named functions with complex signatures is rarely better than one.

cc @dharmaturtle 