### PR TITLE
CosmosStore: Cleanup Cosmos calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
    - target `Microsoft.Azure.Cosmos` v `3.9.0` (instead of `Microsoft.Azure.DocumentDB`[`.Core`] v 2.x) [#144](https://github.com/jet/equinox/pull/144)
    - Replaced `BatchingPolicy`, `RetryPolicy` with `TipOptions`, `QueryOptions` to better align with Cosmos SDK V4 [#253](https://github.com/jet/equinox/pull/253)
    - Reorganized `QueryRetryPolicy` to handle `IAsyncEnumerable` coming in Cosmos SDK V4 [#246](https://github.com/jet/equinox/pull/246) :pray: [@ylibrach](https://github.com/ylibrach)
-   - Remove exceptions from 302/404 paths when reading Tip [#257](https://github.com/jet/equinox/pull/257)
+   - Remove exceptions from 304/404 paths when reading Tip [#257](https://github.com/jet/equinox/pull/257)
    - Removed [warmup call](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/1436)
    - Rename `Equinox.Cosmos` DLL and namespace to `Equinox.CosmosStore` [#243](https://github.com/jet/equinox/pull/243)
         - Rename `Equinox.Cosmos.Store` -> `Equinox.CosmosStore.Core` 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1735,7 +1735,7 @@ produce the `state` by folding in a variety of ways:
 
 If we have `state5` based on the events up to `C3 d5`, and (being the writer,
 or a recent reader), have the etag: `etagXYZ`, we can do a `HTTP GET` with
-`etag: IfNoneMatch etagXYZ`, which will return `302 Not Modified` with < 1K of
+`etag: IfNoneMatch etagXYZ`, which will return `304 Not Modified` with < 1K of
 data, and a charge of `1.00` RU allowing us to derive the state as:
 
 - `state5`

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ _If you're looking to learn more about and/or discuss Event Sourcing and it's my
     - It can maintain events in a buffer when the tip accumulation limit is reached. The limit is up to a specified count or `JSON.stringify` length. When the limit is met, events are shifted to a immutable `Batch`. 
   - Has the benefits of the in-stream Rolling Snapshots approach while reducing latency and RU provisioning requirements due to meticulously tuned Request Charge costs:
     - When the stream is empty, the initial `Load` operation involves a single point read that yields a `404 NotFound` response, costing 1.0 RU
-    - When coupled with the cache, a typical read is a point read [with `IfNoneMatch` on an etag], costing 1.0 RU if in-date [to get the `302 Not Found` response] (when the stream is empty, a `404 NotFound` response, also costing 1.0 RU)
+    - When coupled with the cache, a typical read is a point read [with `IfNoneMatch` on an etag], costing 1.0 RU if in-date [to get the `304 Not Modified` response] (when the stream is empty, a `404 NotFound` response, also costing 1.0 RU)
     - Writes are a single invocation of the `Sync` stored procedure which:
         - Does a point read
         - Performs a concurrency check

--- a/samples/Tutorial/Cosmos.fsx
+++ b/samples/Tutorial/Cosmos.fsx
@@ -99,7 +99,7 @@ module Store =
     // default connection mode is `Direct`; we use Gateway mode here to reduce connectivity potential issues. Ideally you want to remove that for production for perf reasons
     let discovery = Discovery.ConnectionString (read "EQUINOX_COSMOS_CONNECTION")
     let connector = CosmosStoreConnector(discovery, System.TimeSpan.FromSeconds 5., 2, System.TimeSpan.FromSeconds 5., Microsoft.Azure.Cosmos.ConnectionMode.Gateway)
-            
+
     let storeClient = CosmosStoreClient.Connect(connector.CreateAndInitialize, read "EQUINOX_COSMOS_DATABASE", read "EQUINOX_COSMOS_CONTAINER") |> Async.RunSynchronously
     let context = CosmosStoreContext(storeClient, tipMaxEvents = 10)
     let cache = Equinox.Cache(appName, 20)
@@ -109,11 +109,11 @@ let service = Favorites.Cosmos.create (Store.context, Store.cache)
 let client = "ClientJ"
 
 service.Favorite(client, "a") |> Async.RunSynchronously
-service.Favorite(client, "b") |> Async.RunSynchronously 
-service.List(client) |> Async.RunSynchronously 
+service.Favorite(client, "b") |> Async.RunSynchronously
+service.List(client) |> Async.RunSynchronously
 
-service.Unfavorite(client, "b") |> Async.RunSynchronously 
-service.List(client) |> Async.RunSynchronously 
+service.Unfavorite(client, "b") |> Async.RunSynchronously
+service.List(client) |> Async.RunSynchronously
 
 Log.dumpMetrics ()
 
@@ -132,10 +132,10 @@ Log.dumpMetrics ()
 [13:48:33 INF] EqxCosmos QueryF Favorites-ClientJ v5 5/1 185ms rc=4.37
 [13:48:33 DBG] Resyncing and retrying
 [13:48:33 INF] EqxCosmos Sync 1+0 96ms rc=37.67
-[13:48:34 INF] EqxCosmos Tip 302 90ms rc=1
-[13:48:34 INF] EqxCosmos Tip 302 92ms rc=1
+[13:48:34 INF] EqxCosmos Tip 304 90ms rc=1
+[13:48:34 INF] EqxCosmos Tip 304 92ms rc=1
 [13:48:34 INF] EqxCosmos Sync 1+0 96ms rc=37.33
-[13:48:34 INF] EqxCosmos Tip 302 87ms rc=1
+[13:48:34 INF] EqxCosmos Tip 304 87ms rc=1
 [13:48:34 INF] Read: 8 requests costing 16 RU (average: 2.05); Average latency: 125ms
 [13:48:34 INF] Write: 3 requests costing 80 RU (average: 26.80); Average latency: 94ms
 [13:48:34 INF] TOTAL: 11 requests costing 97 RU (average: 8.80); Average latency: 116ms

--- a/samples/Tutorial/Todo.fsx
+++ b/samples/Tutorial/Todo.fsx
@@ -39,7 +39,7 @@ let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
 
 type State = { items : Todo list; nextId : int }
 let initial = { items = []; nextId = 0 }
-let evolve s (e : Event) = 
+let evolve s (e : Event) =
     match e with
     | Added item -> { s with items = item :: s.items; nextId = s.nextId + 1 }
     | Updated value -> { s with items = s.items |> List.map (function { id = id } when id = value.id -> value | item -> item) }
@@ -163,7 +163,7 @@ service.TryGet(client, 3) |> Async.RunSynchronously
 
 let itemH = { id = 1; order = 0; title = "Feed horse"; completed = false }
 service.Patch(client, itemH) |> Async.RunSynchronously
-//[05:49:33 INF] EqxCosmos Tip 302 116ms rc=1
+//[05:49:33 INF] EqxCosmos Tip 304 116ms rc=1
 //Updated {id = 1;
 //         order = 0;
 //         title = "Feed horse";
@@ -175,10 +175,10 @@ service.Patch(client, itemH) |> Async.RunSynchronously
 //                 order = 0;
 //                 title = "Feed horse";
 //                 completed = false;}
-service.Execute(client, Delete 1) |> Async.RunSynchronously 
-//[05:47:18 INF] EqxCosmos Tip 302 224ms rc=1
+service.Execute(client, Delete 1) |> Async.RunSynchronously
+//[05:47:18 INF] EqxCosmos Tip 304 224ms rc=1
 //Deleted 1[05:47:19 INF] EqxCosmos Sync 1+1 230ms rc=13.91
 //val it : unit = ()
 service.List(client) |> Async.RunSynchronously
-//[05:47:22 INF] EqxCosmos Tip 302 119ms rc=1
+//[05:47:22 INF] EqxCosmos Tip 304 119ms rc=1
 //val it : seq<Todo> = []

--- a/src/Equinox.CosmosStore.Prometheus/CosmosStorePrometheus.fs
+++ b/src/Equinox.CosmosStore.Prometheus/CosmosStorePrometheus.fs
@@ -110,7 +110,7 @@ type LogSink(customTags: seq<string * string>) =
             | MetricEvent cm -> cm |> function
                 | Op       (Operation.Tip,      m) -> observeTip  ("query",    "tip",           "ok", "200") m
                 | Op       (Operation.Tip404,   m) -> observeTip  ("query",    "tip",           "ok", "404") m
-                | Op       (Operation.Tip302,   m) -> observeTip  ("query",    "tip",           "ok", "302") m
+                | Op       (Operation.Tip304,   m) -> observeTip  ("query",    "tip",           "ok", "304") m
                 | Op       (Operation.Query,    m) -> observe     ("query",    "query",         "ok")        m
                 | QueryRes (_direction,         m) -> observeRes  ("query",    "queryPage")                  m
                 | Op       (Operation.Write,    m) -> observe     ("transact", "sync",          "ok")        m

--- a/tests/Equinox.CosmosStore.Integration/CosmosCoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosCoreIntegration.fs
@@ -163,7 +163,7 @@ type Tests(testOutputHelper) =
 
         let! _pos = ctx.Sync(stream,pos)
         test <@ [EqxAct.TipNotModified] = capture.ExternalCalls @>
-        verifyRequestChargesMax 1 // for a 302 by definition - when an etag IfNotMatch is honored, you only pay one RU
+        verifyRequestChargesMax 1 // for a 304 by definition - when an etag IfNotMatch is honored, you only pay one RU
     }
 
     [<AutoData(MaxTest = 2, SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]


### PR DESCRIPTION
Long overdue cleanup in CosmosStore - initial logic was intentionally matching V2 init logic, but it can be clarified now based on:
- support for Autoscale from @belcher-rok 
- the V3 SDK has Database and Container objects where V2 did not