### PR TITLE
Fix Cosmos.Prometheus namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
-- `Cosmos.Prometheus`: Correct namespace (was erroneously `Equinox.CosmosStore.Prometheus`) [#268](https://github.com/jet/equinox/pull/268)
+- `Cosmos.Prometheus`: Correct namespace (was erroneously `Equinox.CosmosStore.Prometheus`) [#271](https://github.com/jet/equinox/pull/271)
 
 <a name="2.4.0"></a>
 ## [2.4.0] - 2020-12-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+- `Cosmos.Prometheus`: Correct namespace (was erroneously `Equinox.CosmosStore.Prometheus`) [#268](https://github.com/jet/equinox/pull/268)
+
 <a name="2.4.0"></a>
 ## [2.4.0] - 2020-12-03
 

--- a/src/Equinox.Cosmos.Prometheus/CosmosPrometheus.fs
+++ b/src/Equinox.Cosmos.Prometheus/CosmosPrometheus.fs
@@ -1,4 +1,4 @@
-namespace Equinox.CosmosStore.Prometheus
+namespace Equinox.Cosmos.Prometheus
 
 module private Impl =
 


### PR DESCRIPTION
:blush: Didnt correct the namespace when cherry-picking in #267
Fixing so V2 `.Cosmos` and V3 `.CosmosStore` stores can run side-by-side in future