### PR TITLE
CosmosStore: Switch to JsonElement bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `CosmosStore`: Require `Microsoft.Azure.Cosmos` v `3.0.25` [#310](https://github.com/jet/equinox/pull/310)
 - `SqlStreamStore`.*: Target `SqlStreamStore` v `1.2.0` (`Postgres` remains at `1.2.0-beta.8` as that's the last released version) [#227](https://github.com/jet/equinox/pull/227) :pray: [@rajivhost](https://github.com/rajivhost)
 - Update all non-Client dependencies except `FSharp.Core`, `FSharp.Control.AsyncSeq` [#310](https://github.com/jet/equinox/pull/310)
+- `CosmosStore`: Switch to natively using `JsonElement` event bodies [#305](https://github.com/jet/equinox/pull/305) :pray: [@ylibrach](https://github.com/ylibrach)
+- `CosmosStore`: Switch to natively using `System.Text.Json` for serialization of all `Microsoft.Azure.Cosmos` round-trips [#305](https://github.com/jet/equinox/pull/305) :pray: [@ylibrach](https://github.com/ylibrach)
+- `CosmosStore`: Only log `bytes` when log level is `Debug` [#305](https://github.com/jet/equinox/pull/305)
 
 ### Removed
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 - `eqx`/`Equinox.Tool`: Flip `-P` option to opt _in_ to pretty printing [#313](https://github.com/jet/equinox/pull/313)
 - `CosmosStore`: Require `Microsoft.Azure.Cosmos` v `3.0.25` [#310](https://github.com/jet/equinox/pull/310)
-- `SqlStreamStore`.*: Target `SqlStreamStore` v `1.2.0` (`Postgres` remains at `1.2.0-beta.8` as that's the last released version) [#227](https://github.com/jet/equinox/pull/227) :pray: [@rajivhost](https://github.com/rajivhost)
-- Update all non-Client dependencies except `FSharp.Core`, `FSharp.Control.AsyncSeq` [#310](https://github.com/jet/equinox/pull/310)
 - `CosmosStore`: Switch to natively using `JsonElement` event bodies [#305](https://github.com/jet/equinox/pull/305) :pray: [@ylibrach](https://github.com/ylibrach)
 - `CosmosStore`: Switch to natively using `System.Text.Json` for serialization of all `Microsoft.Azure.Cosmos` round-trips [#305](https://github.com/jet/equinox/pull/305) :pray: [@ylibrach](https://github.com/ylibrach)
 - `CosmosStore`: Only log `bytes` when log level is `Debug` [#305](https://github.com/jet/equinox/pull/305)
+- `SqlStreamStore`.*: Target `SqlStreamStore` v `1.2.0` (`Postgres` remains at `1.2.0-beta.8` as that's the last released version) [#227](https://github.com/jet/equinox/pull/227) :pray: [@rajivhost](https://github.com/rajivhost)
+- Update all non-Client dependencies except `FSharp.Core`, `FSharp.Control.AsyncSeq` [#310](https://github.com/jet/equinox/pull/310)
 
 ### Removed
  

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,4 @@
 name: $(Rev:r)
-trigger:
-- master
-- main
-- refs/tags/*
 jobs:
 - job: Windows
   pool:

--- a/samples/Infrastructure/Services.fs
+++ b/samples/Infrastructure/Services.fs
@@ -3,6 +3,7 @@
 open Domain
 open Microsoft.Extensions.DependencyInjection
 open System
+open FsCodec.SystemTextJson
 
 type StreamResolver(storage) =
     member _.Resolve
@@ -13,7 +14,7 @@ type StreamResolver(storage) =
         match storage with
         | Storage.StorageConfig.Cosmos (store, caching, unfolds) ->
             let accessStrategy = if unfolds then Equinox.CosmosStore.AccessStrategy.Snapshot snapshot else Equinox.CosmosStore.AccessStrategy.Unoptimized
-            Equinox.CosmosStore.CosmosStoreCategory<'event,'state,_>(store, codec, fold, initial, caching, accessStrategy).Resolve
+            Equinox.CosmosStore.CosmosStoreCategory<'event,'state,_>(store, codec.ToJsonElementCodec(), fold, initial, caching, accessStrategy).Resolve
         | Storage.StorageConfig.Es (context, caching, unfolds) ->
             let accessStrategy = if unfolds then Equinox.EventStore.AccessStrategy.RollingSnapshots snapshot |> Some else None
             Equinox.EventStore.EventStoreCategory<'event,'state,_>(context, codec, fold, initial, ?caching = caching, ?access = accessStrategy).Resolve

--- a/samples/Infrastructure/Services.fs
+++ b/samples/Infrastructure/Services.fs
@@ -1,9 +1,9 @@
 ﻿module Samples.Infrastructure.Services
 
 open Domain
+open FsCodec.SystemTextJson
 open Microsoft.Extensions.DependencyInjection
 open System
-open FsCodec.SystemTextJson
 
 type StreamResolver(storage) =
     member _.Resolve

--- a/samples/Store/Domain/Cart.fs
+++ b/samples/Store/Domain/Cart.fs
@@ -25,6 +25,7 @@ module Events =
         | ItemPropertiesChanged     of ItemPropertiesChangedInfo
         interface TypeShape.UnionContract.IUnionContract
     let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
+    let codecStj = FsCodec.SystemTextJson.Codec.Create<Event>()
 
 module Fold =
 

--- a/samples/Store/Domain/ContactPreferences.fs
+++ b/samples/Store/Domain/ContactPreferences.fs
@@ -13,6 +13,7 @@ module Events =
         | [<System.Runtime.Serialization.DataMember(Name = "contactPreferencesChanged")>]Updated of Value
         interface TypeShape.UnionContract.IUnionContract
     let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
+    let codecStj = FsCodec.SystemTextJson.Codec.Create<Event>()
 
 module Fold =
 

--- a/samples/Store/Domain/Domain.fsproj
+++ b/samples/Store/Domain/Domain.fsproj
@@ -22,6 +22,7 @@
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
 
     <PackageReference Include="FsCodec.NewtonsoftJson" Version="2.3.1" />
+    <PackageReference Include="FsCodec.SystemTextJson" Version="2.3.1" />
 
     <ProjectReference Include="..\..\..\src\Equinox\Equinox.fsproj" />
   </ItemGroup>

--- a/samples/Store/Domain/Favorites.fs
+++ b/samples/Store/Domain/Favorites.fs
@@ -15,6 +15,7 @@ module Events =
         | Unfavorited                           of Unfavorited
         interface TypeShape.UnionContract.IUnionContract
     let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
+    let codecStj = FsCodec.SystemTextJson.Codec.Create<Event>()
 
 module Fold =
 

--- a/samples/Store/Domain/Infrastructure.fs
+++ b/samples/Store/Domain/Infrastructure.fs
@@ -32,7 +32,7 @@ module Guid =
 /// - Ensures canonical rendering without dashes via ToString + Newtonsoft.Json
 /// - Guards against XSS by only permitting initialization based on Guid.Parse
 /// - Implements comparison/equality solely to enable tests to leverage structural equality
-[<Sealed; AutoSerializable(false); JsonConverter(typeof<SkuIdJsonConverter>)>]
+[<Sealed; AutoSerializable(false); JsonConverter(typeof<SkuIdJsonConverter>); System.Text.Json.Serialization.JsonConverter(typeof<SkuIdJsonConverterStj>)>]
 type SkuId private (id : string) =
     inherit StringId<SkuId>(id)
     new(value : Guid) = SkuId(value.ToString "N")
@@ -45,6 +45,10 @@ and private SkuIdJsonConverter() =
     override __.Pickle value = string value
     /// Input must be a `Guid.Parse`able value
     override __.UnPickle input = Guid.Parse input |> SkuId
+and private SkuIdJsonConverterStj() =
+    inherit FsCodec.SystemTextJson.JsonIsomorphism<SkuId, string>()
+    override _.Pickle value = string value
+    override _.UnPickle input = Guid.Parse input |> SkuId
 
 /// RequestId strongly typed id, represented internally as a string
 /// - Ensures canonical rendering without dashes via ToString, Newtonsoft.Json, sprintf "%s" etc

--- a/samples/Store/Integration/CartIntegration.fs
+++ b/samples/Store/Integration/CartIntegration.fs
@@ -15,6 +15,7 @@ let createServiceMemory log store =
     Cart.create log (fun (id,opt) -> MemoryStore.MemoryStoreCategory(store, Domain.Cart.Events.codec, fold, initial).Resolve(id,?option=opt))
 
 let codec = Cart.Events.codec
+let codecStj = Cart.Events.codecStj
 
 let resolveGesStreamWithRollingSnapshots context =
     fun (id,opt) -> EventStore.EventStoreCategory(context, codec, fold, initial, access = EventStore.AccessStrategy.RollingSnapshots snapshot).Resolve(id,?option=opt)
@@ -22,9 +23,9 @@ let resolveGesStreamWithoutCustomAccessStrategy context =
     fun (id,opt) -> EventStore.EventStoreCategory(context, codec, fold, initial).Resolve(id,?option=opt)
 
 let resolveCosmosStreamWithSnapshotStrategy context =
-    fun (id,opt) -> CosmosStore.CosmosStoreCategory(context, codec, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Snapshot snapshot).Resolve(id,?option=opt)
+    fun (id,opt) -> CosmosStore.CosmosStoreCategory(context, codecStj, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Snapshot snapshot).Resolve(id,?option=opt)
 let resolveCosmosStreamWithoutCustomAccessStrategy context =
-    fun (id,opt) -> CosmosStore.CosmosStoreCategory(context, codec, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Unoptimized).Resolve(id,?option=opt)
+    fun (id,opt) -> CosmosStore.CosmosStoreCategory(context, codecStj, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Unoptimized).Resolve(id,?option=opt)
 
 let addAndThenRemoveItemsManyTimesExceptTheLastOne context cartId skuId (service: Cart.Service) count =
     service.ExecuteManyAsync(cartId, false, seq {

--- a/samples/Store/Integration/ContactPreferencesIntegration.fs
+++ b/samples/Store/Integration/ContactPreferencesIntegration.fs
@@ -14,18 +14,19 @@ let createServiceMemory log store =
     ContactPreferences.create log (MemoryStore.MemoryStoreCategory(store, FsCodec.Box.Codec.Create(), fold, initial).Resolve)
 
 let codec = ContactPreferences.Events.codec
+let codecStj = ContactPreferences.Events.codecStj
 let resolveStreamGesWithOptimizedStorageSemantics context =
     EventStore.EventStoreCategory(context 1, codec, fold, initial, access = EventStore.AccessStrategy.LatestKnownEvent).Resolve
 let resolveStreamGesWithoutAccessStrategy context =
     EventStore.EventStoreCategory(context defaultBatchSize, codec, fold, initial).Resolve
 
 let resolveStreamCosmosWithLatestKnownEventSemantics context =
-    CosmosStore.CosmosStoreCategory(context, codec, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.LatestKnownEvent).Resolve
+    CosmosStore.CosmosStoreCategory(context, codecStj, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.LatestKnownEvent).Resolve
 let resolveStreamCosmosUnoptimized context =
-    CosmosStore.CosmosStoreCategory(context, codec, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Unoptimized).Resolve
+    CosmosStore.CosmosStoreCategory(context, codecStj, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Unoptimized).Resolve
 let resolveStreamCosmosRollingUnfolds context =
     let access = CosmosStore.AccessStrategy.Custom(ContactPreferences.Fold.isOrigin, ContactPreferences.Fold.transmute)
-    CosmosStore.CosmosStoreCategory(context, codec, fold, initial, CosmosStore.CachingStrategy.NoCaching, access).Resolve
+    CosmosStore.CosmosStoreCategory(context, codecStj, fold, initial, CosmosStore.CachingStrategy.NoCaching, access).Resolve
 
 type Tests(testOutputHelper) =
     let testOutput = TestOutputAdapter testOutputHelper

--- a/samples/Store/Integration/FavoritesIntegration.fs
+++ b/samples/Store/Integration/FavoritesIntegration.fs
@@ -14,18 +14,19 @@ let createMemoryStore () = MemoryStore.VolatileStore<_>()
 let createServiceMemory log store =
     Favorites.create log (MemoryStore.MemoryStoreCategory(store, FsCodec.Box.Codec.Create(), fold, initial).Resolve)
 
-let codec = Domain.Favorites.Events.codec
+let codec = Favorites.Events.codec
+let codecStj = Favorites.Events.codecStj
 let createServiceGes log context =
     let cat = EventStore.EventStoreCategory(context, codec, fold, initial, access = EventStore.AccessStrategy.RollingSnapshots snapshot)
     Favorites.create log cat.Resolve
 
 let createServiceCosmosSnapshotsUncached log context =
-    let cat = CosmosStore.CosmosStoreCategory(context, codec, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Snapshot snapshot)
+    let cat = CosmosStore.CosmosStoreCategory(context, codecStj, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Snapshot snapshot)
     Favorites.create log cat.Resolve
 
 let createServiceCosmosRollingStateUncached log context =
     let access = CosmosStore.AccessStrategy.RollingState Favorites.Fold.snapshot
-    let cat = CosmosStore.CosmosStoreCategory(context, codec, fold, initial, CosmosStore.CachingStrategy.NoCaching, access)
+    let cat = CosmosStore.CosmosStoreCategory(context, codecStj, fold, initial, CosmosStore.CachingStrategy.NoCaching, access)
     Favorites.create log cat.Resolve
 
 let createServiceCosmosUnoptimizedButCached log context =
@@ -33,7 +34,7 @@ let createServiceCosmosUnoptimizedButCached log context =
     let caching =
         let cache = Equinox.Cache ("name", 10)
         CosmosStore.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
-    let cat = CosmosStore.CosmosStoreCategory(context, codec, fold, initial, caching, access)
+    let cat = CosmosStore.CosmosStoreCategory(context, codecStj, fold, initial, caching, access)
     Favorites.create log cat.Resolve
 
 type Command =

--- a/samples/Tutorial/Gapless.fs
+++ b/samples/Tutorial/Gapless.fs
@@ -18,7 +18,7 @@ module Events =
         | Released of Item
         | Snapshotted of Snapshotted
         interface TypeShape.UnionContract.IUnionContract
-    let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
+    let codec = FsCodec.SystemTextJson.Codec.Create<Event>()
 
 module Fold =
 

--- a/samples/Tutorial/Index.fs
+++ b/samples/Tutorial/Index.fs
@@ -13,7 +13,7 @@ module Events =
         | Deleted of ItemIds
         | Snapshotted of Items<'v>
         interface TypeShape.UnionContract.IUnionContract
-    let codec<'v> = FsCodec.NewtonsoftJson.Codec.Create<Event<'v>>()
+    let codec<'v> = FsCodec.SystemTextJson.Codec.Create<Event<'v>>()
 
 module Fold =
 

--- a/samples/Tutorial/Sequence.fs
+++ b/samples/Tutorial/Sequence.fs
@@ -14,7 +14,7 @@ module Events =
     type Event =
         | Reserved of Reserved
         interface TypeShape.UnionContract.IUnionContract
-    let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
+    let codec = FsCodec.SystemTextJson.Codec.Create<Event>()
 
 module Fold =
 

--- a/samples/Tutorial/Set.fs
+++ b/samples/Tutorial/Set.fs
@@ -12,7 +12,7 @@ module Events =
         | Deleted of Items
         | Snapshotted of Items
         interface TypeShape.UnionContract.IUnionContract
-    let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
+    let codec = FsCodec.SystemTextJson.Codec.Create<Event>()
 
 module Fold =
 

--- a/samples/Tutorial/Tutorial.fsproj
+++ b/samples/Tutorial/Tutorial.fsproj
@@ -28,6 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FsCodec.NewtonsoftJson" Version="2.3.1" />
+    <PackageReference Include="FsCodec.SystemTextJson" Version="2.3.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="5.1.1" />
   </ItemGroup>

--- a/samples/Tutorial/Upload.fs
+++ b/samples/Tutorial/Upload.fs
@@ -30,6 +30,7 @@ module Events =
         | IdAssigned of IdAssigned
         interface TypeShape.UnionContract.IUnionContract
     let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
+    let codecStj = FsCodec.SystemTextJson.Codec.Create<Event>()
 
 module Fold =
 
@@ -62,7 +63,7 @@ module Cosmos =
     open Equinox.CosmosStore
     let create (context,cache) =
         let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
-        let category = CosmosStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, AccessStrategy.LatestKnownEvent)
+        let category = CosmosStoreCategory(context, Events.codecStj, Fold.fold, Fold.initial, cacheStrategy, AccessStrategy.LatestKnownEvent)
         create category.Resolve
 
 module EventStore =

--- a/src/Equinox.CosmosStore.Prometheus/Equinox.CosmosStore.Prometheus.fsproj
+++ b/src/Equinox.CosmosStore.Prometheus/Equinox.CosmosStore.Prometheus.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <WarningLevel>5</WarningLevel>
     <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>

--- a/src/Equinox.CosmosStore.Prometheus/Equinox.CosmosStore.Prometheus.fsproj
+++ b/src/Equinox.CosmosStore.Prometheus/Equinox.CosmosStore.Prometheus.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <WarningLevel>5</WarningLevel>
     <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -230,10 +230,10 @@ module Log =
     let internal event (value : Metric) (log : ILogger) =
         let enrich (e : Serilog.Events.LogEvent) =
             e.AddPropertyIfAbsent(Serilog.Events.LogEventProperty(PropertyTag, Serilog.Events.ScalarValue(value)))
-        log.ForContext({ new Serilog.Core.ILogEventEnricher with member _.Enrich(evt, _) = enrich evt })
+        log.ForContext({ new Serilog.Core.ILogEventEnricher with member _.Enrich(evt,_) = enrich evt })
     let internal (|BlobLen|) (x : EventBody) = if x.ValueKind = JsonValueKind.Null then 0 else x.GetRawText().Length
-    let internal (|EventLen|) (x : #IEventData<_>) = let BlobLen bytes, BlobLen metaBytes = x.Data, x.Meta in bytes + metaBytes + 80
-    let internal (|BatchLen|) = Seq.sumBy (|EventLen|)
+    let internal eventLen (x: #IEventData<_>) = let BlobLen bytes, BlobLen metaBytes = x.Data, x.Meta in bytes + metaBytes + 80
+    let internal batchLen = Seq.sumBy eventLen
     let internal (|SerilogScalar|_|) : Serilog.Events.LogEventPropertyValue -> obj option = function
         | :? Serilog.Events.ScalarValue as x -> Some x.Value
         | _ -> None
@@ -479,12 +479,12 @@ module internal Sync =
     let private logged (container, stream) (maxEventsInTip, maxStringifyLen) (exp : SyncExp, req : Tip) (log : ILogger)
         : Async<Result> = async {
         let! t, (ru, result) = run (container, stream) (maxEventsInTip, maxStringifyLen) (exp, req) |> Stopwatch.Time
-        let Log.BatchLen bytes, count = Enum.Events req, req.e.Length
+        let verbose = log.IsEnabled Serilog.Events.LogEventLevel.Debug
+        let count, bytes = req.e.Length, if verbose then Enum.Events req |> Log.batchLen else 0
         let log =
             let inline mkMetric ru : Log.Measurement =
                 { database = container.Database.Id; container = container.Id; stream = stream; interval = t; bytes = bytes; count = count; ru = ru }
             let inline propConflict log = log |> Log.prop "conflict" true |> Log.prop "eventTypes" (Seq.truncate 5 (seq { for x in req.e -> x.c }))
-            let verbose = log.IsEnabled Events.LogEventLevel.Debug
             if verbose then log |> Log.propEvents (Enum.Events req) |> Log.propDataUnfolds req.u else log
             |> match exp with
                 | SyncExp.Etag et ->     Log.prop "expectedEtag" et
@@ -613,7 +613,7 @@ module internal Tip =
             (log 0 0 Log.Metric.TipNotFound).Information("EqxCosmos {action:l} {stream} {res} {ms}ms rc={ru}", "Tip", stream, 404, (let e = t.Elapsed in e.TotalMilliseconds), ru)
         | ReadResult.Found tip ->
             let log =
-                let Log.BatchLen bytes, count = Enum.Unfolds tip.u, tip.u.Length
+                let count, bytes = tip.u.Length, if verbose then Enum.Unfolds tip.u |> Log.batchLen else 0
                 log bytes count Log.Metric.Tip
             let log = if verbose then log |> Log.propDataUnfolds tip.u else log
             let log = match maybePos with Some p -> log |> Log.propStartPos p |> Log.propStartEtag p | None -> log
@@ -642,7 +642,7 @@ module internal Query =
             if query.HasMoreResults then
                 yield! loop (i + 1) }
         // earlier versions, such as 3.9.0, do not implement IDisposable; see linked issue for detail on when SDK team added it
-        use __ = query // see https://github.com/jet/equinox/issues/225 - in the Cosmos V4 SDK, all this is managed IAsyncEnumerable
+        use _ = query // see https://github.com/jet/equinox/issues/225 - in the Cosmos V4 SDK, all this is managed IAsyncEnumerable
         loop 0
     let private mkQuery (log : ILogger) (container : Container, stream : string) includeTip maxItems (direction : Direction, minIndex, maxIndex) : FeedIterator<Batch> =
         let order = if direction = Direction.Forward then "ASC" else "DESC"
@@ -676,10 +676,10 @@ module internal Query =
             Enum.Events(b, ?minIndex = minIndex, ?maxIndex = maxIndex)
             |> if direction = Direction.Backward then System.Linq.Enumerable.Reverse else id
         let events = batches |> Seq.collect unwrapBatch |> Array.ofSeq
-        let Log.BatchLen bytes, count = events, events.Length
+        let verbose = log.IsEnabled Events.LogEventLevel.Debug
+        let count, bytes = events.Length, if verbose then events |> Log.batchLen else 0
         let reqMetric : Log.Measurement = { database = container.Database.Id; container = container.Id; stream = streamName; interval = t; bytes = bytes; count = count; ru = ru }
         let log = let evt = Log.Metric.QueryResponse (direction, reqMetric) in log |> Log.event evt
-        let verbose = log.IsEnabled Events.LogEventLevel.Debug
         let log = if verbose then log |> Log.propEvents events else log
         let index = if count = 0 then Nullable () else Nullable <| Seq.min (seq { for x in batches -> x.i })
         (log|> Log.prop "bytes" bytes
@@ -691,7 +691,8 @@ module internal Query =
         events, maybePosition, ru
 
     let private logQuery direction queryMaxItems (container : Container, streamName) interval (responsesCount, events : ITimelineEvent<EventBody>[]) n (ru : float) (log : ILogger) =
-        let Log.BatchLen bytes, count = events, events.Length
+        let verbose = log.IsEnabled Events.LogEventLevel.Debug
+        let count, bytes = events.Length, if verbose then events |> Log.batchLen else 0
         let reqMetric : Log.Measurement = { database = container.Database.Id; container = container.Id; stream = streamName; interval = interval; bytes = bytes; count = count; ru = ru }
         let evt = Log.Metric.Query (direction, responsesCount, reqMetric)
         let action = match direction with Direction.Forward -> "QueryF" | Direction.Backward -> "QueryB"
@@ -703,7 +704,7 @@ module internal Query =
         let mutable used, dropped = 0, 0
         let mutable found = false
         for x in xs do
-            let (Log.EventLen bytes) = x
+            let bytes = Log.eventLen x
             if found then dropped <- dropped + bytes
             else used <- used + bytes
             if x.Index = stopIndex then found <- true

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -66,7 +66,7 @@ type Batch = // TODO for STJ v5: All fields required unless explicitly optional
 
         /// The Domain Events (as opposed to Unfolded Events, see Tip) at this offset in the stream
         e: Event[] }
-    /// Unless running in single partition mode (which would restrict us to 10GB per collection)
+    /// Unless running in single partition mode (which would restrict us to 10GB per container)
     /// we need to nominate a partition key that will be in every document
     static member internal PartitionKeyField = "p"
     /// As one cannot sort by the implicit `id` field, we have an indexed `i` field for sort and range query use

--- a/src/Equinox.CosmosStore/CosmosStoreSerialization.fs
+++ b/src/Equinox.CosmosStore/CosmosStoreSerialization.fs
@@ -1,0 +1,58 @@
+namespace Equinox.CosmosStore.Core
+
+open Microsoft.Azure.Cosmos
+open System.IO
+open System.Text.Json
+open System.Text.Json.Serialization
+
+//module JsonHelper =
+//
+//    let d = JsonDocument.Parse "null"
+//    let private Null = d.RootElement
+//    /// System.Text.Json versions > 4.7 reject JsonValueKind.Undefined elements
+//    let fixup (e : JsonElement) = if e.ValueKind = JsonValueKind.Undefined then Null else e
+
+type CosmosJsonSerializer(options: JsonSerializerOptions) =
+    inherit CosmosSerializer()
+
+    override _.FromStream<'T>(stream) =
+        use __ = stream
+
+        if stream.Length = 0L then Unchecked.defaultof<'T>
+        elif typeof<Stream>.IsAssignableFrom(typeof<'T>) then box stream :?> 'T
+        else JsonSerializer.Deserialize<'T>(stream, options)
+
+    override _.ToStream<'T>(input: 'T) =
+        let memoryStream = new MemoryStream()
+        JsonSerializer.Serialize(memoryStream, input, input.GetType(), options)
+        memoryStream.Position <- 0L
+        memoryStream :> Stream
+
+/// Manages zipping of the UTF-8 json bytes to make the index record minimal from the perspective of the writer stored proc
+/// Only applied to snapshots in the Tip
+and JsonCompressedBase64Converter() =
+    inherit JsonConverter<JsonElement>()
+
+    static member Compress(value: JsonElement) =
+        if value.ValueKind = JsonValueKind.Null then value
+        else
+            let input = System.Text.Encoding.UTF8.GetBytes(value.GetRawText())
+            use output = new MemoryStream()
+            use compressor = new System.IO.Compression.DeflateStream(output, System.IO.Compression.CompressionLevel.Optimal)
+            compressor.Write(input, 0, input.Length)
+            compressor.Close()
+            JsonDocument.Parse("\"" + System.Convert.ToBase64String(output.ToArray()) + "\"").RootElement
+
+    override _.Read(reader, _typeToConvert, options) =
+        if reader.TokenType <> JsonTokenType.String then
+            JsonSerializer.Deserialize<JsonElement>(&reader, options)
+        else
+            let compressedBytes = reader.GetBytesFromBase64()
+            use input = new MemoryStream(compressedBytes)
+            use decompressor = new System.IO.Compression.DeflateStream(input, System.IO.Compression.CompressionMode.Decompress)
+            use output = new MemoryStream()
+            decompressor.CopyTo(output)
+            JsonSerializer.Deserialize<JsonElement>(System.ReadOnlySpan.op_Implicit(output.ToArray()), options)
+
+    override _.Write(writer, value, options) =
+        JsonSerializer.Serialize<JsonElement>(writer, value, options)

--- a/src/Equinox.CosmosStore/Equinox.CosmosStore.fsproj
+++ b/src/Equinox.CosmosStore/Equinox.CosmosStore.fsproj
@@ -25,9 +25,9 @@
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
 
     <PackageReference Include="FsCodec" Version="2.3.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.1" />
     <PackageReference Include="FSharp.Control.AsyncSeq" Version="2.0.23" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.25.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Equinox.CosmosStore/Equinox.CosmosStore.fsproj
+++ b/src/Equinox.CosmosStore/Equinox.CosmosStore.fsproj
@@ -24,7 +24,7 @@
 
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
 
-    <PackageReference Include="FsCodec" Version="2.3.0-rc.1" />
+    <PackageReference Include="FsCodec" Version="2.3.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
     <PackageReference Include="FSharp.Control.AsyncSeq" Version="2.0.23" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.25.0" />

--- a/src/Equinox.CosmosStore/Equinox.CosmosStore.fsproj
+++ b/src/Equinox.CosmosStore/Equinox.CosmosStore.fsproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <Compile Include="..\Equinox.Core\Infrastructure.fs" Link="Infrastructure.fs" />
+    <Compile Include="CosmosStoreSerialization.fs" />
     <Compile Include="CosmosStore.fs" />
   </ItemGroup>
 
@@ -23,7 +24,8 @@
 
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
 
-    <PackageReference Include="FsCodec.NewtonsoftJson" Version="2.0.0" />
+    <PackageReference Include="FsCodec" Version="2.3.0-rc.1" />
+    <PackageReference Include="System.Text.Json" Version="6.0.1" />
     <PackageReference Include="FSharp.Control.AsyncSeq" Version="2.0.23" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.25.0" />
   </ItemGroup>

--- a/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
+++ b/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
@@ -33,7 +33,7 @@ module SequenceCheck =
         type Event =
             | Add of {| value : int |}
             interface TypeShape.UnionContract.IUnionContract
-        let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
+        let codec = FsCodec.SystemTextJson.Codec.Create<Event>()
 
     module Fold =
 

--- a/tests/Equinox.CosmosStore.Integration/CosmosCoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosCoreIntegration.fs
@@ -17,7 +17,7 @@ type TestEvents() =
         let ser = System.Text.Json.JsonSerializer.SerializeToElement
         EventData.FromUtf8Bytes
             (   sprintf "%s:%d" (defaultArg eventType "test_event") i,
-                defaultArg json "{\"d\":\"d\"}" |> ser,
+                ser <| defaultArg json "{\"d\":\"d\"}",
                 ser "{\"m\":\"m\"}")
     static member Create(i, c) = Array.init c (fun x -> TestEvents.Create(x+i))
 

--- a/tests/Equinox.CosmosStore.Integration/CosmosCoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosCoreIntegration.fs
@@ -17,7 +17,7 @@ type TestEvents() =
         let ser = System.Text.Json.JsonSerializer.SerializeToElement
         EventData.FromUtf8Bytes
             (   sprintf "%s:%d" (defaultArg eventType "test_event") i,
-                ser <| defaultArg json "{\"d\":\"d\"}",
+                ser (defaultArg json "{\"d\":\"d\"}"),
                 ser "{\"m\":\"m\"}")
     static member Create(i, c) = Array.init c (fun x -> TestEvents.Create(x+i))
 

--- a/tests/Equinox.CosmosStore.Integration/CosmosCoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosCoreIntegration.fs
@@ -14,10 +14,11 @@ open System.Text
 
 type TestEvents() =
     static member private Create(i, ?eventType, ?json) =
+        let ser = System.Text.Json.JsonSerializer.SerializeToElement
         EventData.FromUtf8Bytes
             (   sprintf "%s:%d" (defaultArg eventType "test_event") i,
-                Encoding.UTF8.GetBytes(defaultArg json "{\"d\":\"d\"}"),
-                Encoding.UTF8.GetBytes "{\"m\":\"m\"}")
+                defaultArg json "{\"d\":\"d\"}" |> ser,
+                ser "{\"m\":\"m\"}")
     static member Create(i, c) = Array.init c (fun x -> TestEvents.Create(x+i))
 
 type Tests(testOutputHelper) =
@@ -69,7 +70,7 @@ type Tests(testOutputHelper) =
     }
 
     let blobEquals (x: byte[]) (y: byte[]) = System.Linq.Enumerable.SequenceEqual(x,y)
-    let stringOfEventBody (x: byte[]) = Encoding.UTF8.GetString(x)
+    let stringOfEventBody (x : System.Text.Json.JsonElement) = x.GetRawText()
     let xmlDiff (x: string) (y: string) =
         match JsonDiffPatchDotNet.JsonDiffPatch().Diff(JToken.Parse x,JToken.Parse y) with
         | null -> ""

--- a/tests/Equinox.CosmosStore.Integration/CosmosIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosIntegration.fs
@@ -11,7 +11,7 @@ open System.Threading
 module Cart =
     let fold, initial = Cart.Fold.fold, Cart.Fold.initial
     let snapshot = Cart.Fold.isOrigin, Cart.Fold.snapshot
-    let codec = Cart.Events.codec
+    let codec = Cart.Events.codecStj
     let createServiceWithoutOptimization log context =
         let resolve (id,opt) = CosmosStoreCategory(context, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.Unoptimized).Resolve(id,?option=opt)
         Cart.create log resolve
@@ -34,7 +34,7 @@ module Cart =
 
 module ContactPreferences =
     let fold, initial = ContactPreferences.Fold.fold, ContactPreferences.Fold.initial
-    let codec = ContactPreferences.Events.codec
+    let codec = ContactPreferences.Events.codecStj
     let createServiceWithoutOptimization createContext queryMaxItems log _ignoreWindowSize _ignoreCompactionPredicate =
         let context = createContext queryMaxItems
         let resolveStream = CosmosStoreCategory(context, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.Unoptimized).Resolve

--- a/tests/Equinox.CosmosStore.Integration/CosmosIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosIntegration.fs
@@ -98,7 +98,7 @@ type Tests(testOutputHelper) =
         test <@ addRemoveCount = match state with { items = [{ quantity = quantity }] } -> quantity | _ -> failwith "nope" @>
 
         test <@ List.replicate (expectedResponses transactions) EqxAct.ResponseBackward @ [EqxAct.QueryBackward] = capture.ExternalCalls @>
-        if eventsInTip then verifyRequestChargesMax 9 // 8.05
+        if eventsInTip then verifyRequestChargesMax 8 // 7.46
         else verifyRequestChargesMax 15 // 14.01
     }
 

--- a/tests/Equinox.CosmosStore.Integration/CosmosIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosIntegration.fs
@@ -98,7 +98,7 @@ type Tests(testOutputHelper) =
         test <@ addRemoveCount = match state with { items = [{ quantity = quantity }] } -> quantity | _ -> failwith "nope" @>
 
         test <@ List.replicate (expectedResponses transactions) EqxAct.ResponseBackward @ [EqxAct.QueryBackward] = capture.ExternalCalls @>
-        if eventsInTip then verifyRequestChargesMax 8 // 7.46
+        if eventsInTip then verifyRequestChargesMax 9 // 8.05
         else verifyRequestChargesMax 15 // 14.01
     }
 

--- a/tests/Equinox.CosmosStore.Integration/JsonConverterTests.fs
+++ b/tests/Equinox.CosmosStore.Integration/JsonConverterTests.fs
@@ -13,30 +13,30 @@ type Union =
     | B of Embedded
     interface TypeShape.UnionContract.IUnionContract
 
-let defaultSettings = FsCodec.NewtonsoftJson.Settings.CreateDefault()
+let defaultSettings = FsCodec.SystemTextJson.Options.CreateDefault()
 
 type Base64ZipUtf8Tests() =
-    let eventCodec = FsCodec.NewtonsoftJson.Codec.Create(defaultSettings)
+    let eventCodec = FsCodec.SystemTextJson.Codec.Create(defaultSettings)
 
     let ser eventType data =
         let e : Core.Unfold =
             {   i = 42L
                 c = eventType
                 d = data
-                m = null
+                m = System.Text.Json.JsonSerializer.SerializeToElement "null"
                 t = DateTimeOffset.MinValue }
         JsonConvert.SerializeObject e
 
     [<Fact>]
     let ``serializes, achieving expected compression`` () =
         let encoded = eventCodec.Encode(None,A { embed = String('x',5000) })
-        let res = ser encoded.EventType (Core.Base64MaybeDeflateUtf8JsonConverter.Compress encoded.Data)
+        let res = ser encoded.EventType (Core.JsonCompressedBase64Converter.Compress encoded.Data)
         test <@ res.Contains("\"d\":\"") && res.Length < 138 @>
 
     [<Property>]
     let roundtrips compress value =
         let encoded = eventCodec.Encode(None, value)
-        let maybeCompressor = if compress then Core.Base64MaybeDeflateUtf8JsonConverter.Compress else id
+        let maybeCompressor = if compress then Core.JsonCompressedBase64Converter.Compress else id
         let actualData = maybeCompressor encoded.Data
         let ser = ser encoded.EventType actualData
         test <@ if compress then ser.Contains("\"d\":\"")
@@ -48,8 +48,9 @@ type Base64ZipUtf8Tests() =
 
     [<Theory; InlineData false; InlineData true>]
     let handlesNulls compress =
-        let maybeCompressor = if compress then Core.Base64MaybeDeflateUtf8JsonConverter.Compress else id
-        let maybeCompressed = maybeCompressor null
+        let maybeCompressor = if compress then Core.JsonCompressedBase64Converter.Compress else id
+        let nullElement = System.Text.Json.JsonSerializer.SerializeToElement "null"
+        let maybeCompressed = maybeCompressor nullElement
         let ser = ser "AnEventType" maybeCompressed
-        let des = JsonConvert.DeserializeObject<Core.Unfold>(ser)
-        test <@ null = des.d @>
+        let des = System.Text.Json.JsonSerializer.Deserialize<Core.Unfold>(ser)
+        test <@ nullElement = des.d @>

--- a/tests/Equinox.CosmosStore.Integration/JsonConverterTests.fs
+++ b/tests/Equinox.CosmosStore.Integration/JsonConverterTests.fs
@@ -2,7 +2,6 @@
 
 open Equinox.CosmosStore
 open FsCheck.Xunit
-open Newtonsoft.Json
 open Swensen.Unquote
 open System
 open Xunit
@@ -13,19 +12,19 @@ type Union =
     | B of Embedded
     interface TypeShape.UnionContract.IUnionContract
 
-let defaultSettings = FsCodec.SystemTextJson.Options.CreateDefault()
+let defaultOptions = FsCodec.SystemTextJson.Options.CreateDefault()
 
 type Base64ZipUtf8Tests() =
-    let eventCodec = FsCodec.SystemTextJson.Codec.Create(defaultSettings)
+    let eventCodec = FsCodec.SystemTextJson.Codec.Create(defaultOptions)
 
     let ser eventType data =
         let e : Core.Unfold =
             {   i = 42L
                 c = eventType
                 d = data
-                m = System.Text.Json.JsonSerializer.SerializeToElement "null"
+                m = System.Text.Json.JsonSerializer.SerializeToElement null
                 t = DateTimeOffset.MinValue }
-        JsonConvert.SerializeObject e
+        System.Text.Json.JsonSerializer.Serialize e
 
     [<Fact>]
     let ``serializes, achieving expected compression`` () =
@@ -41,7 +40,7 @@ type Base64ZipUtf8Tests() =
         let ser = ser encoded.EventType actualData
         test <@ if compress then ser.Contains("\"d\":\"")
                 else ser.Contains("\"d\":{") @>
-        let des = JsonConvert.DeserializeObject<Core.Unfold>(ser)
+        let des = System.Text.Json.JsonSerializer.Deserialize<Core.Unfold>(ser)
         let d = FsCodec.Core.TimelineEvent.Create(-1L, des.c, des.d)
         let decoded = eventCodec.TryDecode d |> Option.get
         test <@ value = decoded @>
@@ -49,8 +48,8 @@ type Base64ZipUtf8Tests() =
     [<Theory; InlineData false; InlineData true>]
     let handlesNulls compress =
         let maybeCompressor = if compress then Core.JsonCompressedBase64Converter.Compress else id
-        let nullElement = System.Text.Json.JsonSerializer.SerializeToElement "null"
+        let nullElement = System.Text.Json.JsonSerializer.SerializeToElement null
         let maybeCompressed = maybeCompressor nullElement
         let ser = ser "AnEventType" maybeCompressed
         let des = System.Text.Json.JsonSerializer.Deserialize<Core.Unfold>(ser)
-        test <@ nullElement = des.d @>
+        test <@ System.Text.Json.JsonValueKind.Null = let d = des.d in d.ValueKind @>


### PR DESCRIPTION
Cherry-pick from #197 see #232
- [x] Stop logging event byte lengths, as that would pretty much undo all perf and allocation improvements moving to `System.Text.Json` can achieve (unless `Debug` log level) 