### PR TITLE
Document MSSQL 2019 Docker Image workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,15 +556,17 @@ For more complete instructions, follow https://developers.eventstore.com/server/
 
 There's a `docker-compose.yml` file in the root, so installing `docker-compose` and then running `docker-compose up` rigs local `equinox-mssql`, `equinox-mysql` and `equinox-postgres` servers and databases at known ports. _NOTE The `Equinox.SqlStreamStore.*.Integration` suites currently assume this is in place and will otherwise fail_.
 
-### Provisioning MSSQL for `SqlStreamStore.MsSql`
+### Provisioning `mcr.microsoft.com/mssql/server:2019-latest` for `SqlStreamStore.MsSql`
 
-Until https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719 is resolved (see [#315](https://github.com/jet/equinox/pull/315), after the `docker compose up`:
+Until https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719 is resolved (see [#315](https://github.com/jet/equinox/pull/315), after the `docker compose up` one needs to manually:
 
 ```zsh
 docker exec -it equinox-mssql /opt/mssql-tools/bin/sqlcmd \
-    -S localhost -U sa -P "!Passw0rd" \
+    -S localhost -U sa -P mssql1Ipw \
     -Q "CREATE database EQUINOX_TEST_DB"
 ```
+
+(PRs welcome to automate the hack, but ideally the image will allow parameterizing it as handled by the Postgres and MySql images when common sense prevails re [`mssql-docker#2`](https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719))
 
 ## DEPROVISIONING
 

--- a/README.md
+++ b/README.md
@@ -556,6 +556,16 @@ For more complete instructions, follow https://developers.eventstore.com/server/
 
 There's a `docker-compose.yml` file in the root, so installing `docker-compose` and then running `docker-compose up` rigs local `equinox-mssql`, `equinox-mysql` and `equinox-postgres` servers and databases at known ports. _NOTE The `Equinox.SqlStreamStore.*.Integration` suites currently assume this is in place and will otherwise fail_.
 
+### Provisioning MSSQL for `SqlStreamStore.MsSql`
+
+Until https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719 is resolved, after the `docker compose up`:
+
+```zsh
+docker exec -it equinox-mssql /opt/mssql-tools/bin/sqlcmd \
+    -S localhost -U sa -P "!Passw0rd" \
+    -Q "CREATE database EQUINOX_TEST_DB"
+```
+
 ## DEPROVISIONING
 
 ### Deprovisioning (aka nuking) EventStore data resulting from tests to reset baseline

--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ There's a `docker-compose.yml` file in the root, so installing `docker-compose` 
 
 ### Provisioning MSSQL for `SqlStreamStore.MsSql`
 
-Until https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719 is resolved, after the `docker compose up`:
+Until https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719 is resolved (see [#315](https://github.com/jet/equinox/pull/315), after the `docker compose up`:
 
 ```zsh
 docker exec -it equinox-mssql /opt/mssql-tools/bin/sqlcmd \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - 1433:1433
     environment:
-      - SA_PASSWORD=!Passw0rd
+      - SA_PASSWORD=mssql1Ipw
       - ACCEPT_EULA=Y
 
 #  MANUAL STEP re https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719; after docker compose up, run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,21 @@ services:
     ports:
       - "5432:5432"
 
+  equinox-mssql:
+    container_name: equinox-mssql
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    restart: unless-stopped
+    ports:
+      - 1433:1433
+    environment:
+      - SA_PASSWORD=!Passw0rd
+      - ACCEPT_EULA=Y
+
+#  MANUAL STEP re https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719; after docker compose up, run:
+#  docker exec -it equinox-mssql /opt/mssql-tools/bin/sqlcmd \
+#    -S localhost -U sa -P "!Passw0rd" \
+#    -Q "CREATE database EQUINOX_TEST_DB"
+
   equinox-mysql:
     container_name: equinox-mysql
     image: mysql:5.6

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -24,13 +24,13 @@ open Equinox.SqlStreamStore
 open Equinox.SqlStreamStore.MsSql
 
 let connectToLocalStore (_ : ILogger) =
-    Connector(sprintf "Server=localhost,1433;User=sa;Password=!Passw0rd;Database=EQUINOX_TEST_DB",autoCreate=true).Establish()
+    Connector(sprintf "Server=localhost,1433;User=sa;Password=mssql1Ipw;Database=EQUINOX_TEST_DB",autoCreate=true).Establish()
 
 (* WORKAROUND FOR https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719
 AFTER `docker compose up`, run:
 
 docker exec -it equinox-mssql /opt/mssql-tools/bin/sqlcmd \
-    -S localhost -U sa -P "!Passw0rd" \
+    -S localhost -U sa -P mssql1Ipw \
     -Q "CREATE database EQUINOX_TEST_DB"
 *)
 

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -24,7 +24,15 @@ open Equinox.SqlStreamStore
 open Equinox.SqlStreamStore.MsSql
 
 let connectToLocalStore (_ : ILogger) =
-    Connector(sprintf "Server=localhost,1433;User=sa;Password=!Passw0rd;Database=test",autoCreate=true).Establish()
+    Connector(sprintf "Server=localhost,1433;User=sa;Password=!Passw0rd;Database=EQUINOX_TEST_DB",autoCreate=true).Establish()
+
+(* WORKAROUND FOR https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719
+AFTER `docker compose up`, run:
+
+docker exec -it equinox-mssql /opt/mssql-tools/bin/sqlcmd \
+    -S localhost -U sa -P "!Passw0rd" \
+    -Q "CREATE database EQUINOX_TEST_DB"
+*)
 
 type Context = SqlStreamStoreContext
 type Category<'event, 'state, 'context> = SqlStreamStoreCategory<'event, 'state, 'context>


### PR DESCRIPTION
Re https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719

Until it's automated and/or the image follows the rest of the world, documents the need to manually do:

```zsh
docker exec -it equinox-mssql /opt/mssql-tools/bin/sqlcmd \
 -S localhost -U sa -P "!Passw0rd" \
 -Q "CREATE database EQUINOX_TEST_DB"
```