### PR TITLE
Fix createAttemptsExhaustedException to allow exn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
-- change `createAttemptsExhaustedException` to allow any `exn`-derived `type` [#264](https://github.com/jet/equinox/pull/264)
+- change `createAttemptsExhaustedException` to allow any `exn`-derived `type` [#275](https://github.com/jet/equinox/pull/275)
 
 <a name="2.4.0"></a>
 ## [2.4.0] - 2020-12-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+- change `createAttemptsExhaustedException` to allow any `exn`-derived `type` [#264](https://github.com/jet/equinox/pull/264)
+
 <a name="2.4.0"></a>
 ## [2.4.0] - 2020-12-03
 

--- a/src/Equinox/Decider.fs
+++ b/src/Equinox/Decider.fs
@@ -10,14 +10,14 @@ type MaxResyncsExhaustedException(count) =
 /// Central Application-facing API. Wraps the handling of decision or query flows in a manner that is store agnostic
 type Decider<'event, 'state>
     (   log, stream : IStream<'event, 'state>, maxAttempts : int,
-        [<Optional; DefaultParameterValue(null)>] ?createAttemptsExhaustedException,
+        [<Optional; DefaultParameterValue(null)>] ?createAttemptsExhaustedException : int -> exn,
         [<Optional; DefaultParameterValue(null)>] ?resyncPolicy) =
 
     let transact decide mapResult =
         let resyncPolicy = defaultArg resyncPolicy (fun _log _attemptNumber resyncF -> async { return! resyncF })
-        let throwMaxResyncsExhaustedException attempts = MaxResyncsExhaustedException attempts
-        let handleResyncsExceeded = defaultArg createAttemptsExhaustedException throwMaxResyncsExhaustedException
-        Flow.transact (maxAttempts, resyncPolicy, handleResyncsExceeded) (stream, log) decide mapResult
+        let inline createDefaultAttemptsExhaustedException attempts : exn = MaxResyncsExhaustedException attempts :> exn
+        let createAttemptsExhaustedException = defaultArg createAttemptsExhaustedException createDefaultAttemptsExhaustedException
+        Flow.transact (maxAttempts, resyncPolicy, createAttemptsExhaustedException) (stream, log) decide mapResult
 
     /// 0.  Invoke the supplied <c>interpret</c> function with the present state
     /// 1a. (if events yielded) Attempt to sync the yielded events events to the stream
@@ -44,7 +44,7 @@ type Decider<'event, 'state>
     /// 1b. Tries up to <c>maxAttempts</c> times in the case of a conflict, throwing <c>MaxResyncsExhaustedException</c> to signal failure.
     /// 2.  Uses <c>mapResult</c> to render the final outcome from the <c>'result</c> and/or the final <c>ISyncContext</c>
     /// 3.  Yields the outcome
-    member __.TransactAsyncEx(decide : 'state -> Async<'result * 'event list>, mapResult : 'result -> ISyncContext<'state> -> 'resultEx) : Async<'resultEx> =
+    member __.TransactAsyncEx(decide : 'state -> Async<'result * 'event list>, mapResult : 'result -> ISyncContext<'state> -> 'result) : Async<'result> =
         transact decide mapResult
 
     /// Project from the folded <c>'state</c>, without executing a decision flow as <c>Transact</c> does

--- a/src/Equinox/Flow.fs
+++ b/src/Equinox/Flow.fs
@@ -19,6 +19,7 @@ type SyncResult<'state> =
 
 /// Store-agnostic interface representing interactions a Flow can have with the state of a given event stream. Not intended for direct use by consumer code.
 type IStream<'event, 'state> =
+
     /// Obtain the state from the target stream
     abstract Load : log: ILogger -> Async<StreamToken * 'state>
 
@@ -43,7 +44,7 @@ type ISyncContext<'state> =
 module internal Flow =
 
     /// Represents stream and folding state between the load and run/render phases
-    type SyncState<'event, 'state>
+    type SyncContext<'event, 'state>
         (   originState : StreamToken * 'state,
             trySync : ILogger * StreamToken * 'state * 'event list -> Async<SyncResult<'state>>) =
         let mutable tokenAndState = originState
@@ -77,45 +78,45 @@ module internal Flow =
     /// 2b. if saved without conflict, exit with updated state
     /// 2b. if conflicting changes, retry by recommencing at step 1 with the updated state
     let run (log : ILogger) (maxSyncAttempts : int, resyncRetryPolicy, createMaxAttemptsExhaustedException)
-        (syncState : SyncState<'event, 'state>)
+        (context : SyncContext<'event, 'state>)
         (decide : 'state -> Async<'result * 'event list>)
-        (mapResult : 'result -> SyncState<'event, 'state> -> 'resultEx)
-        : Async<'resultEx> =
+        (mapResult : 'result -> SyncContext<'event, 'state> -> 'view)
+        : Async<'view> =
 
         if maxSyncAttempts < 1 then raise <| System.ArgumentOutOfRangeException("maxSyncAttempts", maxSyncAttempts, "should be >= 1")
 
         /// Run a decision cycle - decide what events should be appended given the presented state
-        let rec loop attempt : Async<'resultEx> = async {
+        let rec loop attempt : Async<'view> = async {
             let log = if attempt = 1 then log else log.ForContext("syncAttempt", attempt)
-            let! result, events = decide (syncState :> ISyncContext<'state>).State
+            let! result, events = decide ((context :> ISyncContext<'state>).State)
             if List.isEmpty events then
                 log.Debug "No events generated"
-                return mapResult result syncState
+                return mapResult result context
             elif attempt = maxSyncAttempts then
                 // Special case: on final attempt, we won't be `resync`ing; we're giving up
-                let! committed = syncState.TryWithoutResync(log, events)
+                let! committed = context.TryWithoutResync(log, events)
                 if not committed then
                     log.Debug "Max Sync Attempts exceeded"
                     return raise (createMaxAttemptsExhaustedException attempt)
                 else
-                    return mapResult result syncState
+                    return mapResult result context
             else
-                let! committed = syncState.TryOrResync(resyncRetryPolicy, attempt, log, events)
+                let! committed = context.TryOrResync(resyncRetryPolicy, attempt, log, events)
                 if not committed then
                     log.Debug "Resyncing and retrying"
                     return! loop (attempt + 1)
                 else
-                    return mapResult result syncState }
+                    return mapResult result context }
 
-        /// Commence, processing based on the incoming state
+        // Commence, processing based on the incoming state
         loop 1
 
     let transact (maxAttempts, resyncRetryPolicy, createMaxAttemptsExhaustedException) (stream : IStream<_, _>, log) decide mapResult : Async<'result> = async {
         let! streamState = stream.Load log
-        let syncState = SyncState(streamState, stream.TrySync)
-        return! run log (maxAttempts, resyncRetryPolicy, createMaxAttemptsExhaustedException) syncState decide mapResult }
+        let context = SyncContext(streamState, stream.TrySync)
+        return! run log (maxAttempts, resyncRetryPolicy, createMaxAttemptsExhaustedException) context decide mapResult }
 
-    let query (stream : IStream<'event, 'state>, log : ILogger, project: SyncState<'event, 'state> -> 'result) : Async<'result> = async {
+    let query (stream : IStream<'event, 'state>, log : ILogger, project: SyncContext<'event, 'state> -> 'result) : Async<'result> = async {
         let! streamState = stream.Load log
-        let syncState = SyncState(streamState, stream.TrySync)
-        return project syncState }
+        let context = SyncContext(streamState, stream.TrySync)
+        return project context }


### PR DESCRIPTION
Cleans `createAttemptsExhaustedException` Decider argument to allow throwing any `Exception`; this had inadvertently been constrained to require it to inherit from `MaxResyncsExhaustedException`