### PR TITLE
Polish eqx dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- `eqx`/`Equinox.Tool`: Flip `-P` option to opt _in_ to pretty printing [#313](https://github.com/jet/equinox/pull/313)
+
 ### Removed
 ### Fixed
 


### PR DESCRIPTION
- [x] Flip default meaning of `eqx dump -P` to *not* pretty print as, on reflection, that's what a dev would want in practice
- [x] Fix bug where `U`nfolds get rendered twice