### PR TITLE
EventStore/SqlStreamStore: Log consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 - `eqx`/`Equinox.Tool`: Flip `-P` option to opt _in_ to pretty printing [#313](https://github.com/jet/equinox/pull/313)
 - `CosmosStore`: Require `Microsoft.Azure.Cosmos` v `3.0.25` [#310](https://github.com/jet/equinox/pull/310)
+- `EventStore/SqlStreamStore`: rename `Equinox.XXXStore.Log.Event` -> `Metric` to match `CosmosStore` [#311](https://github.com/jet/equinox/pull/311)
 - `SqlStreamStore`.*: Target `SqlStreamStore` v `1.2.0` (`Postgres` remains at `1.2.0-beta.8` as that's the last released version) [#227](https://github.com/jet/equinox/pull/227) :pray: [@rajivhost](https://github.com/rajivhost)
 - Update all non-Client dependencies except `FSharp.Core`, `FSharp.Control.AsyncSeq` [#310](https://github.com/jet/equinox/pull/310)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Fixed
 
+- `SqlStreamStore`: Fix `Metric` key to be `ssEvt` (was `esEvt`) [#311](https://github.com/jet/equinox/pull/311)
+
 <a name="3.0.6"></a>
 ## [3.0.6] - 2022-01-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 - `eqx`/`Equinox.Tool`: Flip `-P` option to opt _in_ to pretty printing [#313](https://github.com/jet/equinox/pull/313)
 - `CosmosStore`: Require `Microsoft.Azure.Cosmos` v `3.0.25` [#310](https://github.com/jet/equinox/pull/310)
-- `EventStore/SqlStreamStore`: rename `Equinox.XXXStore.Log.Event` -> `Metric` to match `CosmosStore` [#311](https://github.com/jet/equinox/pull/311)
 - `SqlStreamStore`.*: Target `SqlStreamStore` v `1.2.0` (`Postgres` remains at `1.2.0-beta.8` as that's the last released version) [#227](https://github.com/jet/equinox/pull/227) :pray: [@rajivhost](https://github.com/rajivhost)
 - Update all non-Client dependencies except `FSharp.Core`, `FSharp.Control.AsyncSeq` [#310](https://github.com/jet/equinox/pull/310)
 
@@ -23,6 +22,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Fixed
 
+- `EventStore/SqlStreamStore`: rename `Equinox.XXXStore.Log.Event` -> `Metric` to match `CosmosStore` [#311](https://github.com/jet/equinox/pull/311)
 - `SqlStreamStore`: Fix `Metric` key to be `ssEvt` (was `esEvt`) [#311](https://github.com/jet/equinox/pull/311)
 
 <a name="3.0.6"></a>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,8 @@
 name: $(Rev:r)
 trigger:
-  - master
-  - main
-  - refs/tags/*
+- master
+- main
+- refs/tags/*
 jobs:
 - job: Windows
   pool:

--- a/samples/Store/Integration/LogIntegration.fs
+++ b/samples/Store/Integration/LogIntegration.fs
@@ -13,7 +13,7 @@ module EquinoxEsInterop =
     [<NoEquality; NoComparison>]
     type FlatMetric = { action: string; stream : string; interval: StopwatchInterval; bytes: int; count: int; batches: int option } with
         override __.ToString() = sprintf "%s-Stream=%s %s-Elapsed=%O" __.action __.stream __.action __.interval.Elapsed
-    let flatten (evt : Log.Event) : FlatMetric =
+    let flatten (evt : Log.Metric) : FlatMetric =
         let action, metric, batches =
             match evt with
             | Log.WriteSuccess m -> "AppendToStreamAsync", m, None
@@ -66,7 +66,7 @@ type SerilogMetricsExtractor(emit : string -> unit) =
     let (|EsMetric|CosmosMetric|GenericMessage|) (logEvent : Serilog.Events.LogEvent) =
         logEvent.Properties
         |> Seq.tryPick (function
-            | KeyValue (k, SerilogScalar (:? Equinox.EventStore.Log.Event as m)) -> Some <| Choice1Of3 (k,m)
+            | KeyValue (k, SerilogScalar (:? Equinox.EventStore.Log.Metric as m)) -> Some <| Choice1Of3 (k,m)
             | KeyValue (k, SerilogScalar (:? Equinox.CosmosStore.Core.Log.Metric as m)) -> Some <| Choice2Of3 (k,m)
             | _ -> None)
         |> Option.defaultValue (Choice3Of3 ())

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -12,14 +12,14 @@ type Direction = Forward | Backward with
 
 module Log =
 
-    /// <summary>Name of Property used for <c>Event</c> in <c>LogEvent</c>s.</summary>
+    /// <summary>Name of Property used for <c>Metric</c> in <c>LogEvent</c>s.</summary>
     let [<Literal>] PropertyTag = "esEvt"
 
     [<NoEquality; NoComparison>]
     type Measurement = { stream : string; interval : StopwatchInterval; bytes : int; count : int }
 
     [<NoEquality; NoComparison>]
-    type Event =
+    type Metric =
         | WriteSuccess of Measurement
         | WriteConflict of Measurement
         | Slice of Direction * Measurement
@@ -48,7 +48,7 @@ module Log =
 
     /// Attach a property to the log context to hold the metrics
     // Sidestep Log.ForContext converting to a string; see https://github.com/serilog/serilog/issues/1124
-    let event (value : Event) (log : ILogger) =
+    let event (value : Metric) (log : ILogger) =
         let enrich (e : LogEvent) = e.AddPropertyIfAbsent(LogEventProperty(PropertyTag, ScalarValue(value)))
         log.ForContext({ new Serilog.Core.ILogEventEnricher with member _.Enrich(evt, _) = enrich evt })
 
@@ -81,9 +81,9 @@ module Log =
                 | :? ScalarValue as x -> Some x.Value
                 | _ -> None
 
-            let (|EsMetric|_|) (logEvent : LogEvent) : Event option =
+            let (|EsMetric|_|) (logEvent : LogEvent) : Metric option =
                 match logEvent.Properties.TryGetValue(PropertyTag) with
-                | true, SerilogScalar (:? Event as e) -> Some e
+                | true, SerilogScalar (:? Metric as e) -> Some e
                 | _ -> None
 
             type Counter =
@@ -230,7 +230,7 @@ module private Read =
         let reqMetric : Log.Measurement = { stream = streamName; interval = t; bytes = bytes; count = count}
         let batches = (events.Length - 1) / batchSize + 1
         let action = match direction with Direction.Forward -> "LoadF" | Direction.Backward -> "LoadB"
-        let evt = Log.Event.Batch (direction, batches, reqMetric)
+        let evt = Log.Metric.Batch (direction, batches, reqMetric)
         (log |> Log.prop "bytes" bytes |> Log.event evt).Information(
             "Ges{action:l} stream={stream} count={count}/{batches} version={version}",
             action, streamName, count, batches, version)

--- a/src/Equinox.SqlStreamStore/SqlStreamStore.fs
+++ b/src/Equinox.SqlStreamStore/SqlStreamStore.fs
@@ -19,7 +19,7 @@ type Direction = Forward | Backward with
 module Log =
 
     /// <summary>Name of Property used for <c>Metric</c> in <c>LogEvent</c>s.</summary>
-    let [<Literal>] PropertyTag = "esEvt"
+    let [<Literal>] PropertyTag = "ssEvt"
 
     [<NoEquality; NoComparison>]
     type Measurement = { stream : string; interval : StopwatchInterval; bytes : int; count : int }

--- a/src/Equinox.SqlStreamStore/SqlStreamStore.fs
+++ b/src/Equinox.SqlStreamStore/SqlStreamStore.fs
@@ -18,13 +18,13 @@ type Direction = Forward | Backward with
 
 module Log =
 
-    /// <summary>Name of Property used for <c>Event</c> in <c>LogEvent</c>s.</summary>
+    /// <summary>Name of Property used for <c>Metric</c> in <c>LogEvent</c>s.</summary>
     let [<Literal>] PropertyTag = "esEvt"
 
     [<NoEquality; NoComparison>]
     type Measurement = { stream : string; interval : StopwatchInterval; bytes : int; count : int }
     [<NoEquality; NoComparison>]
-    type Event =
+    type Metric =
         | WriteSuccess of Measurement
         | WriteConflict of Measurement
         | Slice of Direction * Measurement
@@ -46,7 +46,7 @@ module Log =
     open Serilog.Events
     /// Attach a property to the log context to hold the metrics
     // Sidestep Log.ForContext converting to a string; see https://github.com/serilog/serilog/issues/1124
-    let event (value : Event) (log : ILogger) =
+    let event (value : Metric) (log : ILogger) =
         let enrich (e : LogEvent) = e.AddPropertyIfAbsent(LogEventProperty(PropertyTag, ScalarValue(value)))
         log.ForContext({ new Serilog.Core.ILogEventEnricher with member _.Enrich(evt, _) = enrich evt })
     let withLoggedRetries<'t> retryPolicy (contextLabel : string) (f : ILogger -> Async<'t>) log : Async<'t> =
@@ -76,9 +76,9 @@ module Log =
             let (|SerilogScalar|_|) : LogEventPropertyValue -> obj option = function
                 | :? ScalarValue as x -> Some x.Value
                 | _ -> None
-            let (|EsMetric|_|) (logEvent : LogEvent) : Event option =
+            let (|EsMetric|_|) (logEvent : LogEvent) : Metric option =
                 match logEvent.Properties.TryGetValue(PropertyTag) with
-                | true, SerilogScalar (:? Event as e) -> Some e
+                | true, SerilogScalar (:? Metric as e) -> Some e
                 | _ -> None
             type Counter =
                 { mutable count : int64; mutable ms : int64 }
@@ -215,7 +215,7 @@ module private Read =
         let reqMetric : Log.Measurement = { stream = streamName; interval = t; bytes = bytes; count = count}
         let batches = (events.Length - 1)/batchSize + 1
         let action = match direction with Direction.Forward -> "LoadF" | Direction.Backward -> "LoadB"
-        let evt = Log.Event.Batch (direction, batches, reqMetric)
+        let evt = Log.Metric.Batch (direction, batches, reqMetric)
         (log |> Log.prop "bytes" bytes |> Log.event evt).Information(
             "SqlEs{action:l} stream={stream} count={count}/{batches} version={version}",
             action, streamName, count, batches, version)

--- a/tests/Equinox.EventStore.Integration/Infrastructure.fs
+++ b/tests/Equinox.EventStore.Integration/Infrastructure.fs
@@ -56,7 +56,7 @@ module SerilogHelpers =
         | _ -> None
     [<RequireQualifiedAccess>]
     type EsAct = Append | AppendConflict | SliceForward | SliceBackward | BatchForward | BatchBackward
-    let (|EsAction|) (evt : Log.Event) =
+    let (|EsAction|) (evt : Log.Metric) =
         match evt with
         | Log.WriteSuccess _ -> EsAct.Append
         | Log.WriteConflict _ -> EsAct.AppendConflict
@@ -64,9 +64,9 @@ module SerilogHelpers =
         | Log.Slice (Direction.Backward,_) -> EsAct.SliceBackward
         | Log.Batch (Direction.Forward,_,_) -> EsAct.BatchForward
         | Log.Batch (Direction.Backward,_,_) -> EsAct.BatchBackward
-    let (|EsEvent|_|) (logEvent : LogEvent) : Log.Event option =
+    let (|EsEvent|_|) (logEvent : LogEvent) : Log.Metric option =
         logEvent.Properties.Values |> Seq.tryPick (function
-            | SerilogScalar (:? Log.Event as e) -> Some e
+            | SerilogScalar (:? Log.Metric as e) -> Some e
             | _ -> None)
 
     let (|HasProp|_|) (name : string) (e : LogEvent) : LogEventPropertyValue option =


### PR DESCRIPTION
- `EventStore/SqlStreamStore`: rename `Equinox.XXXStore.Log.Event` -> `Metric` to match `CosmosStore`
- `SqlStreamStore`: correct internal name to `ssEvt` (was `esEvt`)