### PR TITLE
CosmosStore: Flip default Connection mode to Direct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- `CosmosStore`: Default Connection Mode now `Direct` to align with V3 SDK (previous default was `Gateway` to match V2 SDK) [#281](https://github.com/jet/equinox/pull/281)
+
 ### Removed
 ### Fixed
 

--- a/samples/Infrastructure/Storage.fs
+++ b/samples/Infrastructure/Storage.fs
@@ -66,7 +66,7 @@ module Cosmos =
                 | TipMaxJsonLength _ -> "specify maximum length of JSON (as measured by JSON.stringify) to hold in Tip before calving off to a frozen Batch. Default: 30,000"
                 | QueryMaxItems _ ->    "specify maximum number of batches of events to retrieve in per query response. Default: 10"
     type Info(args : ParseResults<Arguments>) =
-        member __.Mode =                args.GetResult(ConnectionMode,Microsoft.Azure.Cosmos.ConnectionMode.Direct)
+        member __.Mode =                args.TryGetResult ConnectionMode
         member __.Connection =          args.TryGetResult Connection |> defaultWithEnvVar "EQUINOX_COSMOS_CONNECTION" "Connection"
         member __.Database =            args.TryGetResult Database   |> defaultWithEnvVar "EQUINOX_COSMOS_DATABASE"   "Database"
         member __.Container =           args.TryGetResult Container  |> defaultWithEnvVar "EQUINOX_COSMOS_CONTAINER"  "Container"
@@ -94,7 +94,7 @@ module Cosmos =
     let logContainer (log: ILogger) name (mode, endpoint, db, container) =
         log.Information("CosmosDB {name:l} {mode} {connection} Database {database} Container {container}", name, mode, endpoint, db, container)
     let createClient (a : Info) connectionString =
-        CosmosStoreClientFactory(a.Timeout, a.Retries, a.MaxRetryWaitTime, mode=a.Mode).Create(Discovery.ConnectionString connectionString)
+        CosmosStoreClientFactory(a.Timeout, a.Retries, a.MaxRetryWaitTime, ?mode=a.Mode).Create(Discovery.ConnectionString connectionString)
     let connect (log : ILogger) (a : Info) =
         let (primaryClient, primaryDatabase, primaryContainer) as primary = createClient a a.Connection, a.Database, a.Container
         logContainer log "Primary" (a.Mode, primaryClient.Endpoint, primaryDatabase, primaryContainer)

--- a/samples/Tutorial/AsAt.fsx
+++ b/samples/Tutorial/AsAt.fsx
@@ -159,7 +159,7 @@ module Cosmos =
     open Equinox.CosmosStore
 
     let read key = System.Environment.GetEnvironmentVariable key |> Option.ofObj |> Option.get
-    let factory = CosmosStoreClientFactory(TimeSpan.FromSeconds 5., 2, TimeSpan.FromSeconds 5., mode=Microsoft.Azure.Cosmos.ConnectionMode.Gateway)
+    let factory = CosmosStoreClientFactory(TimeSpan.FromSeconds 5., 2, TimeSpan.FromSeconds 5.)
     let client = factory.Create(Discovery.ConnectionString (read "EQUINOX_COSMOS_CONNECTION"))
     let connection = CosmosStoreConnection(client, read "EQUINOX_COSMOS_DATABASE", read "EQUINOX_COSMOS_CONTAINER")
     let context = CosmosStoreContext(connection)

--- a/samples/Tutorial/Cosmos.fsx
+++ b/samples/Tutorial/Cosmos.fsx
@@ -96,7 +96,8 @@ module Store =
     open Equinox.CosmosStore
 
     let read key = System.Environment.GetEnvironmentVariable key |> Option.ofObj |> Option.get
-    let factory = Equinox.CosmosStore.CosmosStoreClientFactory(System.TimeSpan.FromSeconds 5., 2, System.TimeSpan.FromSeconds 5.)
+    // default connection mode is `Direct`; we use Gateway mode here to reduce connectivity potential issues. Ideally you want to remove that for production for perf reasons
+    let factory = Equinox.CosmosStore.CosmosStoreClientFactory(System.TimeSpan.FromSeconds 5., 2, System.TimeSpan.FromSeconds 5., mode=Microsoft.Azure.Cosmos.ConnectionMode.Gateway)
     let client = factory.Create(Discovery.ConnectionString (read "EQUINOX_COSMOS_CONNECTION"))
     let connection = CosmosStoreConnection(client, read "EQUINOX_COSMOS_DATABASE", read "EQUINOX_COSMOS_CONTAINER")
     let createContext () = CosmosStoreContext(connection)

--- a/samples/Tutorial/FulfilmentCenter.fsx
+++ b/samples/Tutorial/FulfilmentCenter.fsx
@@ -125,7 +125,7 @@ module Store =
 
     let read key = Environment.GetEnvironmentVariable key |> Option.ofObj |> Option.get
     let appName = "equinox-tutorial"
-    let factory = CosmosStoreClientFactory(TimeSpan.FromSeconds 5., 2, TimeSpan.FromSeconds 5., mode=Microsoft.Azure.Cosmos.ConnectionMode.Gateway)
+    let factory = CosmosStoreClientFactory(TimeSpan.FromSeconds 5., 2, TimeSpan.FromSeconds 5.)
     let client = factory.Create(Discovery.ConnectionString (read "EQUINOX_COSMOS_CONNECTION"))
     let connection = CosmosStoreConnection(client, read "EQUINOX_COSMOS_DATABASE", read "EQUINOX_COSMOS_CONTAINER")
     let context = CosmosStoreContext(connection)

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -1397,7 +1397,8 @@ type CosmosStoreClientFactory
         maxRetryWaitTimeOnRateLimitedRequests: TimeSpan,
         /// Connection limit for Gateway Mode (default 1000)
         [<O; D(null)>]?gatewayModeMaxConnectionLimit,
-        /// Connection mode (default: ConnectionMode.Gateway (lowest perf, least trouble))
+        /// Connection mode (default: ConnectionMode.Direct (best performance, same as Microsoft.Azure.Cosmos SDK default)
+        /// NOTE: default for Equinox.Cosmos.Connector (i.e. V2) was Gateway (worst performance, least trouble, Microsoft.Azure.DocumentDb SDK default)
         [<O; D(null)>]?mode : ConnectionMode,
         /// consistency mode (default: ConsistencyLevel.Session)
         [<O; D(null)>]?defaultConsistencyLevel : ConsistencyLevel,
@@ -1413,8 +1414,8 @@ type CosmosStoreClientFactory
                 MaxRetryWaitTimeOnRateLimitedRequests = maxWait,
                 RequestTimeout = timeout)
         match mode with
-        | Some ConnectionMode.Direct -> co.ConnectionMode <- ConnectionMode.Direct
-        | None | Some ConnectionMode.Gateway | Some _ (* enum total match :( *) -> co.ConnectionMode <- ConnectionMode.Gateway // default; only supports Https
+        | None | Some ConnectionMode.Direct -> co.ConnectionMode <- ConnectionMode.Direct
+        | Some ConnectionMode.Gateway | Some _ (* enum total match :( *) -> co.ConnectionMode <- ConnectionMode.Gateway // only supports Https
         match gatewayModeMaxConnectionLimit with
         | Some _ when co.ConnectionMode = ConnectionMode.Direct -> invalidArg "gatewayModeMaxConnectionLimit" "Not admissible in Direct mode"
         | x -> if co.ConnectionMode = ConnectionMode.Gateway then co.GatewayModeMaxConnectionLimit <- defaultArg x 1000


### PR DESCRIPTION
The `Cosmos` store on the `/v2` branch has the default connection mode aligned with the underlying Cosmos V2 SDK default mode: Gateway

The fact that this can leave significant perf on the table, and is not aligned with the default in the Cosmos V3 SDK makes this a bad default going forward so taking the hit of breaking it now as we move to V3.