### PR TITLE
Add RollForward for Equinox.Tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Equinox.Tool`: Target `FSharp.Core` v `4.7.1`
 - Update AzDO CI/CD to use `windows-latest`
 - Update to `3.1.101` SDK
-- Add `<RollForward>Major</RollForward>` for `Equinox.Tool`
+- Add `<RollForward>Major</RollForward>` for `Equinox.Tool` [#270](https://github.com/jet/equinox/pull/270)
 - Remove `module Commands` convention from examples
 - Remove separated `Backend` project from examples (support for architecturally separating all domain logic from Equinox and Domain Service logic from Concrete Stores remains)
 - Revise semantics of Cart Sample Command handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Equinox.Tool`: Target `FSharp.Core` v `4.7.1`
 - Update AzDO CI/CD to use `windows-latest`
 - Update to `3.1.101` SDK
+- Add `<RollForward>Major</RollForward>` for `Equinox.Tool`
 - Remove `module Commands` convention from examples
 - Remove separated `Backend` project from examples (support for architecturally separating all domain logic from Equinox and Domain Service logic from Concrete Stores remains)
 - Revise semantics of Cart Sample Command handling

--- a/tools/Equinox.Tool/Equinox.Tool.fsproj
+++ b/tools/Equinox.Tool/Equinox.Tool.fsproj
@@ -13,6 +13,9 @@
     <PackageId>Equinox.Tool</PackageId>
     <AssemblyName>eqx</AssemblyName>
 
+    <!-- Allow to run on SDK >= 5-->
+    <RollForward>Major</RollForward>
+
     <!-- workaround for not being able to make Domain inlined in a complete way https://github.com/nuget/home/issues/3891#issuecomment-377319939 -->
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>

--- a/tools/Equinox.Tool/Equinox.Tool.fsproj
+++ b/tools/Equinox.Tool/Equinox.Tool.fsproj
@@ -12,7 +12,6 @@
 
     <PackageId>Equinox.Tool</PackageId>
     <AssemblyName>eqx</AssemblyName>
-
     <!-- Allow to run on SDK >= 5-->
     <RollForward>Major</RollForward>
 


### PR DESCRIPTION
In order to allow usage of tool where only SDK >= 5 is installed in a given context