### PR TITLE
CosmosStore - Extend aux collection initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Equinox.Tool`/`samples/`: switched to use `Equinox.EventStoreDb` [#196](https://github.com/jet/equinox/pull/196)
 - Update all non-Client dependencies except `FSharp.Core`, `FSharp.Control.AsyncSeq` [#310](https://github.com/jet/equinox/pull/310)
 - Update all Stores to use `FsCodec` v `3.0.0`, with [`EventBody` types switching from `byte[]` to `ReadOnlyMemory<byte>`, see FsCodec#75](https://github.com/jet/FsCodec/pull/75) [#323](https://github.com/jet/equinox/pull/323)
+- `CosmosStore`: Replace the hard-coding in `Equinox.CosmosStore.Core.Initialization.initAux` with an input parameter [#328](https://github.com/jet/equinox/pull/328) 
 
 ### Removed
  

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -581,7 +581,7 @@ module Initialization =
         cp.IndexingPolicy.Automatic <- false
         cp.IndexingPolicy.IndexingMode <- IndexingMode.None
 
-    let initAux (client : CosmosClient) (dName, cName) rus mode = async {
+    let initAux (client : CosmosClient) (dName, cName) mode = async {
         let! d = createOrProvisionDatabase client dName mode
         return! createOrProvisionContainer d (cName, "/id", applyAuxContainerProperties) mode } // as per Cosmos team, Partition Key must be "/id"
 

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -580,9 +580,8 @@ module Initialization =
         // TL;DR no indexing of any kind; see https://github.com/Azure/azure-documentdb-changefeedprocessor-dotnet/issues/142
         cp.IndexingPolicy.Automatic <- false
         cp.IndexingPolicy.IndexingMode <- IndexingMode.None
-    let initAux (client : CosmosClient) (dName, cName) rus = async {
-        // Hardwired for now to be Container level manual provisioning; need to be very far from normal usage to want to vary that
-        let mode = Provisioning.Container (Throughput.Manual rus)
+
+    let initAux (client : CosmosClient) (dName, cName) rus mode = async {
         let! d = createOrProvisionDatabase client dName mode
         return! createOrProvisionContainer d (cName, "/id", applyAuxContainerProperties) mode } // as per Cosmos team, Partition Key must be "/id"
 


### PR DESCRIPTION
Modifies initialization of aux collection to take an explicit input representing the cosmos provisioning mode. This change will be used in 'Propulsion.Tool' for supporting autoscale option and 'serverless' cosmos database.