### PR TITLE
Consistency changes/fixes for `ISyncContext.Version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,17 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- `ISyncContext.Version`: documented value as being `0`-based, rather than whatever a given store happens to use internally (which happens to align with the native version representation in `Equinox.Cosmos`) [#282](https://github.com/jet/equinox/pull/282)
+- `MemoryStore` / `SqlStreamStore` / `EventStore`: aligned implementations to represent `Version` in a store-neutral manner per the documentation change [#282](https://github.com/jet/equinox/pull/282)
+
 ### Removed
 ### Fixed
 
+- `Cosmos` / `ISyncContext.Version`: fixed erroneous `0` value when re-reading with caching but without snapshots in `Cosmos` store [#282](https://github.com/jet/equinox/pull/282)
+
 <a name="2.5.0"></a>
 ## [2.5.0] - 2021-02-24
-
 
 ### Added
 

--- a/samples/Store/Backend/Favorites.fs
+++ b/samples/Store/Backend/Favorites.fs
@@ -7,21 +7,20 @@ type Service(log, resolve, ?maxAttempts) =
 
     let resolve (Events.ForClientId streamId) = Equinox.Stream(log, resolve streamId, defaultArg maxAttempts 2)
 
-    let execute clientId command : Async<unit> =
+    member __.Execute(clientId, command) =
         let stream = resolve clientId
         stream.Transact(Commands.interpret command)
-    let read clientId : Async<Events.Favorited []> =
-        let stream = resolve clientId
-        stream.Query id
-
-    member __.Execute(clientId, command) =
-        execute clientId command
 
     member __.Favorite(clientId, skus) =
-        execute clientId (Command.Favorite(DateTimeOffset.Now, skus))
+        __.Execute(clientId, Command.Favorite(DateTimeOffset.Now, skus))
 
     member __.Unfavorite(clientId, sku) =
-        execute clientId (Command.Unfavorite sku)
+        __.Execute(clientId, Command.Unfavorite sku)
 
     member __.List clientId : Async<Events.Favorited []> =
-        read clientId 
+        let stream = resolve clientId
+        stream.Query(id)
+
+    member __.ListWithVersion clientId : Async<int64 * Events.Favorited []> =
+        let stream = resolve clientId
+        stream.QueryEx(fun ctx -> ctx.Version, ctx.State)

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -317,7 +317,9 @@ module Token =
         {   value = box {
                 stream = { name = streamName}
                 pos = { streamVersion = streamVersion; compactionEventNumber = compactionEventNumber; batchCapacityLimit = batchCapacityLimit } }
-            version = streamVersion }
+            // In this impl, the StreamVersion matches the EventStore StreamVersion in being -1-based
+            // Version however is the representation that needs to align with ISyncContext.Version
+            version = streamVersion + 1L }
 
     /// No batching / compaction; we only need to retain the StreamVersion
     let ofNonCompacting streamName streamVersion : StreamToken =

--- a/src/Equinox.SqlStreamStore/SqlStreamStore.fs
+++ b/src/Equinox.SqlStreamStore/SqlStreamStore.fs
@@ -301,7 +301,9 @@ module Token =
         {   value = box {
                 stream = { name = streamName}
                 pos = { streamVersion = streamVersion; compactionEventNumber = compactionEventNumber; batchCapacityLimit = batchCapacityLimit } }
-            version = streamVersion }
+            // In this impl, the StreamVersion matches the SqlStreamStore (and EventStore) StreamVersion in being -1-based
+            // Version however is the representation that needs to align with ISyncContext.Version
+            version = streamVersion + 1L }
     /// No batching / compaction; we only need to retain the StreamVersion
     let ofNonCompacting streamName streamVersion : StreamToken =
         create None None streamName streamVersion

--- a/src/Equinox/Flow.fs
+++ b/src/Equinox/Flow.fs
@@ -33,7 +33,10 @@ type ISyncContext<'state> =
     /// Represents a Checkpoint position on a Stream's timeline; Can be used to manage continuations via a Resolver's FromMemento method
     abstract member CreateMemento : unit -> StreamToken * 'state
 
-    /// Exposes the underlying Store's internal Version/Index (which, depending on the Codec, may or may not be reflected in the last event presented)
+    /// Exposes the underlying Store's internal Version for the underlying stream.
+    /// An empty stream is Version 0; one with a single event is Version 1 etc.
+    /// It's important to consider that this Version is more authoritative than inspecting the `Index` of the last event passed to
+    /// your `fold` function - the codec may opt to ignore it
     abstract member Version : int64
 
     /// The present State of the stream within the context of this Flow


### PR DESCRIPTION
This addresses a problem at two levels:

- `Equinox.Cosmos` v `2.5.0` can return a Version of `0` when re-reading a stream that
    a) uses `AccessStrategy.Unoptimized`
    b) uses a cache
- the `Version` field was defined in an ambiguous manner, indicating it was a store-native version field
    a) That doesn't make sense for an interface in the `Equinox` package
    b) There's a reasonable general way to express it in a neutral way
    
The fix consists of:
- a doc change for the property
- patching the bug in the corner case that caused the actual issue (will follow up with a V3 edition of this shortly - its likely that the events in Tip impl removed the issue on that side)
- changing the impl of the SSS, ESDB and MemoryStore stores to match the new definition