### PR TITLE
Migrate EventBody to FsCodec 3 conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - `eqx dump`/`Equinox.Tool`: Add `-F` option to opt out of pretty printing unfolds [#319](https://github.com/jet/equinox/pull/319)
+- `eqx dump`/`Equinox.Tool`: Show payload statistics [#323](https://github.com/jet/equinox/pull/323)
+- `eqx dump`/`Equinox.Tool`: Add `-B` option to prevent assuming UTF-8 bodies [#323](https://github.com/jet/equinox/pull/323)
 - `Equinox`: `Decider.Transact(interpret : 'state -> Async<'event list>)` [#314](https://github.com/jet/equinox/pull/314)
 
 ### Changed
@@ -19,16 +21,17 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Equinox`: rename `Decider.TransactAsync` to `Transact` [#314](https://github.com/jet/equinox/pull/314)
 - `Equinox`: Merge `ResolveOption` and `XXXStoreCategory.FromMemento` as `LoadOption` [#308](https://github.com/jet/equinox/pull/308)
 - `Equinox`: Merge `XXXStoreCategory.Resolve(sn, ?ResolveOption)` and `XXXStoreCategory.FromMemento` as option `LoadOption` parameter on all `Transact` and `Query` methods [#308](https://github.com/jet/equinox/pull/308)
-- `CosmosStore`: Require `Microsoft.Azure.Cosmos` v `3.0.25` [#310](https://github.com/jet/equinox/pull/310)
+- `CosmosStore`: Require `Microsoft.Azure.Cosmos` v `3.27.0` [#310](https://github.com/jet/equinox/pull/310)
 - `CosmosStore`: Switch to natively using `JsonElement` event bodies [#305](https://github.com/jet/equinox/pull/305) :pray: [@ylibrach](https://github.com/ylibrach)
 - `CosmosStore`: Switch to natively using `System.Text.Json` for serialization of all `Microsoft.Azure.Cosmos` round-trips [#305](https://github.com/jet/equinox/pull/305) :pray: [@ylibrach](https://github.com/ylibrach)
 - `CosmosStore`: Only log `bytes` when log level is `Debug` [#305](https://github.com/jet/equinox/pull/305)
 - `EventStore`: Target `EventStore.Client` v `22.0.0-preview`; rename `Connector` -> `EventStoreConnector` [#317](https://github.com/jet/equinox/pull/317)
 - Update all non-Client dependencies except `FSharp.Core`, `FSharp.Control.AsyncSeq` [#310](https://github.com/jet/equinox/pull/310)
+- Update all Stores to use `FsCodec` v `3.0.0`, with [`EventBody` types switching from `byte[]` to `ReadOnlyMemory<byte>`, see FsCodec#75](https://github.com/jet/FsCodec/pull/75) [#323](https://github.com/jet/equinox/pull/323)
 
 ### Removed
  
-- Remove explicit `net461` handling; minimum target now `netstandard 2.1` / `net6.0` [#310](https://github.com/jet/equinox/pull/310)
+- Remove explicit `net461` handling; minimum target now `netstandard 2.1` / `net6.0` / `FSharp.Core` v `4.5.4` [#310](https://github.com/jet/equinox/pull/310) [#323](https://github.com/jet/equinox/pull/323)
 
 ### Fixed
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,8 @@
     <PackageLicense>Apache-2.0</PackageLicense>
     <Copyright>Copyright © 2016-22</Copyright>
 
+    <WarningLevel>5</WarningLevel>
+    
     <ThisDirAbsolute>$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory)"))</ThisDirAbsolute>
 
     <!-- SourceLink related properties https://github.com/dotnet/SourceLink#using-sourcelink -->

--- a/samples/Infrastructure/Infrastructure.fsproj
+++ b/samples/Infrastructure/Infrastructure.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <WarningLevel>5</WarningLevel>
-    <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
@@ -27,7 +25,7 @@
   <ItemGroup>
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Destructurama.FSharp" Version="1.2.0" />
-    <PackageReference Include="FSharp.Core" Version="4.3.4" />
+    <PackageReference Include="FSharp.Core" Version="4.5.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="5.1.1" />

--- a/samples/Infrastructure/Services.fs
+++ b/samples/Infrastructure/Services.fs
@@ -1,13 +1,13 @@
 ﻿module Samples.Infrastructure.Services
 
 open Domain
-open FsCodec.SystemTextJson
+open FsCodec.SystemTextJson.Interop // use ToJsonElementCodec because we are doing an overkill example
 open Microsoft.Extensions.DependencyInjection
 open System
 
 type StreamResolver(storage) =
     member _.Resolve
-        (   codec : FsCodec.IEventCodec<'event,byte[],_>,
+        (   codec : FsCodec.IEventCodec<'event, ReadOnlyMemory<byte>, _>,
             fold: 'state -> 'event seq -> 'state,
             initial : 'state,
             snapshot : ('event -> bool) * ('state -> 'event)) =

--- a/samples/Infrastructure/Storage.fs
+++ b/samples/Infrastructure/Storage.fs
@@ -7,7 +7,7 @@ open System
 [<RequireQualifiedAccess; NoEquality; NoComparison>]
 type StorageConfig =
     // For MemoryStore, we keep the events as UTF8 arrays - we could use FsCodec.Codec.Box to remove the JSON encoding, which would improve perf but can conceal problems
-    | Memory of Equinox.MemoryStore.VolatileStore<byte[]>
+    | Memory of Equinox.MemoryStore.VolatileStore<ReadOnlyMemory<byte>>
     | Cosmos of Equinox.CosmosStore.CosmosStoreContext * Equinox.CosmosStore.CachingStrategy * unfolds: bool
     | Es     of Equinox.EventStore.EventStoreContext * Equinox.EventStore.CachingStrategy option * unfolds: bool
     | Sql    of Equinox.SqlStreamStore.SqlStreamStoreContext * Equinox.SqlStreamStore.CachingStrategy option * unfolds: bool

--- a/samples/Store/Domain.Tests/Domain.Tests.fsproj
+++ b/samples/Store/Domain.Tests/Domain.Tests.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <WarningLevel>5</WarningLevel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Store/Domain/Cart.fs
+++ b/samples/Store/Domain/Cart.fs
@@ -24,8 +24,8 @@ module Events =
         | ItemQuantityChanged       of ItemQuantityChangedInfo
         | ItemPropertiesChanged     of ItemPropertiesChangedInfo
         interface TypeShape.UnionContract.IUnionContract
-    let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
-    let codecStj = FsCodec.SystemTextJson.Codec.Create<Event>()
+    let codec = EventCodec.create<Event>()
+    let codecJe = EventCodec.createJson<Event>()
 
 module Fold =
 

--- a/samples/Store/Domain/ContactPreferences.fs
+++ b/samples/Store/Domain/ContactPreferences.fs
@@ -12,8 +12,8 @@ module Events =
     type Event =
         | [<System.Runtime.Serialization.DataMember(Name = "contactPreferencesChanged")>]Updated of Value
         interface TypeShape.UnionContract.IUnionContract
-    let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
-    let codecStj = FsCodec.SystemTextJson.Codec.Create<Event>()
+    let codec = EventCodec.create<Event>()
+    let codecJe = EventCodec.createJson<Event>()
 
 module Fold =
 

--- a/samples/Store/Domain/Domain.fsproj
+++ b/samples/Store/Domain/Domain.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <WarningLevel>5</WarningLevel>
-    <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
@@ -19,10 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.3.4" />
+    <PackageReference Include="FSharp.Core" Version="4.5.4" />
 
-    <PackageReference Include="FsCodec.NewtonsoftJson" Version="2.3.2" />
-    <PackageReference Include="FsCodec.SystemTextJson" Version="2.3.2" />
+    <PackageReference Include="FsCodec.NewtonsoftJson" Version="3.0.0-rc.2" />
+    <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.2" />
 
     <ProjectReference Include="..\..\..\src\Equinox\Equinox.fsproj" />
   </ItemGroup>

--- a/samples/Store/Domain/Favorites.fs
+++ b/samples/Store/Domain/Favorites.fs
@@ -14,8 +14,8 @@ module Events =
         | Favorited                             of Favorited
         | Unfavorited                           of Unfavorited
         interface TypeShape.UnionContract.IUnionContract
-    let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
-    let codecStj = FsCodec.SystemTextJson.Codec.Create<Event>()
+    let codec = EventCodec.create<Event>()
+    let codecJe = EventCodec.createJson<Event>()
 
 module Fold =
 

--- a/samples/Store/Domain/SavedForLater.fs
+++ b/samples/Store/Domain/SavedForLater.fs
@@ -29,7 +29,7 @@ module Events =
         /// Addition of a collection of skus to the list
         | Added of Added
         interface TypeShape.UnionContract.IUnionContract
-    let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
+    let codec = EventCodec.create<Event>()
 
 module Fold =
     open Events

--- a/samples/Store/Integration/CartIntegration.fs
+++ b/samples/Store/Integration/CartIntegration.fs
@@ -4,16 +4,17 @@ open Domain
 open Equinox
 open Equinox.CosmosStore.Integration.CosmosFixtures
 open Swensen.Unquote
+open System
 
 let fold, initial = Cart.Fold.fold, Cart.Fold.initial
 let snapshot = Cart.Fold.isOrigin, Cart.Fold.snapshot
 
-let createMemoryStore () = MemoryStore.VolatileStore<byte[]>()
+let createMemoryStore () = MemoryStore.VolatileStore<ReadOnlyMemory<byte>>()
 let createServiceMemory log store =
     Cart.create log (MemoryStore.MemoryStoreCategory(store, Cart.Events.codec, fold, initial).Resolve)
 
 let codec = Cart.Events.codec
-let codecStj = Cart.Events.codecStj
+let codecJe = Cart.Events.codecJe
 
 let resolveGesStreamWithRollingSnapshots context =
     EventStore.EventStoreCategory(context, codec, fold, initial, access = EventStore.AccessStrategy.RollingSnapshots snapshot).Resolve
@@ -21,9 +22,9 @@ let resolveGesStreamWithoutCustomAccessStrategy context =
     EventStore.EventStoreCategory(context, codec, fold, initial).Resolve
 
 let resolveCosmosStreamWithSnapshotStrategy context =
-    CosmosStore.CosmosStoreCategory(context, codecStj, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Snapshot snapshot).Resolve
+    CosmosStore.CosmosStoreCategory(context, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Snapshot snapshot).Resolve
 let resolveCosmosStreamWithoutCustomAccessStrategy context =
-    CosmosStore.CosmosStoreCategory(context, codecStj, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Unoptimized).Resolve
+    CosmosStore.CosmosStoreCategory(context, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Unoptimized).Resolve
 
 let addAndThenRemoveItemsManyTimesExceptTheLastOne context cartId skuId (service: Cart.Service) count =
     service.ExecuteManyAsync(cartId, false, seq {

--- a/samples/Store/Integration/CodecIntegration.fs
+++ b/samples/Store/Integration/CodecIntegration.fs
@@ -42,8 +42,9 @@ let codec = FsCodec.NewtonsoftJson.Codec.Create()
 
 [<AutoData(MaxTest=100)>]
 let ``Can roundtrip, rendering correctly`` (x: SimpleDu) =
-    let serialized = codec.Encode(None,x)
-    render x =! if serialized.Data = null then null else System.Text.Encoding.UTF8.GetString(serialized.Data)
-    let adapted = FsCodec.Core.TimelineEvent.Create(-1L, serialized.EventType, serialized.Data)
+    let serialized = codec.Encode(None, x)
+    let d = serialized.Data
+    render x =! if d.IsEmpty then null else System.Text.Encoding.UTF8.GetString(d.Span)
+    let adapted = FsCodec.Core.TimelineEvent.Create(-1L, serialized.EventType, d)
     let deserialized = codec.TryDecode adapted |> Option.get
     deserialized =! x

--- a/samples/Store/Integration/ContactPreferencesIntegration.fs
+++ b/samples/Store/Integration/ContactPreferencesIntegration.fs
@@ -12,19 +12,19 @@ let createServiceMemory log store =
     ContactPreferences.create log (MemoryStore.MemoryStoreCategory(store, FsCodec.Box.Codec.Create(), fold, initial).Resolve)
 
 let codec = ContactPreferences.Events.codec
-let codecStj = ContactPreferences.Events.codecStj
+let codecJe = ContactPreferences.Events.codecJe
 let resolveStreamGesWithOptimizedStorageSemantics context =
     EventStore.EventStoreCategory(context 1, codec, fold, initial, access = EventStore.AccessStrategy.LatestKnownEvent).Resolve
 let resolveStreamGesWithoutAccessStrategy context =
     EventStore.EventStoreCategory(context defaultBatchSize, codec, fold, initial).Resolve
 
 let resolveStreamCosmosWithLatestKnownEventSemantics context =
-    CosmosStore.CosmosStoreCategory(context, codecStj, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.LatestKnownEvent).Resolve
+    CosmosStore.CosmosStoreCategory(context, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.LatestKnownEvent).Resolve
 let resolveStreamCosmosUnoptimized context =
-    CosmosStore.CosmosStoreCategory(context, codecStj, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Unoptimized).Resolve
+    CosmosStore.CosmosStoreCategory(context, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Unoptimized).Resolve
 let resolveStreamCosmosRollingUnfolds context =
     let access = CosmosStore.AccessStrategy.Custom(ContactPreferences.Fold.isOrigin, ContactPreferences.Fold.transmute)
-    CosmosStore.CosmosStoreCategory(context, codecStj, fold, initial, CosmosStore.CachingStrategy.NoCaching, access).Resolve
+    CosmosStore.CosmosStoreCategory(context, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, access).Resolve
 
 type Tests(testOutputHelper) =
     let testOutput = TestOutput testOutputHelper

--- a/samples/Store/Integration/FavoritesIntegration.fs
+++ b/samples/Store/Integration/FavoritesIntegration.fs
@@ -13,26 +13,26 @@ let createServiceMemory log store =
     Favorites.create log (MemoryStore.MemoryStoreCategory(store, FsCodec.Box.Codec.Create(), fold, initial).Resolve)
 
 let codec = Favorites.Events.codec
-let codecStj = Favorites.Events.codecStj
+let codecJe = Favorites.Events.codecJe
 let createServiceGes log context =
     let cat = EventStore.EventStoreCategory(context, codec, fold, initial, access = EventStore.AccessStrategy.RollingSnapshots snapshot)
     Favorites.create log cat.Resolve
 
 let createServiceCosmosSnapshotsUncached log context =
-    let cat = CosmosStore.CosmosStoreCategory(context, codecStj, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Snapshot snapshot)
+    let cat = CosmosStore.CosmosStoreCategory(context, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Snapshot snapshot)
     Favorites.create log cat.Resolve
 
 let createServiceCosmosRollingStateUncached log context =
     let access = CosmosStore.AccessStrategy.RollingState Favorites.Fold.snapshot
-    let cat = CosmosStore.CosmosStoreCategory(context, codecStj, fold, initial, CosmosStore.CachingStrategy.NoCaching, access)
+    let cat = CosmosStore.CosmosStoreCategory(context, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, access)
     Favorites.create log cat.Resolve
 
 let createServiceCosmosUnoptimizedButCached log context =
     let access = CosmosStore.AccessStrategy.Unoptimized
     let caching =
-        let cache = Equinox.Cache ("name", 10)
+        let cache = Cache ("name", 10)
         CosmosStore.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
-    let cat = CosmosStore.CosmosStoreCategory(context, codecStj, fold, initial, caching, access)
+    let cat = CosmosStore.CosmosStoreCategory(context, codecJe, fold, initial, caching, access)
     Favorites.create log cat.Resolve
 
 type Command =

--- a/samples/Store/Integration/Integration.fsproj
+++ b/samples/Store/Integration/Integration.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <WarningLevel>5</WarningLevel>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
 
@@ -29,7 +27,6 @@
 
   <ItemGroup>
     <PackageReference Include="FsCheck.xUnit" Version="2.16.4" />
-    <PackageReference Include="FsCodec.Box" Version="2.3.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="5.1.1" />
     <PackageReference Include="unquote" Version="6.1.0" />

--- a/samples/TodoBackend/Todo.fs
+++ b/samples/TodoBackend/Todo.fs
@@ -20,7 +20,7 @@ module Events =
         | Cleared
         | Snapshotted   of Snapshotted
         interface TypeShape.UnionContract.IUnionContract
-    let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
+    let codec = EventCodec.create<Event> ()
 
 module Fold =
     type State = { items : Events.Todo list; nextId : int }

--- a/samples/TodoBackend/TodoBackend.fsproj
+++ b/samples/TodoBackend/TodoBackend.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <WarningLevel>5</WarningLevel>
-    <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
@@ -13,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.3.4" />
+    <PackageReference Include="FSharp.Core" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Tutorial/Cosmos.fsx
+++ b/samples/Tutorial/Cosmos.fsx
@@ -22,7 +22,8 @@
 #else
 #r "nuget:Serilog.Sinks.Console"
 #r "nuget:Serilog.Sinks.Seq"
-#r "nuget:Equinox.CosmosStore"
+#r "nuget:Equinox.CosmosStore, *-*"
+#r "nuget:FsCodec.SystemTextJson, *-*"
 #endif
 
 module Log =
@@ -51,7 +52,7 @@ module Favorites =
             | Added of Item
             | Removed of Item
             interface TypeShape.UnionContract.IUnionContract
-        let codec = FsCodec.SystemTextJson.Codec.Create<Event>() // Coming soon, replace Newtonsoft with SystemTextJson and works same
+        let codec = FsCodec.SystemTextJson.CodecJsonElement.Create<Event>()
 
     module Fold =
 

--- a/samples/Tutorial/FulfilmentCenter.fsx
+++ b/samples/Tutorial/FulfilmentCenter.fsx
@@ -1,23 +1,24 @@
 #if LOCAL
-#I "bin/Debug/netstandard2.1/"
+#I "bin/Debug/net6.0/"
 #r "Serilog.dll"
 #r "Serilog.Sinks.Console.dll"
 #r "Newtonsoft.Json.dll"
-#r "TypeShape.dll"
 #r "Equinox.dll"
 #r "Equinox.Core.dll"
 #r "FSharp.UMX.dll"
-#r "FSCodec.dll"
+#r "FsCodec.dll"
+#r "TypeShape.dll"
+#r "FsCodec.NewtonsoftJson.dll"
 #r "FsCodec.SystemTextJson.dll"
 #r "Microsoft.Azure.Cosmos.Client.dll"
-#r "Microsoft.Azure.Cosmos.Direct.dll"
 #r "System.Net.Http"
 #r "Serilog.Sinks.Seq.dll"
 #r "Equinox.CosmosStore.dll"
 #else
-#r "nuget:Equinox.MemoryStore"
-#r "nuget:Equinox.CosmosStore"
-#r "nuget:FsCodec.NewtonsoftJson"
+#r "nuget:Equinox.MemoryStore, *-*"
+#r "nuget:Equinox.CosmosStore, *-*"
+#r "nuget:FsCodec.NewtonsoftJson, *-*"
+#r "nuget:FsCodec.SystemTextJson, *-*"
 #r "nuget:Serilog.Sinks.Console"
 #r "nuget:Serilog.Sinks.Seq"
 #endif
@@ -63,7 +64,7 @@ module FulfilmentCenter =
             | FcDetailsChanged of FcData
             | FcRenamed of FcName
             interface TypeShape.UnionContract.IUnionContract
-        let codec = FsCodec.SystemTextJson.Codec.Create<Event>()
+        let codec = FsCodec.SystemTextJson.CodecJsonElement.Create<Event>()
 
     module Fold =
 

--- a/samples/Tutorial/Gapless.fs
+++ b/samples/Tutorial/Gapless.fs
@@ -18,7 +18,7 @@ module Events =
         | Released of Item
         | Snapshotted of Snapshotted
         interface TypeShape.UnionContract.IUnionContract
-    let codec = FsCodec.SystemTextJson.Codec.Create<Event>()
+    let codec = FsCodec.SystemTextJson.CodecJsonElement.Create<Event>()
 
 module Fold =
 

--- a/samples/Tutorial/Index.fs
+++ b/samples/Tutorial/Index.fs
@@ -13,7 +13,7 @@ module Events =
         | Deleted of ItemIds
         | Snapshotted of Items<'v>
         interface TypeShape.UnionContract.IUnionContract
-    let codec<'v> = FsCodec.SystemTextJson.Codec.Create<Event<'v>>()
+    let codec<'v> = FsCodec.SystemTextJson.CodecJsonElement.Create<Event<'v>>()
 
 module Fold =
 

--- a/samples/Tutorial/Infrastructure.fs
+++ b/samples/Tutorial/Infrastructure.fs
@@ -18,3 +18,13 @@ and [<Measure>] indexId
 module IndexId =
     let parse (value : string) : IndexId = %value
     let toString (value : IndexId) : string = %value
+
+module EventCodec =
+
+    /// For CosmosStore - we encode to JsonElement as that's what the store talks
+    let createJson<'t when 't :> TypeShape.UnionContract.IUnionContract> () =
+        FsCodec.SystemTextJson.CodecJsonElement.Create<'t>()
+
+    /// For stores other than CosmosStore, we encode to UTF-8 and have the store do the right thing
+    let create<'t when 't :> TypeShape.UnionContract.IUnionContract> () =
+        FsCodec.NewtonsoftJson.Codec.Create<'t>()

--- a/samples/Tutorial/Sequence.fs
+++ b/samples/Tutorial/Sequence.fs
@@ -14,7 +14,7 @@ module Events =
     type Event =
         | Reserved of Reserved
         interface TypeShape.UnionContract.IUnionContract
-    let codec = FsCodec.SystemTextJson.Codec.Create<Event>()
+    let codec = FsCodec.SystemTextJson.CodecJsonElement.Create<Event>()
 
 module Fold =
 

--- a/samples/Tutorial/Set.fs
+++ b/samples/Tutorial/Set.fs
@@ -12,7 +12,7 @@ module Events =
         | Deleted of Items
         | Snapshotted of Items
         interface TypeShape.UnionContract.IUnionContract
-    let codec = FsCodec.SystemTextJson.Codec.Create<Event>()
+    let codec = FsCodec.SystemTextJson.CodecJsonElement.Create<Event>()
 
 module Fold =
 

--- a/samples/Tutorial/Todo.fsx
+++ b/samples/Tutorial/Todo.fsx
@@ -18,9 +18,10 @@
 #r "Microsoft.Azure.Cosmos.Client.dll"
 #r "Equinox.CosmosStore.dll"
 #else
-#r "nuget:Equinox.CosmosStore"
-#r "nuget:Serilog.Sinks.Console"
-#r "nuget:Serilog.Sinks.Seq"
+#r "nuget: Equinox.CosmosStore, *-*"
+#r "nuget: FsCodec.SystemTextJson, *-*"
+#r "nuget: Serilog.Sinks.Console"
+#r "nuget: Serilog.Sinks.Seq"
 #endif
 open System
 
@@ -40,7 +41,7 @@ type Event =
     | Cleared
     | Snapshotted       of Snapshotted
     interface TypeShape.UnionContract.IUnionContract
-let codec = FsCodec.SystemTextJson.Codec.Create<Event>()
+let codec = FsCodec.SystemTextJson.CodecJsonElement.Create<Event>()
 
 type State = { items : Todo list; nextId : int }
 let initial = { items = []; nextId = 0 }

--- a/samples/Tutorial/Tutorial.fsproj
+++ b/samples/Tutorial/Tutorial.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <WarningLevel>5</WarningLevel>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
@@ -13,10 +12,10 @@
     <Compile Include="Index.fs" />
     <Compile Include="Set.fs" />
     <Compile Include="Upload.fs" />
-    <None Include="Todo.fsx" />
-    <None Include="Favorites.fsx" />
     <None Include="Counter.fsx" />
+    <None Include="Favorites.fsx" />
     <None Include="Cosmos.fsx" />
+    <None Include="Todo.fsx" />
     <None Include="AsAt.fsx" />
     <None Include="FulfilmentCenter.fsx" />
   </ItemGroup>
@@ -28,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FsCodec.NewtonsoftJson" Version="2.3.2" />
-    <PackageReference Include="FsCodec.SystemTextJson" Version="2.3.2" />
+    <PackageReference Include="FsCodec.NewtonsoftJson" Version="3.0.0-rc.2" />
+    <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="5.1.1" />
   </ItemGroup>

--- a/samples/Tutorial/Upload.fs
+++ b/samples/Tutorial/Upload.fs
@@ -29,8 +29,8 @@ module Events =
     type Event =
         | IdAssigned of IdAssigned
         interface TypeShape.UnionContract.IUnionContract
-    let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
-    let codecStj = FsCodec.SystemTextJson.Codec.Create<Event>()
+    let codec = EventCodec.create<Event> ()
+    let codecJe = EventCodec.createJson<Event> ()
 
 module Fold =
 
@@ -63,7 +63,7 @@ module Cosmos =
     open Equinox.CosmosStore
     let create (context,cache) =
         let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
-        let category = CosmosStoreCategory(context, Events.codecStj, Fold.fold, Fold.initial, cacheStrategy, AccessStrategy.LatestKnownEvent)
+        let category = CosmosStoreCategory(context, Events.codecJe, Fold.fold, Fold.initial, cacheStrategy, AccessStrategy.LatestKnownEvent)
         create category.Resolve
 
 module EventStore =

--- a/samples/Web/Startup.fs
+++ b/samples/Web/Startup.fs
@@ -8,12 +8,12 @@ open Samples.Infrastructure
 open Serilog
 open Serilog.Events
 
-[<NoComparison>]
+[<NoEquality; NoComparison>]
 type Arguments =
-    | [<AltCommandLine "-V">]                                 Verbose
-    | [<AltCommandLine "-S">]                                 LocalSeq
-    | [<AltCommandLine "-C">]                                 Cached
-    | [<AltCommandLine "-U">]                                 Unfolds
+    | [<AltCommandLine "-V">]                                   Verbose
+    | [<AltCommandLine "-S">]                                   LocalSeq
+    | [<AltCommandLine "-C">]                                   Cached
+    | [<AltCommandLine "-U">]                                   Unfolds
     | [<CliPrefix(CliPrefix.None); Last>]                       Memory   of ParseResults<Storage.MemoryStore.Arguments>
     | [<CliPrefix(CliPrefix.None); Last>]                       Cosmos   of ParseResults<Storage.Cosmos.Arguments>
     | [<CliPrefix(CliPrefix.None); Last>]                       Es       of ParseResults<Storage.EventStore.Arguments>

--- a/samples/Web/Web.fsproj
+++ b/samples/Web/Web.fsproj
@@ -13,8 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Argu" Version="6.1.1" />
-    <PackageReference Include="FsCodec.SystemTextJson" Version="2.3.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
   </ItemGroup>
 

--- a/src/Equinox.Core/Equinox.Core.fsproj
+++ b/src/Equinox.Core/Equinox.Core.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <WarningLevel>5</WarningLevel>
-    <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
@@ -27,7 +25,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
 
-    <PackageReference Include="FSharp.Core" Version="4.3.4" />
+    <PackageReference Include="FSharp.Core" Version="4.5.4" />
     <PackageReference Include="System.Runtime.Caching" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/Equinox.Core/StoreCategory.fs
+++ b/src/Equinox.Core/StoreCategory.fs
@@ -18,6 +18,6 @@ type private Stream<'event, 'state, 'context>(category : ICategory<'event, 'stat
 /// Store-agnostic interface representing interactions a Flow can have with the state of a given event stream. Not intended for direct use by consumer code.
 type StoreCategory<'event, 'state, 'streamId, 'context>(resolve, empty) =
 
-    member _.Resolve(streamName : 'streamId, [<O; D null>]?context) =
+    member _.Resolve(streamName : 'streamId, [<O; D null>] ?context) =
         let category, streamName, maybeContainerInitializationGate = resolve streamName
         Stream<'event, 'state, 'context>(category, streamName, empty, ?context = context, ?init = maybeContainerInitializationGate) :> IStream<'event, 'state>

--- a/src/Equinox.CosmosStore.Prometheus/Equinox.CosmosStore.Prometheus.fsproj
+++ b/src/Equinox.CosmosStore.Prometheus/Equinox.CosmosStore.Prometheus.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <WarningLevel>5</WarningLevel>
-    <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
@@ -20,7 +18,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
 
-    <PackageReference Include="FSharp.Core" Version="4.3.4" />
+    <PackageReference Include="FSharp.Core" Version="4.5.4" />
 
     <PackageReference Include="prometheus-net" Version="3.6.0" />
   </ItemGroup>

--- a/src/Equinox.CosmosStore/Equinox.CosmosStore.fsproj
+++ b/src/Equinox.CosmosStore/Equinox.CosmosStore.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <WarningLevel>5</WarningLevel>
-    <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
@@ -22,11 +20,11 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
 
-    <PackageReference Include="FSharp.Core" Version="4.3.4" />
+    <PackageReference Include="FSharp.Core" Version="4.5.4" />
 
-    <PackageReference Include="FsCodec" Version="2.3.2" />
+    <PackageReference Include="FsCodec" Version="3.0.0-rc.2" />
     <PackageReference Include="FSharp.Control.AsyncSeq" Version="2.0.23" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.25.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.27.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/Equinox.EventStore/Equinox.EventStore.fsproj
+++ b/src/Equinox.EventStore/Equinox.EventStore.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <WarningLevel>5</WarningLevel>
-    <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
@@ -21,10 +19,10 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
 
-    <PackageReference Include="FSharp.Core" Version="4.3.4" />
+    <PackageReference Include="FSharp.Core" Version="4.5.4" />
 
     <PackageReference Include="EventStore.Client" Version="22.0.0-preview" />
-    <PackageReference Include="FsCodec" Version="2.3.2" />
+    <PackageReference Include="FsCodec" Version="3.0.0-rc.2" />
     <PackageReference Include="FSharp.Control.AsyncSeq" Version="2.0.23" />
   </ItemGroup>
 

--- a/src/Equinox.MemoryStore/Equinox.MemoryStore.fsproj
+++ b/src/Equinox.MemoryStore/Equinox.MemoryStore.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <WarningLevel>5</WarningLevel>
-    <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
@@ -20,9 +18,9 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
 
-    <PackageReference Include="FSharp.Core" Version="4.3.4" />
+    <PackageReference Include="FSharp.Core" Version="4.5.4" />
 
-    <PackageReference Include="FsCodec" Version="2.3.2" />
+    <PackageReference Include="FsCodec" Version="3.0.0-rc.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Equinox.SqlStreamStore.MsSql/Equinox.SqlStreamStore.MsSql.fsproj
+++ b/src/Equinox.SqlStreamStore.MsSql/Equinox.SqlStreamStore.MsSql.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <WarningLevel>5</WarningLevel>
-    <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
@@ -17,7 +15,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
 
-    <PackageReference Include="FSharp.Core" Version="4.3.4" />
+    <PackageReference Include="FSharp.Core" Version="4.5.4" />
 
     <PackageReference Include="SqlStreamStore.MsSql" Version="1.2.0-beta.8" />
   </ItemGroup>

--- a/src/Equinox.SqlStreamStore.MySql/Equinox.SqlStreamStore.MySql.fsproj
+++ b/src/Equinox.SqlStreamStore.MySql/Equinox.SqlStreamStore.MySql.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <WarningLevel>5</WarningLevel>
-    <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
@@ -17,7 +15,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
 
-    <PackageReference Include="FSharp.Core" Version="4.3.4" />
+    <PackageReference Include="FSharp.Core" Version="4.5.4" />
 
     <PackageReference Include="SqlStreamStore.MySql" Version="1.2.0-beta.8" />
   </ItemGroup>

--- a/src/Equinox.SqlStreamStore.Postgres/Equinox.SqlStreamStore.Postgres.fsproj
+++ b/src/Equinox.SqlStreamStore.Postgres/Equinox.SqlStreamStore.Postgres.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <WarningLevel>5</WarningLevel>
-    <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
@@ -17,7 +15,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
 
-    <PackageReference Include="FSharp.Core" Version="4.3.4" />
+    <PackageReference Include="FSharp.Core" Version="4.5.4" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
 
     <PackageReference Include="SqlStreamStore.Postgres" Version="1.2.0-beta.8" />

--- a/src/Equinox.SqlStreamStore/Equinox.SqlStreamStore.fsproj
+++ b/src/Equinox.SqlStreamStore/Equinox.SqlStreamStore.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <WarningLevel>5</WarningLevel>
-    <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
@@ -21,9 +19,9 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
 
-    <PackageReference Include="FSharp.Core" Version="4.3.4" />
+    <PackageReference Include="FSharp.Core" Version="4.5.4" />
 
-    <PackageReference Include="FsCodec" Version="2.3.2" />
+    <PackageReference Include="FsCodec" Version="3.0.0-rc.2" />
     <PackageReference Include="FSharp.Control.AsyncSeq" Version="2.0.23" />
     <PackageReference Include="SqlStreamStore" Version="1.2.0-beta.8" />
   </ItemGroup>

--- a/src/Equinox/Decider.fs
+++ b/src/Equinox/Decider.fs
@@ -9,8 +9,8 @@ type MaxResyncsExhaustedException(count) =
 /// Central Application-facing API. Wraps the handling of decision or query flows in a manner that is store agnostic
 type Decider<'event, 'state>
     (   log, stream : Core.IStream<'event, 'state>, maxAttempts : int,
-        [<Optional; DefaultParameterValue(null)>] ?createAttemptsExhaustedException : int -> exn,
-        [<Optional; DefaultParameterValue(null)>] ?resyncPolicy) =
+        [<Optional; DefaultParameterValue null>] ?createAttemptsExhaustedException : int -> exn,
+        [<Optional; DefaultParameterValue null>] ?resyncPolicy) =
 
     do if maxAttempts < 1 then raise <| System.ArgumentOutOfRangeException("maxAttempts", maxAttempts, "should be >= 1")
     let fetch : LoadOption<'state> option -> (Serilog.ILogger -> Async<Core.StreamToken * 'state>) = function

--- a/src/Equinox/Equinox.fsproj
+++ b/src/Equinox/Equinox.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <WarningLevel>5</WarningLevel>
-    <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
@@ -17,7 +15,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
 
-    <PackageReference Include="FSharp.Core" Version="4.3.4" />
+    <PackageReference Include="FSharp.Core" Version="4.5.4" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 

--- a/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
+++ b/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
@@ -35,8 +35,7 @@ module SequenceCheck =
         type Event =
             | Add of {| value : int |}
             interface TypeShape.UnionContract.IUnionContract
-        open FsCodec.SystemTextJson
-        let codec = Codec.Create<Event>()
+        let codec = FsCodec.SystemTextJson.CodecJsonElement.Create<Event>()
 
     module Fold =
 

--- a/tests/Equinox.CosmosStore.Integration/CosmosCoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosCoreIntegration.fs
@@ -10,12 +10,11 @@ open System
 
 type TestEvents() =
     static member private Create(i, ?eventType, ?json) =
-        let ser = System.Text.Json.JsonSerializer.SerializeToElement
         EventData.FromUtf8Bytes
             (   sprintf "%s:%d" (defaultArg eventType "test_event") i,
-                ser (defaultArg json "{\"d\":\"d\"}"),
-                ser "{\"m\":\"m\"}")
-    static member Create(i, c) = Array.init c (fun x -> TestEvents.Create(x+i))
+                System.Text.Json.JsonSerializer.SerializeToElement (defaultArg json "{\"d\":\"d\"}"),
+                System.Text.Json.JsonSerializer.SerializeToElement "{\"m\":\"m\"}")
+    static member Create(i, c) = Array.init c (fun x -> TestEvents.Create(x + i))
 
 type Tests(testOutputHelper) =
     let testContext = TestContext(testOutputHelper)
@@ -387,7 +386,7 @@ type Tests(testOutputHelper) =
     [<AutoData(MaxTest = 2, SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let fallback (eventsInTip, TestStream streamName) = Async.RunSynchronously <| async {
         let ctx1, ctx1Unsafe = createPrimaryEventsContextWithUnsafe log 10 (if eventsInTip then 3 else 0)
-        let ctx2 = createSecondaryEventsContext log defaultQueryMaxItems
+        let ctx2 = createArchiveEventsContext log defaultQueryMaxItems
         let ctx12 = createFallbackEventsContext log defaultQueryMaxItems
 
         let! expected = add6EventsIn2BatchesEx ctx1 streamName 4

--- a/tests/Equinox.CosmosStore.Integration/CosmosFixtures.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosFixtures.fs
@@ -46,7 +46,7 @@ type StoreContext = CosmosStoreContext
 type StoreCategory<'E, 'S> = CosmosStoreCategory<'E, 'S, obj>
 
 let createPrimaryContextIgnoreMissing client queryMaxItems tipMaxEvents ignoreMissing =
-    StoreContext(client, tipMaxEvents, queryMaxItems = queryMaxItems, ignoreMissingEvents = ignoreMissing)
+    StoreContext(client, tipMaxEvents = tipMaxEvents, queryMaxItems = queryMaxItems, ignoreMissingEvents = ignoreMissing)
 
 let createPrimaryContextEx log queryMaxItems tipMaxEvents =
     let connection = connectPrimary log
@@ -57,7 +57,7 @@ let defaultTipMaxEvents = 10
 let createPrimaryContext log queryMaxItems =
     createPrimaryContextEx log queryMaxItems defaultTipMaxEvents
 
-let createSecondaryContext log queryMaxItems =
+let createArchiveContext log queryMaxItems =
     let connection = connectArchive log
     StoreContext(connection, defaultTipMaxEvents, queryMaxItems = queryMaxItems)
 
@@ -78,8 +78,8 @@ let createPrimaryEventsContextWithUnsafe log queryMaxItems tipMaxItems =
         Core.EventsContext(context, log)
     create false, create true
 
-let createSecondaryEventsContext log queryMaxItems =
-    let context = createSecondaryContext log queryMaxItems
+let createArchiveEventsContext log queryMaxItems =
+    let context = createArchiveContext log queryMaxItems
     Core.EventsContext(context, log)
 
 let createFallbackEventsContext log queryMaxItems =

--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -11,7 +11,7 @@ open Equinox.CosmosStore.Integration.CosmosFixtures
 module Cart =
     let fold, initial = Cart.Fold.fold, Cart.Fold.initial
     let snapshot = Cart.Fold.isOrigin, Cart.Fold.snapshot
-    let codec = Cart.Events.codecStj
+    let codec = Cart.Events.codecJe
     let createServiceWithoutOptimization log context =
         let resolve = StoreCategory(context, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.Unoptimized).Resolve
         Cart.create log resolve
@@ -34,7 +34,7 @@ module Cart =
 
 module ContactPreferences =
     let fold, initial = ContactPreferences.Fold.fold, ContactPreferences.Fold.initial
-    let codec = ContactPreferences.Events.codecStj
+    let codec = ContactPreferences.Events.codecJe
     let private createServiceWithLatestKnownEvent context log cachingStrategy =
         let resolveStream = StoreCategory(context, codec, fold, initial, cachingStrategy, AccessStrategy.LatestKnownEvent).Resolve
         ContactPreferences.create log resolveStream

--- a/tests/Equinox.CosmosStore.Integration/Equinox.CosmosStore.Integration.fsproj
+++ b/tests/Equinox.CosmosStore.Integration/Equinox.CosmosStore.Integration.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <WarningLevel>5</WarningLevel>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
 

--- a/tests/Equinox.EventStore.Integration/Equinox.EventStore.Integration.fsproj
+++ b/tests/Equinox.EventStore.Integration/Equinox.EventStore.Integration.fsproj
@@ -21,7 +21,6 @@
 
   <ItemGroup>
     <PackageReference Include="FsCheck.xUnit" Version="2.16.4" />
-    <PackageReference Include="FsCodec.NewtonsoftJson" Version="2.3.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="5.1.1" />
     <PackageReference Include="unquote" Version="6.1.0" />

--- a/tests/Equinox.MemoryStore.Integration/Equinox.MemoryStore.Integration.fsproj
+++ b/tests/Equinox.MemoryStore.Integration/Equinox.MemoryStore.Integration.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <WarningLevel>5</WarningLevel>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,7 +17,6 @@
 
   <ItemGroup>
     <PackageReference Include="FsCheck.xUnit" Version="2.16.4" />
-    <PackageReference Include="FsCodec.Box" Version="2.3.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="unquote" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/Equinox.SqlStreamStore.MsSql.Integration/Equinox.SqlStreamStore.MsSql.Integration.fsproj
+++ b/tests/Equinox.SqlStreamStore.MsSql.Integration/Equinox.SqlStreamStore.MsSql.Integration.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <WarningLevel>5</WarningLevel>
     <DefineConstants>$(DefineConstants);STORE_MSSQL</DefineConstants>
   </PropertyGroup>
 

--- a/tests/Equinox.SqlStreamStore.MySql.Integration/Equinox.SqlStreamStore.MySql.Integration.fsproj
+++ b/tests/Equinox.SqlStreamStore.MySql.Integration/Equinox.SqlStreamStore.MySql.Integration.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <WarningLevel>5</WarningLevel>
     <DefineConstants>$(DefineConstants);STORE_MYSQL</DefineConstants>
   </PropertyGroup>
 

--- a/tests/Equinox.SqlStreamStore.Postgres.Integration/Equinox.SqlStreamStore.Postgres.Integration.fsproj
+++ b/tests/Equinox.SqlStreamStore.Postgres.Integration/Equinox.SqlStreamStore.Postgres.Integration.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <WarningLevel>5</WarningLevel>
     <DefineConstants>$(DefineConstants);STORE_POSTGRES</DefineConstants>
   </PropertyGroup>
 

--- a/tools/Equinox.Tool/Equinox.Tool.fsproj
+++ b/tools/Equinox.Tool/Equinox.Tool.fsproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <WarningLevel>5</WarningLevel>
-    <IsTestProject>false</IsTestProject>
 
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
 

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -89,6 +89,7 @@ and [<NoComparison; NoEquality>]StatsArguments =
 and [<NoComparison; NoEquality>]DumpArguments =
     | [<AltCommandLine "-s">]               Stream of FsCodec.StreamName
     | [<AltCommandLine "-C"; Unique>]       Correlation
+    | [<AltCommandLine "-B"; Unique>]       Blobs
     | [<AltCommandLine "-J"; Unique>]       JsonSkip
     | [<AltCommandLine "-P"; Unique>]       Pretty
     | [<AltCommandLine "-F"; Unique>]       FlattenUnfolds
@@ -104,7 +105,8 @@ and [<NoComparison; NoEquality>]DumpArguments =
         member a.Usage = a |> function
             | Stream _ ->                   "Specify stream(s) to dump."
             | Correlation ->                "Include Correlation/Causation identifiers"
-            | JsonSkip ->                   "Don't attempt to decode JSON"
+            | Blobs ->                      "Don't assume Data/Metadata is UTF-8 text"
+            | JsonSkip ->                   "Don't assume Data/Metadata is JSON"
             | Pretty ->                     "Pretty print the JSON over multiple lines"
             | FlattenUnfolds ->             "Don't pretty print the JSON over multiple lines for Unfolds"
             | TimeRegular ->                "Don't humanize time intervals between events"
@@ -236,6 +238,16 @@ let createStoreLog verbose verboseConsole maybeSeqEndpoint =
     let c = match maybeSeqEndpoint with None -> c | Some endpoint -> c.WriteTo.Seq(endpoint)
     c.CreateLogger() :> ILogger
 
+let dumpStats storeConfig log =
+    match storeConfig with
+    | Some (Storage.StorageConfig.Cosmos _) ->
+        Equinox.CosmosStore.Core.Log.InternalMetrics.dump log
+    | Some (Storage.StorageConfig.Es _) ->
+        Equinox.EventStore.Log.InternalMetrics.dump log
+    | Some (Storage.StorageConfig.Sql _) ->
+        Equinox.SqlStreamStore.Log.InternalMetrics.dump log
+    | _ -> ()
+
 module LoadTest =
 
     open Equinox.Tools.TestHarness
@@ -297,15 +309,7 @@ module LoadTest =
         for r in results do
             resultFile.Information("Aggregate: {aggregate}", r)
         log.Information("Run completed; Current memory allocation: {bytes:n2} MiB", (GC.GetTotalMemory(true) |> float) / 1024./1024.)
-
-        match storeConfig with
-        | Some (Storage.StorageConfig.Cosmos _) ->
-            Equinox.CosmosStore.Core.Log.InternalMetrics.dump log
-        | Some (Storage.StorageConfig.Es _) ->
-            Equinox.EventStore.Log.InternalMetrics.dump log
-        | Some (Storage.StorageConfig.Sql _) ->
-            Equinox.SqlStreamStore.Log.InternalMetrics.dump log
-        | _ -> ()
+        dumpStats storeConfig log
 
 let createDomainLog verbose verboseConsole maybeSeqEndpoint =
     let c = LoggerConfiguration().Destructure.FSharpTypes().Enrich.FromLogContext()
@@ -359,8 +363,7 @@ module SqlInit =
 
 module CosmosStats =
 
-    type Microsoft.Azure.Cosmos.Container with
-        // NB DO NOT CONSIDER PROMULGATING THIS HACK
+    type Microsoft.Azure.Cosmos.Container with // NB DO NOT CONSIDER PROMULGATING THIS HACK
         member container.QueryValue<'T>(sqlQuery : string) =
             let query : Microsoft.Azure.Cosmos.FeedResponse<'T> = container.GetItemQueryIterator<'T>(sqlQuery).ReadNextAsync() |> Async.AwaitTaskCorrect |> Async.RunSynchronously
             query |> Seq.exactlyOne
@@ -393,27 +396,33 @@ module Dump =
         let createStoreLog verboseStore = createStoreLog verboseStore verboseConsole maybeSeq
         let storeLog, storeConfig = a.ConfigureStore(log, createStoreLog)
         let doU, doE = not (args.Contains EventsOnly), not (args.Contains UnfoldsOnly)
-        let doC, doJ, doT = args.Contains Correlation, not (args.Contains JsonSkip), not (args.Contains TimeRegular)
+        let doC, doJ, doS, doT = args.Contains Correlation, not (args.Contains JsonSkip), not (args.Contains Blobs), not (args.Contains TimeRegular)
         let cat = Services.StreamResolver(storeConfig)
 
         let streams = args.GetResults DumpArguments.Stream
         log.ForContext("streams",streams).Information("Reading...")
         let initial = List.empty
         let fold state events = (events, state) ||> Seq.foldBack (fun e l -> e :: l)
-        let tryDecode (x : FsCodec.ITimelineEvent<byte[]>) = Some x
+        let tryDecode (x : FsCodec.ITimelineEvent<ReadOnlyMemory<byte>>) = Some x
         let idCodec = FsCodec.Codec.Create((fun _ -> failwith "No encoding required"), tryDecode, (fun _ -> failwith "No mapCausation"))
         let isOriginAndSnapshot = (fun (event : FsCodec.ITimelineEvent<_>) -> not doE && event.IsUnfold), fun _state -> failwith "no snapshot required"
         let formatUnfolds, formatEvents =
             let indentedOptions = FsCodec.SystemTextJson.Options.Create(indent = true)
-            let prettify : string -> _ = System.Text.Json.JsonDocument.Parse >> fun d -> System.Text.Json.JsonSerializer.Serialize(d, indentedOptions)
+            let prettify (json : string) =
+                use parsed = System.Text.Json.JsonDocument.Parse json
+                System.Text.Json.JsonSerializer.Serialize(parsed, indentedOptions)
             if args.Contains FlattenUnfolds then id else prettify
             , if args.Contains Pretty then prettify else id
-        let render format (data : byte[]) =
-            try match data with
-                | null | [||] -> null
-                | _ when doJ -> System.Text.Encoding.UTF8.GetString data |> format
-                | _ -> $"(%d{System.Text.Encoding.UTF8.GetString(data).Length} chars)"
-            with e -> log.ForContext("str", System.Text.Encoding.UTF8.GetString data).Warning(e, "JSON Parse failure - use SkipJson option to inhibit"); reraise()
+        let mutable payloadBytes = 0
+        let render format (data : ReadOnlyMemory<byte>) =
+            payloadBytes <- payloadBytes + data.Length
+            if data.IsEmpty then null
+            elif not doS then $"%6d{data.Length}b"
+            else try let s = System.Text.Encoding.UTF8.GetString data.Span
+                     if doJ then try format s
+                                 with e -> log.ForContext("str", s).Warning(e, "JSON Parse failure - use --JsonSkip option to inhibit"); reraise()
+                     else $"(%d{s.Length} chars)"
+                 with e -> log.Warning(e, "UTF-8 Parse failure - use --Blobs option to inhibit"); reraise()
         let readStream (streamName : FsCodec.StreamName) = async {
             let stream = cat.Resolve(idCodec, fold, initial, isOriginAndSnapshot) streamName
             let! _token, events = stream.Load(storeLog, allowStale = false)
@@ -438,6 +447,11 @@ module Dump =
         |> Seq.map readStream
         |> Async.Parallel
         |> Async.Ignore<unit[]>
+        |> Async.RunSynchronously
+
+        log.Information("Total Payload {kib:n1}KiB", float payloadBytes / 1024.)
+        if verboseConsole then
+            dumpStats (Some storeConfig) log
 
 [<EntryPoint>]
 let main argv =
@@ -451,7 +465,7 @@ let main argv =
         try match args.GetSubCommand() with
             | Init iargs -> CosmosInit.containerAndOrDb log iargs |> Async.RunSynchronously
             | Config cargs -> SqlInit.databaseOrSchema log cargs |> Async.RunSynchronously
-            | Dump dargs -> Dump.run (log, verboseConsole, maybeSeq) dargs |> Async.RunSynchronously
+            | Dump dargs -> Dump.run (log, verboseConsole, maybeSeq) dargs
             | Stats sargs -> CosmosStats.run (log, verboseConsole, maybeSeq) sargs |> Async.RunSynchronously
             | Run rargs ->
                 let reportFilename = args.GetResult(LogFile, programName + ".log") |> fun n -> System.IO.FileInfo(n).FullName

--- a/tools/Equinox.Tools.TestHarness/Equinox.Tools.TestHarness.fsproj
+++ b/tools/Equinox.Tools.TestHarness/Equinox.Tools.TestHarness.fsproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <WarningLevel>5</WarningLevel>
-    <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>


### PR DESCRIPTION
Summarised in https://github.com/jet/FsCodec/pull/75 - this PR updates the stores to align with this convention
Some dependency cleanup/simplification comes along for the ride, calved from #321 