### PR TITLE
Backtick ruins GH syntax highlighting

### DIFF
--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -1427,7 +1427,7 @@ type AccessStrategy<'event,'state> =
     /// Don't apply any optimized reading logic. Note this can be extremely RU cost prohibitive
     /// and can severely impact system scalability. Should hence only be used with careful consideration.
     | Unoptimized
-    /// Load only the single most recent event defined in <c>'event`</c> and trust that doing a <c>fold</c> from any such event
+    /// Load only the single most recent event defined in <c>'event</c> and trust that doing a <c>fold</c> from any such event
     /// will yield a correct and complete state
     /// In other words, the <c>fold</c> function should not need to consider either the preceding <c>'state</state> or <c>'event</c>s.
     /// <remarks>


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/5726993/133251079-e86135c5-eaae-4dea-a6e3-44fe8c0803e2.png)

After:

![image](https://user-images.githubusercontent.com/5726993/133251396-d2b78cb8-52ce-475b-977b-a83043b17f24.png)
