### PR TITLE
Fix fallback when Tip pruned to no events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Fixed
 
+- `CosmosStore`: Fix fallback detection when all events pruned from Tip [#306](https://github.com/jet/equinox/pull/306)
+
 <a name="3.0.5"></a>
 ## [3.0.5] - 2021-11-18
 

--- a/tests/Equinox.CosmosStore.Integration/CosmosCoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosCoreIntegration.fs
@@ -217,7 +217,7 @@ type Tests(testOutputHelper) =
         verifyCorrectEvents 1L expected res
 
         test <@ [EqxAct.ResponseForward; EqxAct.QueryForward] = capture.ExternalCalls @>
-        if eventsInTip then verifyRequestChargesMax 3
+        if eventsInTip then verifyRequestChargesMax 4 // 3.54
         else verifyRequestChargesMax 5 // (4.15) // WAS 13 with SDK bugs// 12.81
     }
 


### PR DESCRIPTION
Not sure when this was introduced as yet, but 3.0-specific, and triggers multiple failing tests which went unnoticed due to the absence of a pair of containers for testing