### PR TITLE
DynamoStore: Cache decoding of Data/Meta

### DIFF
--- a/src/Equinox.CosmosStore/CosmosStoreSerialization.fs
+++ b/src/Equinox.CosmosStore/CosmosStoreSerialization.fs
@@ -7,14 +7,14 @@ module private Deflate =
 
     let compress (uncompressedBytes : byte array) =
         let output = new MemoryStream()
-        let compressor = new System.IO.Compression.DeflateStream(output, System.IO.Compression.CompressionLevel.Optimal)
+        let compressor = new System.IO.Compression.DeflateStream(output, System.IO.Compression.CompressionLevel.Optimal, leaveOpen = true)
         compressor.Write(uncompressedBytes)
         compressor.Flush() // Could `Close`, but not required
         output.ToArray()
 
     let inflate (compressedBytes : byte array) =
         let input = new MemoryStream(compressedBytes)
-        let decompressor = new System.IO.Compression.DeflateStream(input, System.IO.Compression.CompressionMode.Decompress)
+        let decompressor = new System.IO.Compression.DeflateStream(input, System.IO.Compression.CompressionMode.Decompress, leaveOpen = true)
         let output = new MemoryStream()
         decompressor.CopyTo(output)
         output.ToArray()

--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -105,7 +105,7 @@ type Tests(testOutputHelper) =
             do! addAndThenRemoveItemsManyTimesExceptTheLastOne cartContext cartId skuId service addRemoveCount
             test <@ i = i && List.replicate (expectedResponses (i-1)) EqxAct.ResponseBackward @ [EqxAct.QueryBackward; EqxAct.Append] = capture.ExternalCalls @>
 #if STORE_DYNAMO
-            if eventsInTip then verifyRequestChargesMax 182 // 181.5 [5.5; 176]
+            if eventsInTip then verifyRequestChargesMax 186 // 185.0 [9.0; 176.0]
 #else
             if eventsInTip then verifyRequestChargesMax 76 // 76.0 [3.72; 72.28]
 #endif


### PR DESCRIPTION
Adds logic to correctly handle cases where the reader traverses the `TimelineEvent.Data` more than once.

In the typical case, Equinox-controlled loads will only walk the events exactly once [until `isOrigin` stops the search]
However in more exotic cases such as in projection loops, there can be cases (and this issue surfaced as an exception in such logic) where layering is such that filtering layers perform some pre-traversals.

It has been argued by @yreynhout that compression doesn't belong in this layer; certainly its absence would have avoided this specific issue, and I can't say I like the impl having ugly excuses and guards as this PR introduces.

Removing it would at a minimum entail adding some form of content-encoding/content-type to the `ITimelineData` in order for an outer layer to be able to drive it. Am considering doing it, likely with a breaking format change prior to entering the `-rc` phase.
