### PR TITLE
MemoryStore: Fix Version for post-context in Equinox.Decider.TransactEx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Changed
 ### Removed
 ### Fixed
+ 
+- `MemoryStore`: Fixed incorrect `Version` computation for `TransactEx` post-State [#296](https://github.com/jet/equinox/pull/296)
 
 <a name="3.0.4"></a>
 ## [3.0.4] - 2021-10-15

--- a/samples/Store/Domain.Tests/FavoritesTests.fs
+++ b/samples/Store/Domain.Tests/FavoritesTests.fs
@@ -10,6 +10,15 @@ open System
 let mkFavorite skuId    = Favorited { date = DateTimeOffset.UtcNow; skuId = skuId }
 let mkUnfavorite skuId  = Unfavorited { skuId = skuId }
 
+type Command =
+    | Favorite      of date : DateTimeOffset * skuIds : SkuId list
+    | Unfavorite    of skuId : SkuId
+
+let interpret (command : Command) =
+    match command with
+    | Favorite (date, skus) ->  decideFavorite date skus
+    | Unfavorite sku ->         decideUnfavorite sku
+
 /// Put the aggregate into the state where the command should trigger an event; verify correct events are yielded
 let verifyCorrectEventGenerationWhenAppropriate command (originState: State) =
     let initialEvents = command |> function


### PR DESCRIPTION
Corrects `MemoryStore`'s computation of the post-`Version` for use by `Equinox.Decider.TransactEx`
Refactors conflict case path to remove ugly use of `Exception` that I once assumed to be unavoidable