### PR TITLE
V4 store alignment; DeciderCore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
+- `Equinox.DeciderCore`: C# friendly equivalent of `Decider` (i.e. `Func` and `Task`) [#338](https://github.com/jet/equinox/pull/338)
 - `Equinox`: `Decider.Transact`, `TransactAsync`, `TransactExAsync` overloads [#325](https://github.com/jet/equinox/pull/325)
 - `Equinox.ISyncContext.StreamEventBytes`: Exposes stored size of events in the stream (initial impl provides it for `DynamoStore` only) [#326](https://github.com/jet/equinox/pull/326)
 - `Equinox.Core`: `Category` base class, with `Decider` and `Stream` helper `module`s [#337](https://github.com/jet/equinox/pull/337)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `CosmosStore`: Switch to natively using `JsonElement` event bodies [#305](https://github.com/jet/equinox/pull/305) :pray: [@ylibrach](https://github.com/ylibrach)
 - `CosmosStore`: Switch to natively using `System.Text.Json` for serialization of all `Microsoft.Azure.Cosmos` round-trips [#305](https://github.com/jet/equinox/pull/305) :pray: [@ylibrach](https://github.com/ylibrach)
 - `CosmosStore`: Only log `bytes` when log level is `Debug` [#305](https://github.com/jet/equinox/pull/305)
+- `CosmosStore.AccessStrategy.MultiSnapshot`,`Custom`: Change `list` and `seq` types to `array` [#338](https://github.com/jet/equinox/pull/338)
 - `EventStore`: Target `EventStore.Client` v `22.0.0-preview`; rename `Connector` -> `EventStoreConnector` [#317](https://github.com/jet/equinox/pull/317)
 - `Equinox.Tool`/`samples/`: switched to use `Equinox.EventStoreDb` [#196](https://github.com/jet/equinox/pull/196)
 - Update all non-Client dependencies except `FSharp.Core`, `FSharp.Control.AsyncSeq` [#310](https://github.com/jet/equinox/pull/310)

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -372,7 +372,7 @@ type Service internal (resolve : Id -> Equinox.Decider<Events.Event, Fold.State)
         let decider = resolve id
         decider.Transact(decideX inputs)
 
-let create resolve = Service(streamName >> resolve)
+let create category = Service(streamName >> Equinox.Decider.resolve Serilog.Log.Logger category)
 ```
 
 - `Service`'s constructor is `internal`; `create` is the main way in which one
@@ -405,7 +405,7 @@ module EventStore =
             Equinox.EventStore.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
         let cat =
             Equinox.EventStore.EventStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
-        create cat.Resolve
+        create cat
 
 module Cosmos =
     let accessStrategy =
@@ -413,9 +413,9 @@ module Cosmos =
     let create (context, cache) =
         let cacheStrategy =
             Equinox.CosmosStore.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
-        let category =
+        let cat =
             Equinox.CosmosStore.CosmosStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
-        create category.Resolve
+        create cat
 ```
 
 ### `MemoryStore` Storage Binding Module
@@ -428,7 +428,7 @@ can use the `MemoryStore` in the context of your tests:
 module MemoryStore =
     let create (store : Equinox.MemoryStore.VolatileStore) =
         let cat = Equinox.MemoryStore.MemoryStoreCategory(store, Events.codec, Fold.fold, Fold.initial)
-        create cat.Resolve
+        create cat
 ```
 
 Typically that binding module can live with your test helpers rather than

--- a/samples/Infrastructure/Services.fs
+++ b/samples/Infrastructure/Services.fs
@@ -34,17 +34,23 @@ type ServiceBuilder(storageConfig, handlerLog) =
      member _.CreateFavoritesService() =
         let fold, initial = Favorites.Fold.fold, Favorites.Fold.initial
         let snapshot = Favorites.Fold.isOrigin, Favorites.Fold.snapshot
-        Favorites.create <| store.Category(Favorites.Events.codec, fold, initial, snapshot).Resolve handlerLog
+        store.Category(Favorites.Events.codec, fold, initial, snapshot)
+        |> Decider.resolve handlerLog
+        |> Favorites.create
 
      member _.CreateSaveForLaterService() =
         let fold, initial = SavedForLater.Fold.fold, SavedForLater.Fold.initial
         let snapshot = SavedForLater.Fold.isOrigin, SavedForLater.Fold.compact
-        SavedForLater.create 50 <| store.Category(SavedForLater.Events.codec, fold, initial, snapshot).Resolve handlerLog
+        store.Category(SavedForLater.Events.codec, fold, initial, snapshot)
+        |> Decider.resolve handlerLog
+        |> SavedForLater.create 50
 
      member _.CreateTodosService() =
         let fold, initial = TodoBackend.Fold.fold, TodoBackend.Fold.initial
         let snapshot = TodoBackend.Fold.isOrigin, TodoBackend.Fold.snapshot
-        TodoBackend.create <| store.Category(TodoBackend.Events.codec, fold, initial, snapshot).Resolve handlerLog
+        store.Category(TodoBackend.Events.codec, fold, initial, snapshot)
+        |> Decider.resolve handlerLog
+        |> TodoBackend.create
 
 let register (services : IServiceCollection, storageConfig, handlerLog) =
     let regF (factory : IServiceProvider -> 'T) = services.AddSingleton<'T>(fun (sp: IServiceProvider) -> factory sp) |> ignore

--- a/samples/Store/Domain/ContactPreferences.fs
+++ b/samples/Store/Domain/ContactPreferences.fs
@@ -27,7 +27,7 @@ module Fold =
     let isOrigin _ = true
     /// When using AccessStrategy.Custom, we use the (single) event become an unfold, but the logic remains identical
     let transmute events _state =
-        [],events
+        [||],events
 
 type Command =
     | Update of Events.Value

--- a/samples/Store/Integration/ContactPreferencesIntegration.fs
+++ b/samples/Store/Integration/ContactPreferencesIntegration.fs
@@ -9,7 +9,8 @@ let fold, initial = ContactPreferences.Fold.fold, ContactPreferences.Fold.initia
 
 let createMemoryStore () = MemoryStore.VolatileStore<_>()
 let createServiceMemory log store =
-    MemoryStore.MemoryStoreCategory(store, FsCodec.Box.Codec.Create(), fold, initial).Resolve log
+    MemoryStore.MemoryStoreCategory(store, FsCodec.Box.Codec.Create(), fold, initial)
+    |> Decider.resolve log
     |> ContactPreferences.create
 
 let codec = ContactPreferences.Events.codec

--- a/samples/Store/Integration/EventStoreIntegration.fs
+++ b/samples/Store/Integration/EventStoreIntegration.fs
@@ -10,4 +10,4 @@ let connectToLocalEventStoreNode (_log : Serilog.ILogger) =
     // Connect to the locally running EventStore Node using Gossip-driven discovery
     c.Establish("Equinox-sample", Discovery.ConnectionString "esdb://localhost:2111,localhost:2112,localhost:2113?tls=true&tlsVerifyCert=false", ConnectionStrategy.ClusterSingle EventStore.Client.NodePreference.Leader)
 let defaultBatchSize = 500
-let createContext connection batchSize = EventStoreContext(connection, BatchingPolicy(maxBatchSize = batchSize))
+let createContext connection batchSize = EventStoreContext(connection, batchSize = batchSize)

--- a/samples/Tutorial/AsAt.fsx
+++ b/samples/Tutorial/AsAt.fsx
@@ -154,7 +154,7 @@ module EventStore =
     let connector = EventStoreConnector(reqTimeout = TimeSpan.FromSeconds 5., reqRetries = 3)
     let esc = connector.Connect(AppName, Discovery.ConnectionString "esdb://localhost:2111,localhost:2112,localhost:2113?tls=true&tlsVerifyCert=false")
     let connection = EventStoreConnection(esc)
-    let context = EventStoreContext(connection, BatchingPolicy(maxBatchSize=snapshotWindow))
+    let context = EventStoreContext(connection, batchSize = snapshotWindow)
     // cache so normal read pattern is to read from whatever we've built in memory
     let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
     // rig snapshots to be injected as events into the stream every `snapshotWindow` events

--- a/samples/Tutorial/AsAt.fsx
+++ b/samples/Tutorial/AsAt.fsx
@@ -160,7 +160,7 @@ module EventStore =
     // rig snapshots to be injected as events into the stream every `snapshotWindow` events
     let accessStrategy = AccessStrategy.RollingSnapshots (Fold.isValid,Fold.snapshot)
     let cat = EventStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
-    let resolve = streamName >> Equinox.Decider.resolve log
+    let resolve = Equinox.Decider.resolve Log.log cat
 
 module Cosmos =
 
@@ -173,11 +173,11 @@ module Cosmos =
     let context = CosmosStoreContext(storeClient, tipMaxEvents = 10)
     let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
     let accessStrategy = AccessStrategy.Snapshot (Fold.isValid,Fold.snapshot)
-    let category = CosmosStoreCategory(context, Events.codecJe, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
-    let resolve id = Equinox.Decider(Log.log, category.Resolve(streamName id), maxAttempts = 3)
+    let cat = CosmosStoreCategory(context, Events.codecJe, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
+    let resolve = Equinox.Decider.resolve Log.log cat
 
-let service = Service(EventStore.resolve)
-//let service= Service(Cosmos.resolve)
+let service = Service(streamName >> EventStore.resolve)
+//let service= Service(streamName >> Cosmos.resolve)
 
 let client = "ClientA"
 service.Add(client, 1) |> Async.RunSynchronously

--- a/samples/Tutorial/Cosmos.fsx
+++ b/samples/Tutorial/Cosmos.fsx
@@ -91,8 +91,9 @@ module Favorites =
         let accessStrategy = AccessStrategy.Unoptimized // Or Snapshot etc https://github.com/jet/equinox/blob/master/DOCUMENTATION.md#access-strategies
         let create (context, cache) =
             let cacheStrategy = CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
-            let category = CosmosStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
-            create <| Equinox.Decider.resolve Log.log cat
+            CosmosStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
+            |> Equinox.Decider.resolve Log.log
+            |> create
 
 let [<Literal>] appName = "equinox-tutorial"
 

--- a/samples/Tutorial/FulfilmentCenter.fsx
+++ b/samples/Tutorial/FulfilmentCenter.fsx
@@ -142,9 +142,11 @@ module Store =
 
 open FulfilmentCenter
 
-let category = CosmosStoreCategory(Store.context, Events.codec, Fold.fold, Fold.initial, Store.cacheStrategy, AccessStrategy.Unoptimized)
-let resolve = Equinox.Decider.resolve Log.log category
-let service = Service(streamName >> resolve)
+let service =
+    let resolve =
+        CosmosStoreCategory(Store.context, Events.codec, Fold.fold, Fold.initial, Store.cacheStrategy, AccessStrategy.Unoptimized)
+        |> Equinox.Decider.resolve Log.log
+    Service(streamName >> resolve)
 
 let fc = "fc0"
 service.UpdateName(fc, { code="FC000"; name="Head" }) |> Async.RunSynchronously

--- a/samples/Tutorial/Gapless.fs
+++ b/samples/Tutorial/Gapless.fs
@@ -79,8 +79,8 @@ module Cosmos =
     open Equinox.CosmosStore
     let private create (context, cache, accessStrategy) =
         let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
-        let category = CosmosStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
-        Service(streamName >> Equinox.Decider.resolve Serilog.Log.Logger category)
+        let cat = CosmosStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
+        Service(streamName >> Equinox.Decider.resolve Serilog.Log.Logger cat)
 
     module Snapshot =
 

--- a/samples/Tutorial/Sequence.fs
+++ b/samples/Tutorial/Sequence.fs
@@ -43,8 +43,9 @@ module Cosmos =
     open Equinox.CosmosStore
     let private create (context, cache, accessStrategy) =
         let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
-        let category = CosmosStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
-        category |> Equinox.Decider.resolve (Serilog.Log.ForContext<Service>()) |> create
+        CosmosStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
+        |> Equinox.Decider.resolve (Serilog.Log.ForContext<Service>())
+        |> create
 
     module LatestKnownEvent =
 

--- a/samples/Tutorial/Todo.fsx
+++ b/samples/Tutorial/Todo.fsx
@@ -136,8 +136,8 @@ module Store =
 module TodosCategory =
 
     let access = AccessStrategy.Snapshot (isOrigin,snapshot)
-    let category = CosmosStoreCategory(Store.context, codec, fold, initial, Store.cacheStrategy, access=access)
-    let resolve = Equinox.Decider.resolve log category
+    let resolve = CosmosStoreCategory(Store.context, codec, fold, initial, Store.cacheStrategy, access=access)
+                  |> Equinox.Decider.resolve log
 
 let service = Service(streamName >> TodosCategory.resolve)
 

--- a/src/Equinox.Core/Category.fs
+++ b/src/Equinox.Core/Category.fs
@@ -53,6 +53,12 @@ module Stream =
 
 module Decider =
 
+    let resolveCoreWithContext context log (cat : Category<'event, 'state, 'context>) : struct (string * string) -> DeciderCore<'event, 'state> =
+         Stream.resolveWithContext context log cat >> DeciderCore
+
+    let resolveCore log (cat : Category<'event, 'state, unit>) =
+         resolveCoreWithContext () log cat
+
     let resolveWithContext context log (cat : Category<'event, 'state, 'context>) : struct (string * string) -> Decider<'event, 'state> =
          Stream.resolveWithContext context log cat >> Decider
 
@@ -63,9 +69,9 @@ module Decider =
 type DeciderExtensions =
 
     [<System.Runtime.CompilerServices.Extension>]
-    static member Resolve(cat : Category<'event, 'state, 'context>, context : 'context, log) : struct (string * string) -> Decider<'event, 'state> =
-         Decider.resolveWithContext context log cat
+    static member Resolve(cat : Category<'event, 'state, 'context>, context : 'context, log) : System.Func<struct (string * string), DeciderCore<'event, 'state>> =
+         Decider.resolveCoreWithContext context log cat
 
     [<System.Runtime.CompilerServices.Extension>]
-    static member Resolve(cat : Category<'event, 'state, unit>, log) : struct (string * string) -> Decider<'event, 'state> =
-         Decider.resolveWithContext () log cat
+    static member Resolve(cat : Category<'event, 'state, unit>, log) : System.Func<struct (string * string), DeciderCore<'event, 'state>> =
+         Decider.resolveCoreWithContext () log cat

--- a/src/Equinox.Core/Category.fs
+++ b/src/Equinox.Core/Category.fs
@@ -15,7 +15,7 @@ type ICategory<'event, 'state, 'context> =
     /// NB the central precondition upon which the sync is predicated is that the stream has not diverged from the `originState` represented by `token`
     ///    where the precondition is not met, the SyncResult.Conflict bears a [lazy] async result (in a specific manner optimal for the store)
     abstract TrySync : log: ILogger * categoryName: string * streamId: string * streamName: string * 'context * maybeInit: (CancellationToken -> Task<unit>) voption
-                       * StreamToken * 'state * events: 'event list * CancellationToken -> Task<SyncResult<'state>>
+                       * StreamToken * 'state * events: 'event array * CancellationToken -> Task<SyncResult<'state>>
 
 // Low level stream impl, used by Store-specific Category types that layer policies such as Caching in
 namespace Equinox

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -355,50 +355,55 @@ type EventStoreConnection(readConnection, [<O; D(null)>] ?writeConnection, [<O; 
     member _.WriteConnection = defaultArg writeConnection readConnection
     member _.WriteRetryPolicy = writeRetryPolicy
 
-type BatchingPolicy(getMaxBatchSize : unit -> int, [<O; D(null)>] ?batchCountLimit) =
-    new (maxBatchSize) = BatchingPolicy(fun () -> maxBatchSize)
-    member _.BatchSize = getMaxBatchSize()
+type BatchOptions(getBatchSize : Func<int>, [<O; D(null)>]?batchCountLimit) =
+    new (batchSize) = BatchOptions(fun () -> batchSize)
+    member _.BatchSize = getBatchSize.Invoke()
     member _.MaxBatches = batchCountLimit
 
 [<RequireQualifiedAccess; NoComparison; NoEquality>]
 type GatewaySyncResult = Written of StreamToken | ConflictUnknown of StreamToken
 
-type EventStoreContext(conn : EventStoreConnection, batching : BatchingPolicy) =
+type EventStoreContext(connection : EventStoreConnection, batchOptions : BatchOptions) =
     let isResolvedEventEventType (tryDecode, predicate) (x : ResolvedEvent) = predicate (tryDecode x.Event.Data)
     let tryIsResolvedEventEventType predicateOption = predicateOption |> Option.map isResolvedEventEventType
+    new (   connection : EventStoreConnection,
+            // Max number of Events to retrieve in a single batch. Also affects frequency of RollingSnapshots. Default: 500.
+            [<O; D null>] ?batchSize) =
+        EventStoreContext(connection, BatchOptions(batchSize = defaultArg batchSize 500))
+    member val BatchOptions = batchOptions
 
-    member _.TokenEmpty = Token.ofUncompactedVersion batching.BatchSize -1L
+    member _.TokenEmpty = Token.ofUncompactedVersion batchOptions.BatchSize -1L
     member _.LoadBatched streamName log (tryDecode, isCompactionEventType) : Async<StreamToken * 'event[]> = async {
-        let! version, events = Read.loadForwardsFrom log conn.ReadRetryPolicy conn.ReadConnection batching.BatchSize batching.MaxBatches streamName 0L
+        let! version, events = Read.loadForwardsFrom log connection.ReadRetryPolicy connection.ReadConnection batchOptions.BatchSize batchOptions.MaxBatches streamName 0L
         match tryIsResolvedEventEventType isCompactionEventType with
         | None -> return Token.ofNonCompacting version, Array.chooseV tryDecode events
         | Some isCompactionEvent ->
             match events |> Array.tryFindBack isCompactionEvent with
-            | None -> return Token.ofUncompactedVersion batching.BatchSize version, Array.chooseV tryDecode events
-            | Some resolvedEvent -> return Token.ofCompactionResolvedEventAndVersion resolvedEvent batching.BatchSize version, Array.chooseV tryDecode events }
+            | None -> return Token.ofUncompactedVersion batchOptions.BatchSize version, Array.chooseV tryDecode events
+            | Some resolvedEvent -> return Token.ofCompactionResolvedEventAndVersion resolvedEvent batchOptions.BatchSize version, Array.chooseV tryDecode events }
 
     member _.LoadBackwardsStoppingAtCompactionEvent streamName log (tryDecode, isOrigin) : Async<StreamToken * 'event []> = async {
         let! version, events =
-            Read.loadBackwardsUntilCompactionOrStart log conn.ReadRetryPolicy conn.ReadConnection batching.BatchSize batching.MaxBatches streamName (tryDecode, isOrigin)
+            Read.loadBackwardsUntilCompactionOrStart log connection.ReadRetryPolicy connection.ReadConnection batchOptions.BatchSize batchOptions.MaxBatches streamName (tryDecode, isOrigin)
         match Array.tryHead events |> Option.filter (function _, ValueSome e -> isOrigin e | _ -> false) with
-        | None -> return Token.ofUncompactedVersion batching.BatchSize version, Array.chooseV ValueTuple.snd events
-        | Some (resolvedEvent, _) -> return Token.ofCompactionResolvedEventAndVersion resolvedEvent batching.BatchSize version, Array.chooseV ValueTuple.snd events }
+        | None -> return Token.ofUncompactedVersion batchOptions.BatchSize version, Array.chooseV ValueTuple.snd events
+        | Some (resolvedEvent, _) -> return Token.ofCompactionResolvedEventAndVersion resolvedEvent batchOptions.BatchSize version, Array.chooseV ValueTuple.snd events }
 
     member _.LoadFromToken useWriteConn streamName log (Token.Unpack token as streamToken) (tryDecode, isCompactionEventType)
         : Async<StreamToken * 'event[]> = async {
         let streamPosition = token.streamVersion + 1L
-        let connToUse = if useWriteConn then conn.WriteConnection else conn.ReadConnection
-        let! version, events = Read.loadForwardsFrom log conn.ReadRetryPolicy connToUse batching.BatchSize batching.MaxBatches streamName streamPosition
+        let connToUse = if useWriteConn then connection.WriteConnection else connection.ReadConnection
+        let! version, events = Read.loadForwardsFrom log connection.ReadRetryPolicy connToUse batchOptions.BatchSize batchOptions.MaxBatches streamName streamPosition
         match isCompactionEventType with
         | None -> return Token.ofNonCompacting version, Array.chooseV tryDecode events
         | Some isCompactionEvent ->
             match events |> Array.tryFindBack (fun re -> match tryDecode re with ValueSome e -> isCompactionEvent e | _ -> false) with
-            | None -> return Token.ofPreviousTokenAndEventsLength streamToken events.Length batching.BatchSize version, Array.chooseV tryDecode events
-            | Some resolvedEvent -> return Token.ofCompactionResolvedEventAndVersion resolvedEvent batching.BatchSize version, Array.chooseV tryDecode events }
+            | None -> return Token.ofPreviousTokenAndEventsLength streamToken events.Length batchOptions.BatchSize version, Array.chooseV tryDecode events
+            | Some resolvedEvent -> return Token.ofCompactionResolvedEventAndVersion resolvedEvent batchOptions.BatchSize version, Array.chooseV tryDecode events }
 
     member _.TrySync log streamName (Token.Unpack token as streamToken) (events, encodedEvents : EventData array) isCompactionEventType : Async<GatewaySyncResult> = async {
         let streamVersion = token.streamVersion
-        match! Write.writeEvents log conn.WriteRetryPolicy conn.WriteConnection streamName streamVersion encodedEvents with
+        match! Write.writeEvents log connection.WriteRetryPolicy connection.WriteConnection streamName streamVersion encodedEvents with
         | EsSyncResult.Conflict actualVersion ->
             return GatewaySyncResult.ConflictUnknown (Token.ofNonCompacting actualVersion)
         | EsSyncResult.Written wr ->
@@ -408,14 +413,14 @@ type EventStoreContext(conn : EventStoreConnection, batching : BatchingPolicy) =
                 | None -> Token.ofNonCompacting version'
                 | Some isCompactionEvent ->
                     match events |> Array.tryFindIndexBack isCompactionEvent with
-                    | None -> Token.ofPreviousTokenAndEventsLength streamToken encodedEvents.Length batching.BatchSize version'
+                    | None -> Token.ofPreviousTokenAndEventsLength streamToken encodedEvents.Length batchOptions.BatchSize version'
                     | Some compactionEventIndex ->
-                        Token.ofPreviousStreamVersionAndCompactionEventDataIndex streamToken compactionEventIndex encodedEvents.Length batching.BatchSize version'
+                        Token.ofPreviousStreamVersionAndCompactionEventDataIndex streamToken compactionEventIndex encodedEvents.Length batchOptions.BatchSize version'
             return GatewaySyncResult.Written token }
 
     member _.Sync(log, streamName, streamVersion, events : FsCodec.IEventData<EventBody>[]) : Async<GatewaySyncResult> = async {
         let encodedEvents : EventData[] = events |> Array.map UnionEncoderAdapters.eventDataOfEncodedEvent
-        match! Write.writeEvents log conn.WriteRetryPolicy conn.WriteConnection streamName streamVersion encodedEvents with
+        match! Write.writeEvents log connection.WriteRetryPolicy connection.WriteConnection streamName streamVersion encodedEvents with
         | EsSyncResult.Conflict actualVersion ->
             return GatewaySyncResult.ConflictUnknown (Token.ofNonCompacting actualVersion)
         | EsSyncResult.Written wr ->

--- a/src/Equinox.EventStoreDb/EventStoreDb.fs
+++ b/src/Equinox.EventStoreDb/EventStoreDb.fs
@@ -565,8 +565,8 @@ type ConnectionStrategy =
 
 type EventStoreConnector
     (   reqTimeout : TimeSpan, reqRetries : int,
-        ?readRetryPolicy, ?writeRetryPolicy, ?tags,
-        ?customize : EventStoreClientSettings -> unit) =
+        [<O; D null>] ?readRetryPolicy, [<O; D null>] ?writeRetryPolicy, [<O; D null>] ?tags,
+        [<O; D null>] ?customize : EventStoreClientSettings -> unit) =
 (* TODO port
     let connSettings node =
       ConnectionSettings.Create().SetDefaultUserCredentials(SystemData.UserCredentials(username, password))

--- a/src/Equinox.EventStoreDb/EventStoreDb.fs
+++ b/src/Equinox.EventStoreDb/EventStoreDb.fs
@@ -341,7 +341,7 @@ type EventStoreContext(conn : EventStoreConnection, batching : BatchingPolicy) =
                 match isCompactionEventType with
                 | None -> Token.ofNonCompacting version'
                 | Some isCompactionEvent ->
-                    match events |> Array.ofList |> Array.tryFindIndexBack isCompactionEvent with
+                    match events |> Array.tryFindIndexBack isCompactionEvent with
                     | None -> Token.ofPreviousTokenAndEventsLength streamToken encodedEvents.Length batching.BatchSize version'
                     | Some compactionEventIndex ->
                         Token.ofPreviousStreamVersionAndCompactionEventDataIndex streamToken compactionEventIndex encodedEvents.Length batching.BatchSize version'
@@ -408,21 +408,21 @@ type private Category<'event, 'state, 'context>(context : EventStoreContext, cod
 
     member _.TrySync<'context>
         (   log : ILogger, fold : 'state -> 'event seq -> 'state,
-            streamName, (Token.Unpack token as streamToken), state : 'state, events : 'event list, ctx : 'context) : Async<SyncResult<'state>> = async {
+            streamName, (Token.Unpack token as streamToken), state : 'state, events : 'event array, ctx : 'context) : Async<SyncResult<'state>> = async {
         let encode e = codec.Encode(ctx, e)
         let events =
             match access with
             | None | Some AccessStrategy.LatestKnownEvent -> events
             | Some (AccessStrategy.RollingSnapshots (_, compact)) ->
-                let cc = CompactionContext(List.length events, token.batchCapacityLimit.Value)
-                if cc.IsCompactionDue then events @ [fold state events |> compact] else events
+                let cc = CompactionContext(Array.length events, token.batchCapacityLimit.Value)
+                if cc.IsCompactionDue then Array.append events (fold state events |> compact |> Array.singleton) else events
 
-        let encodedEvents : EventData[] = events |> Seq.map (encode >> UnionEncoderAdapters.eventDataOfEncodedEvent) |> Array.ofSeq
+        let encodedEvents : EventData[] = events |> Array.map (encode >> UnionEncoderAdapters.eventDataOfEncodedEvent)
         match! context.TrySync(log, streamName, streamToken, events, encodedEvents, compactionPredicate) with
         | GatewaySyncResult.ConflictUnknown _ ->
             return SyncResult.Conflict  (fun ct -> load fold state (context.LoadFromToken(true, streamName, log, streamToken, tryDecode, compactionPredicate)) |> Async.startAsTask ct)
         | GatewaySyncResult.Written token' ->
-            return SyncResult.Written   (token', fold state (Seq.ofList events)) }
+            return SyncResult.Written   (token', fold state (Seq.ofArray events)) }
 
 type private Folder<'event, 'state, 'context>(category : Category<'event, 'state, 'context>, fold : 'state -> 'event seq -> 'state, initial : 'state, ?readCache) =
     let batched log streamName = category.Load(fold, initial, streamName, log)

--- a/src/Equinox.EventStoreDb/EventStoreDb.fs
+++ b/src/Equinox.EventStoreDb/EventStoreDb.fs
@@ -221,15 +221,17 @@ module private Read =
         log |> logBatchRead direction streamName t events None version
         return version, events }
 
-module UnionEncoderAdapters =
-    let encodedEventOfResolvedEvent (x : ResolvedEvent) : FsCodec.ITimelineEvent<EventBody> =
-        let e = x.Event
+module ClientCodec =
+
+    let timelineEvent (x : EventRecord) : FsCodec.ITimelineEvent<EventBody> =
         // TOCONSIDER wire e.Metadata["$correlationId"] and ["$causationId"] into correlationId and causationId
         // https://eventstore.org/docs/server/metadata-and-reserved-names/index.html#event-metadata
-        let n, eu, ts = e.EventNumber, e.EventId, DateTimeOffset e.Created
-        FsCodec.Core.TimelineEvent.Create(n.ToInt64(), e.EventType, e.Data, e.Metadata, eu.ToGuid(), correlationId = null, causationId = null, timestamp = ts)
+        let n, eu, ts = x.EventNumber, x.EventId, DateTimeOffset x.Created
+        FsCodec.Core.TimelineEvent.Create(n.ToInt64(), x.EventType, x.Data, x.Metadata, eu.ToGuid(), correlationId = null, causationId = null, timestamp = ts)
+    let isSystemEvent (x : EventRecord) = x.EventStreamId.StartsWith '$'
+    let isJson (x : EventRecord) = x.ContentType = "application/json"
 
-    let eventDataOfEncodedEvent (x : FsCodec.IEventData<EventBody>) =
+    let eventData (x : FsCodec.IEventData<EventBody>) =
         // TOCONSIDER wire x.CorrelationId, x.CausationId into x.Meta.["$correlationId"] and .["$causationId"]
         // https://eventstore.org/docs/server/metadata-and-reserved-names/index.html#event-metadata
         EventData(Uuid.FromGuid x.EventId, x.EventType, contentType = "application/json", data = x.Data, metadata = x.Meta)
@@ -289,49 +291,53 @@ type EventStoreConnection(readConnection, [<O; D(null)>] ?writeConnection, [<O; 
     member _.WriteConnection = defaultArg writeConnection readConnection
     member _.WriteRetryPolicy = writeRetryPolicy
 
-type BatchingPolicy(getMaxBatchSize : unit -> int) =
-    new (maxBatchSize) = BatchingPolicy(fun () -> maxBatchSize)
-    // TOCONSIDER remove if Client does not start to expose it
-    member _.BatchSize = getMaxBatchSize()
+type BatchOptions(getBatchSize : Func<int>) =
+    new (batchSize) = BatchOptions(fun () -> batchSize)
+    member _.BatchSize = getBatchSize.Invoke()
 
 [<RequireQualifiedAccess; NoComparison; NoEquality>]
 type GatewaySyncResult = Written of StreamToken | ConflictUnknown of StreamToken
 
-type EventStoreContext(conn : EventStoreConnection, batching : BatchingPolicy) =
+type EventStoreContext(connection : EventStoreConnection, batchOptions : BatchOptions) =
     let isResolvedEventEventType (tryDecode, predicate) (x : ResolvedEvent) = predicate (tryDecode x.Event.Data)
     let tryIsResolvedEventEventType predicateOption = predicateOption |> Option.map isResolvedEventEventType
+    new (   connection : EventStoreConnection,
+            // Max number of Events to retrieve in a single batch. Also affects frequency of RollingSnapshots. Default: 500.
+            [<O; D null>] ?batchSize) =
+        EventStoreContext(connection, BatchOptions(batchSize = defaultArg batchSize 500))
+    member val BatchOptions = batchOptions
 
-    member _.TokenEmpty = Token.ofUncompactedVersion batching.BatchSize -1L
-    member _.LoadBatched(streamName, log, tryDecode, isCompactionEventType) : Async<struct (StreamToken * 'event[])> = async {
-        let! version, events = Read.loadForwards log conn.ReadConnection streamName StreamPosition.Start
+    member internal _.TokenEmpty = Token.ofUncompactedVersion batchOptions.BatchSize -1L
+    member internal _.LoadBatched(streamName, log, tryDecode, isCompactionEventType) : Async<struct (StreamToken * 'event[])> = async {
+        let! version, events = Read.loadForwards log connection.ReadConnection streamName StreamPosition.Start
         match tryIsResolvedEventEventType isCompactionEventType with
         | None -> return Token.ofNonCompacting version, Array.chooseV tryDecode events
         | Some isCompactionEvent ->
             match events |> Array.tryFindBack isCompactionEvent with
-            | None -> return Token.ofUncompactedVersion batching.BatchSize version, Array.chooseV tryDecode events
-            | Some resolvedEvent -> return Token.ofCompactionResolvedEventAndVersion resolvedEvent batching.BatchSize version, Array.chooseV tryDecode events }
+            | None -> return Token.ofUncompactedVersion batchOptions.BatchSize version, Array.chooseV tryDecode events
+            | Some resolvedEvent -> return Token.ofCompactionResolvedEventAndVersion resolvedEvent batchOptions.BatchSize version, Array.chooseV tryDecode events }
 
-    member _.LoadBackwardsStoppingAtCompactionEvent(streamName, log, limit, (tryDecode, isOrigin)) : Async<struct (StreamToken * 'event [])> = async {
-        let! version, events = Read.loadBackwards log conn.ReadConnection (defaultArg limit Int32.MaxValue) streamName (tryDecode, isOrigin)
+    member internal _.LoadBackwardsStoppingAtCompactionEvent(streamName, log, limit, (tryDecode, isOrigin)) : Async<struct (StreamToken * 'event [])> = async {
+        let! version, events = Read.loadBackwards log connection.ReadConnection (defaultArg limit Int32.MaxValue) streamName (tryDecode, isOrigin)
         match Array.tryHead events |> Option.filter (function _, ValueSome e -> isOrigin e | _ -> false) with
-        | None -> return Token.ofUncompactedVersion batching.BatchSize version, Array.chooseV ValueTuple.snd events
-        | Some (resolvedEvent, _) -> return Token.ofCompactionResolvedEventAndVersion resolvedEvent batching.BatchSize version, Array.chooseV ValueTuple.snd events }
+        | None -> return Token.ofUncompactedVersion batchOptions.BatchSize version, Array.chooseV ValueTuple.snd events
+        | Some (resolvedEvent, _) -> return Token.ofCompactionResolvedEventAndVersion resolvedEvent batchOptions.BatchSize version, Array.chooseV ValueTuple.snd events }
 
-    member _.LoadFromToken(useWriteConn, streamName, log, (Token.Unpack token as streamToken), tryDecode, isCompactionEventType)
+    member internal _.LoadFromToken(useWriteConn, streamName, log, (Token.Unpack token as streamToken), tryDecode, isCompactionEventType)
         : Async<struct (StreamToken * 'event[])> = async {
         let streamPosition = StreamPosition.FromInt64(token.streamVersion + 1L)
-        let connToUse = if useWriteConn then conn.WriteConnection else conn.ReadConnection
+        let connToUse = if useWriteConn then connection.WriteConnection else connection.ReadConnection
         let! version, events = Read.loadForwards log connToUse streamName streamPosition
         match isCompactionEventType with
         | None -> return Token.ofNonCompacting version, Array.chooseV tryDecode events
         | Some isCompactionEvent ->
             match events |> Array.tryFindBack (fun re -> match tryDecode re with ValueSome e -> isCompactionEvent e | _ -> false) with
-            | None -> return Token.ofPreviousTokenAndEventsLength streamToken events.Length batching.BatchSize version, Array.chooseV tryDecode events
-            | Some resolvedEvent -> return Token.ofCompactionResolvedEventAndVersion resolvedEvent batching.BatchSize version, Array.chooseV tryDecode events }
+            | None -> return Token.ofPreviousTokenAndEventsLength streamToken events.Length batchOptions.BatchSize version, Array.chooseV tryDecode events
+            | Some resolvedEvent -> return Token.ofCompactionResolvedEventAndVersion resolvedEvent batchOptions.BatchSize version, Array.chooseV tryDecode events }
 
-    member _.TrySync(log, streamName, (Token.Unpack token as streamToken), events, encodedEvents : EventData array, isCompactionEventType): Async<GatewaySyncResult> = async {
+    member internal _.TrySync(log, streamName, (Token.Unpack token as streamToken), events, encodedEvents : EventData array, isCompactionEventType): Async<GatewaySyncResult> = async {
         let streamVersion = token.streamVersion
-        let! wr = Write.writeEvents log conn.WriteRetryPolicy conn.WriteConnection streamName streamVersion encodedEvents
+        let! wr = Write.writeEvents log connection.WriteRetryPolicy connection.WriteConnection streamName streamVersion encodedEvents
         match wr with
         | EsSyncResult.Conflict actualVersion ->
             return GatewaySyncResult.ConflictUnknown (Token.ofNonCompacting actualVersion)
@@ -342,14 +348,14 @@ type EventStoreContext(conn : EventStoreConnection, batching : BatchingPolicy) =
                 | None -> Token.ofNonCompacting version'
                 | Some isCompactionEvent ->
                     match events |> Array.tryFindIndexBack isCompactionEvent with
-                    | None -> Token.ofPreviousTokenAndEventsLength streamToken encodedEvents.Length batching.BatchSize version'
+                    | None -> Token.ofPreviousTokenAndEventsLength streamToken encodedEvents.Length batchOptions.BatchSize version'
                     | Some compactionEventIndex ->
-                        Token.ofPreviousStreamVersionAndCompactionEventDataIndex streamToken compactionEventIndex encodedEvents.Length batching.BatchSize version'
+                        Token.ofPreviousStreamVersionAndCompactionEventDataIndex streamToken compactionEventIndex encodedEvents.Length batchOptions.BatchSize version'
             return GatewaySyncResult.Written token }
 
     member _.Sync(log, streamName, streamVersion, events : FsCodec.IEventData<EventBody>[]) : Async<GatewaySyncResult> = async {
-        let encodedEvents : EventData[] = events |> Array.map UnionEncoderAdapters.eventDataOfEncodedEvent
-        let! wr = Write.writeEvents log conn.WriteRetryPolicy conn.WriteConnection streamName streamVersion encodedEvents
+        let encodedEvents : EventData[] = events |> Array.map ClientCodec.eventData
+        let! wr = Write.writeEvents log connection.WriteRetryPolicy connection.WriteConnection streamName streamVersion encodedEvents
         match wr with
         | EsSyncResult.Conflict actualVersion ->
             return GatewaySyncResult.ConflictUnknown (Token.ofNonCompacting actualVersion)
@@ -375,7 +381,7 @@ type private CompactionContext(eventsLen : int, capacityBeforeCompaction : int) 
     member _.IsCompactionDue = eventsLen > capacityBeforeCompaction
 
 type private Category<'event, 'state, 'context>(context : EventStoreContext, codec : FsCodec.IEventCodec<_, _, 'context>, ?access : AccessStrategy<'event, 'state>) =
-    let tryDecode (e : ResolvedEvent) = e |> UnionEncoderAdapters.encodedEventOfResolvedEvent |> codec.TryDecode
+    let tryDecode (e : ResolvedEvent) = e.Event |> ClientCodec.timelineEvent |> codec.TryDecode
 
     let compactionPredicate =
         match access with
@@ -417,7 +423,7 @@ type private Category<'event, 'state, 'context>(context : EventStoreContext, cod
                 let cc = CompactionContext(Array.length events, token.batchCapacityLimit.Value)
                 if cc.IsCompactionDue then Array.append events (fold state events |> compact |> Array.singleton) else events
 
-        let encodedEvents : EventData[] = events |> Array.map (encode >> UnionEncoderAdapters.eventDataOfEncodedEvent)
+        let encodedEvents : EventData[] = events |> Array.map (encode >> ClientCodec.eventData)
         match! context.TrySync(log, streamName, streamToken, events, encodedEvents, compactionPredicate) with
         | GatewaySyncResult.ConflictUnknown _ ->
             return SyncResult.Conflict  (fun ct -> load fold state (context.LoadFromToken(true, streamName, log, streamToken, tryDecode, compactionPredicate)) |> Async.startAsTask ct)
@@ -493,67 +499,10 @@ type EventStoreCategory<'event, 'state, 'context>(resolveInner, empty) =
         let empty = struct (context.TokenEmpty, initial)
         EventStoreCategory(resolveInner, empty)
 
-(* TODO
-type private SerilogAdapter(log : ILogger) =
-    interface EventStore.ClientAPI.ILogger with
-        member _.Debug(format : string, args : obj []) =           log.Debug(format, args)
-        member _.Debug(ex : exn, format : string, args : obj []) = log.Debug(ex, format, args)
-        member _.Info(format : string, args : obj []) =            log.Information(format, args)
-        member _.Info(ex : exn, format : string, args : obj []) =  log.Information(ex, format, args)
-        member _.Error(format : string, args : obj []) =           log.Error(format, args)
-        member _.Error(ex : exn, format : string, args : obj []) = log.Error(ex, format, args)
-
-[<RequireQualifiedAccess; NoComparison; NoEquality>]
-type Logger =
-    | SerilogVerbose of ILogger
-    | SerilogNormal of ILogger
-    | CustomVerbose of EventStore.ClientAPI.ILogger
-    | CustomNormal of EventStore.ClientAPI.ILogger
-    member log.Configure(b : ConnectionSettingsBuilder) =
-        match log with
-        | SerilogVerbose logger -> b.EnableVerboseLogging().UseCustomLogger(SerilogAdapter(logger))
-        | SerilogNormal logger -> b.UseCustomLogger(SerilogAdapter(logger))
-        | CustomVerbose logger -> b.EnableVerboseLogging().UseCustomLogger(logger)
-        | CustomNormal logger -> b.UseCustomLogger(logger)
-*)
-
 [<RequireQualifiedAccess; NoComparison>]
 type Discovery =
     // Allow Uri-based connection definition (esdb://, etc)
     | ConnectionString of string
-(* TODO
-    /// Supply a set of pre-resolved EndPoints instead of letting Gossip resolution derive from the DNS outcome
-    | GossipSeeded of seedManagerEndpoints : System.Net.IPEndPoint []
-    // Standard Gossip-based discovery based on Dns query and standard manager port
-    | GossipDns of clusterDns : string
-    // Standard Gossip-based discovery based on Dns query (with manager port overriding default 2113)
-    | GossipDnsCustomPort of clusterDns : string * managerPortOverride : int
-
-module private Discovery =
-    let buildDns np (f : DnsClusterSettingsBuilder -> DnsClusterSettingsBuilder) =
-        ClusterSettings.Create().DiscoverClusterViaDns().KeepDiscovering()
-        |> fun s -> match np with NodePreference.Random -> s.PreferRandomNode() | NodePreference.PreferSlave -> s.PreferSlaveNode() | _ -> s
-        |> f |> fun s -> s.Build()
-
-    let buildSeeded np (f : GossipSeedClusterSettingsBuilder -> GossipSeedClusterSettingsBuilder) =
-        ClusterSettings.Create().DiscoverClusterViaGossipSeeds().KeepDiscovering()
-        |> fun s -> match np with NodePreference.Random -> s.PreferRandomNode() | NodePreference.PreferSlave -> s.PreferSlaveNode() | _ -> s
-        |> f |> fun s -> s.Build()
-
-    let configureDns clusterDns maybeManagerPort (x : DnsClusterSettingsBuilder) =
-        x.SetClusterDns(clusterDns)
-        |> fun s -> match maybeManagerPort with Some port -> s.SetClusterGossipPort(port) | None -> s
-
-    let inline configureSeeded (seedEndpoints : System.Net.IPEndPoint []) (x : GossipSeedClusterSettingsBuilder) =
-        x.SetGossipSeedEndPoints(seedEndpoints)
-
-    // converts a Discovery mode to a ClusterSettings or a Uri as appropriate
-    let (|DiscoverViaUri|DiscoverViaGossip|) : Discovery * NodePreference -> Choice<Uri,ClusterSettings> = function
-        | (Discovery.Uri uri), _ ->                         DiscoverViaUri    uri
-        | (Discovery.GossipSeeded seedEndpoints), np ->     DiscoverViaGossip (buildSeeded np   (configureSeeded seedEndpoints))
-        | (Discovery.GossipDns clusterDns), np ->           DiscoverViaGossip (buildDns np      (configureDns clusterDns None))
-        | (Discovery.GossipDnsCustomPort (dns, port)), np ->DiscoverViaGossip (buildDns np      (configureDns dns (Some port)))
-*)
 
 // see https://github.com/EventStore/EventStore/issues/1652
 [<RequireQualifiedAccess; NoComparison>]
@@ -567,40 +516,13 @@ type EventStoreConnector
     (   reqTimeout : TimeSpan, reqRetries : int,
         [<O; D null>] ?readRetryPolicy, [<O; D null>] ?writeRetryPolicy, [<O; D null>] ?tags,
         [<O; D null>] ?customize : EventStoreClientSettings -> unit) =
-(* TODO port
-    let connSettings node =
-      ConnectionSettings.Create().SetDefaultUserCredentials(SystemData.UserCredentials(username, password))
-        .KeepReconnecting() // ES default: .LimitReconnectionsTo(10)
-        .SetQueueTimeoutTo(reqTimeout) // ES default: Zero/unlimited
-        .FailOnNoServerResponse() // ES default: DoNotFailOnNoServerResponse() => wait forever; retry and/or log
-        .SetOperationTimeoutTo(reqTimeout) // ES default: 7s
-        .LimitRetriesForOperationTo(reqRetries) // ES default: 10
-        |> fun s ->
-            match node with
-            | NodePreference.Master         -> s.PerformOnMasterOnly()                  // explicitly use ES default of requiring master, use default Node preference of Master
-            | NodePreference.PreferMaster   -> s.PerformOnAnyNode()                     // override default [implied] PerformOnMasterOnly(), use default Node preference of Master
-            // NB .PreferSlaveNode/.PreferRandomNode setting is ignored if using EventStoreConneciton.Create(ConnectionSettings, ClusterSettings) overload but
-            // this code is necessary for cases where people are using the discover :// and related URI schemes
-            | NodePreference.PreferSlave    -> s.PerformOnAnyNode().PreferSlaveNode()   // override default PerformOnMasterOnly(), override Master Node preference
-            | NodePreference.Random         -> s.PerformOnAnyNode().PreferRandomNode()  // override default PerformOnMasterOnly(), override Master Node preference
-        |> fun s -> match concurrentOperationsLimit with Some col -> s.LimitConcurrentOperationsTo(col) | None -> s // ES default: 5000
-        |> fun s -> match heartbeatTimeout with Some v -> s.SetHeartbeatTimeout v | None -> s // default: 1500 ms
-        |> fun s -> match gossipTimeout with Some v -> s.SetGossipTimeout v | None -> s // default: 1000 ms
-        |> fun s -> match clientConnectionTimeout with Some v -> s.WithConnectionTimeoutOf v | None -> s // default: 1000 ms
-        |> fun s -> match log with Some log -> log.Configure s | None -> s
-        |> fun s -> s.Build()
-*)
+
     member _.Connect
         (   // Name should be sufficient to uniquely identify this connection within a single app instance's logs
             name, discovery : Discovery, ?clusterNodePreference) : EventStoreClient =
         let settings =
             match discovery with
             | Discovery.ConnectionString s -> EventStoreClientSettings.Create(s)
-(* TODO
-            | Discovery.DiscoverViaGossip clusterSettings ->
-                // NB This overload's implementation ignores the calls to ConnectionSettingsBuilder.PreferSlaveNode/.PreferRandomNode and
-                // requires equivalent ones on the GossipSeedClusterSettingsBuilder or ClusterSettingsBuilder
-                EventStoreConnection.Create(connSettings clusterNodePreference, clusterSettings, sanitizedName) *)
         if name = null then nullArg "name"
         let name = String.concat ";" <| seq {
             name

--- a/src/Equinox.SqlStreamStore/SqlStreamStore.fs
+++ b/src/Equinox.SqlStreamStore/SqlStreamStore.fs
@@ -384,7 +384,7 @@ type SqlStreamStoreContext(connection : SqlStreamStoreConnection, batching : Bat
                 match isCompactionEventType with
                 | None -> Token.ofNonCompacting version'
                 | Some isCompactionEvent ->
-                    match events |> Array.ofList |> Array.tryFindIndexBack isCompactionEvent with
+                    match events |> Array.tryFindIndexBack isCompactionEvent with
                     | None -> Token.ofPreviousTokenAndEventsLength streamToken encodedEvents.Length batching.BatchSize version'
                     | Some compactionEventIndex ->
                         Token.ofPreviousStreamVersionAndCompactionEventDataIndex streamToken compactionEventIndex encodedEvents.Length batching.BatchSize version'
@@ -442,20 +442,20 @@ type private Category<'event, 'state, 'context>(context : SqlStreamStoreContext,
         (load fold) state (context.LoadFromToken false streamName log token (tryDecode, compactionPredicate))
     member _.TrySync<'context>
         (   log : ILogger, fold : 'state -> 'event seq -> 'state,
-            streamName, (Token.Unpack token as streamToken), state : 'state, events : 'event list, ctx : 'context) : Async<SyncResult<'state>> = async {
+            streamName, (Token.Unpack token as streamToken), state : 'state, events : 'event array, ctx : 'context) : Async<SyncResult<'state>> = async {
         let encode e = codec.Encode(ctx, e)
         let events =
             match access with
             | None | Some AccessStrategy.LatestKnownEvent -> events
             | Some (AccessStrategy.RollingSnapshots (_, compact)) ->
-                let cc = CompactionContext(List.length events, token.batchCapacityLimit.Value)
-                if cc.IsCompactionDue then events @ [fold state events |> compact] else events
-        let encodedEvents : EventData[] = events |> Seq.map (encode >> UnionEncoderAdapters.eventDataOfEncodedEvent) |> Array.ofSeq
+                let cc = CompactionContext(Array.length events, token.batchCapacityLimit.Value)
+                if cc.IsCompactionDue then Array.append events (fold state events |> compact |> Array.singleton) else events
+        let encodedEvents : EventData[] = events |> Array.map (encode >> UnionEncoderAdapters.eventDataOfEncodedEvent)
         match! context.TrySync log streamName streamToken (events, encodedEvents) compactionPredicate with
         | GatewaySyncResult.ConflictUnknown ->
             return SyncResult.Conflict  (fun ct -> load fold state (context.LoadFromToken true streamName log streamToken (tryDecode, compactionPredicate)) |> Async.startAsTask ct)
         | GatewaySyncResult.Written token' ->
-            return SyncResult.Written   (token', fold state (Seq.ofList events)) }
+            return SyncResult.Written   (token', fold state (Seq.ofArray events)) }
 
 type private Folder<'event, 'state, 'context>(category : Category<'event, 'state, 'context>, fold : 'state -> 'event seq -> 'state, initial : 'state, ?readCache) =
     let batched log streamName ct = category.Load fold initial streamName log |> Async.startAsTask ct

--- a/src/Equinox/Core.fs
+++ b/src/Equinox/Core.fs
@@ -2,6 +2,7 @@
 // i.e., if you're seeking to understand the main usage flows of the Equinox library, that's in Decider.fs, not here
 namespace Equinox.Core
 
+open System
 open System.Threading
 open System.Threading.Tasks
 
@@ -30,37 +31,33 @@ and [<NoEquality; NoComparison; RequireQualifiedAccess>] SyncResult<'state> =
 /// Store-specific opaque token to be used for synchronization purposes
 and [<Struct; NoEquality; NoComparison>] StreamToken = { value : obj; version : int64; streamBytes : int64 }
 
-module internal Impl =
+type internal Impl() =
 
-    let query struct (stream, fetch, projection) = async {
-        let! ct = Async.CancellationToken
-        let! tokenAndState = Async.AwaitTaskCorrect(fetch stream ct)
-        return projection tokenAndState }
-
-    let private run (stream : IStream<'e, 's>)
-                    (decide : struct (_ * _) -> CancellationToken -> Task<struct ('r * 'e list)>)
-                    (validateResync : int -> unit)
-                    (mapResult : 'r -> struct (StreamToken * 's) -> 'v)
-                    originTokenAndState ct : Task<'v>=
+    static let run (stream : IStream<'e, 's>)
+            (decide : Func<struct (_ * _), CancellationToken, Task<struct ('r * 'e seq)>>)
+            (validateResync : int -> unit)
+            (mapResult : Func<'r, struct (StreamToken * 's), 'v>)
+            originTokenAndState ct : Task<'v>=
         let rec loop attempt tokenAndState : Task<'v> = task {
-            let! result, events = decide tokenAndState ct
-            if List.isEmpty events then
-                return mapResult result tokenAndState
-            else
+            let! result, events = decide.Invoke(tokenAndState, ct)
+            match List.ofSeq events with
+            | [] -> return mapResult.Invoke(result, tokenAndState)
+            | events ->
                 match! stream.TrySync(attempt, tokenAndState, events, ct) with
                 | SyncResult.Written tokenAndState' ->
-                    return mapResult result tokenAndState'
+                    return mapResult.Invoke(result, tokenAndState')
                 | SyncResult.Conflict resync ->
                     validateResync attempt
                     let! tokenAndState = resync ct
                     return! loop (attempt + 1) tokenAndState }
         loop 1 originTokenAndState
 
-    let private transactTask stream (fetch : IStream<'e, 's> -> CancellationToken -> Task<struct (StreamToken * 's)>)
-                             decide reload mapResult ct : Task<'v> = task {
+    static member QueryAsync(stream, fetch : IStream<'e, 's> -> CancellationToken -> Task<struct (StreamToken * 's)>,
+                             projection : Func<struct (StreamToken * 's), 'v>, ct) : Task<'v> = task {
+        let! tokenAndState = fetch stream ct
+        return projection.Invoke tokenAndState }
+
+    static member TransactAsync(stream, fetch : IStream<'e, 's> -> CancellationToken -> Task<struct (StreamToken * 's)>,
+                                decide, reload, mapResult, ct) : Task<'v> = task {
         let! originTokenAndState = fetch stream ct
         return! run stream decide reload mapResult originTokenAndState ct }
-
-    let transact (stream, fetch, decide, reload, mapResult) = async {
-        let! ct = Async.CancellationToken
-        return! Async.AwaitTaskCorrect(transactTask stream fetch decide reload mapResult ct) }

--- a/src/Equinox/Core.fs
+++ b/src/Equinox/Core.fs
@@ -18,7 +18,7 @@ type IStream<'event, 'state> =
     /// Given the supplied `token` [and related `originState`], attempt to move to state `state'` by appending the supplied `events` to the underlying stream
     /// SyncResult.Written: implies the state is now the value represented by the Result's value
     /// SyncResult.Conflict: implies the `events` were not synced; if desired the consumer can use the included resync workflow in order to retry
-    abstract TrySync : attempt : int * originTokenAndState : struct (StreamToken * 'state) * events : 'event list * CancellationToken -> Task<SyncResult<'state>>
+    abstract TrySync : attempt : int * originTokenAndState : struct (StreamToken * 'state) * events : 'event array * CancellationToken -> Task<SyncResult<'state>>
 
 /// Internal type used to represent the outcome of a TrySync operation
 and [<NoEquality; NoComparison; RequireQualifiedAccess>] SyncResult<'state> =
@@ -40,8 +40,8 @@ type internal Impl() =
             originTokenAndState ct : Task<'v>=
         let rec loop attempt tokenAndState : Task<'v> = task {
             let! result, events = decide.Invoke(tokenAndState, ct)
-            match List.ofSeq events with
-            | [] -> return mapResult.Invoke(result, tokenAndState)
+            match Array.ofSeq events with
+            | [||] -> return mapResult.Invoke(result, tokenAndState)
             | events ->
                 match! stream.TrySync(attempt, tokenAndState, events, ct) with
                 | SyncResult.Written tokenAndState' ->

--- a/src/Equinox/Decider.fs
+++ b/src/Equinox/Decider.fs
@@ -1,108 +1,227 @@
 ﻿namespace Equinox
 
+open Equinox.Core
+open System
+open System.Threading
 open System.Threading.Tasks
 
 /// Central Application-facing API. Wraps the handling of decision or query flows in a manner that is store agnostic
-type Decider<'event, 'state>(stream : Core.IStream<'event, 'state>) =
+/// NOTE: For C#, direct usage of DeciderCore is recommended
+type Decider<'event, 'state>(stream : IStream<'event, 'state>) =
+
+    let inner = DeciderCore(stream)
+
+    /// 1.  Invoke the supplied <c>interpret</c> function with the present state to determine whether any write is to occur.
+    /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
+    ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
+    member _.Transact(interpret : 'state -> 'event list, ?load, ?attempts) : Async<unit> = async {
+        let! ct = Async.CancellationToken
+        return! inner.Transact(interpret >> Seq.ofList, ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
+
+    /// 1. Invoke the supplied <c>interpret</c> function with the present state
+    /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
+    ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
+    /// 3. Uses <c>render</c> to generate a 'view from the persisted final state
+    member _.Transact(interpret : 'state -> 'event list, render : 'state -> 'view, ?load, ?attempts) : Async<'view> = async {
+        let! ct = Async.CancellationToken
+        return! inner.Transact(interpret >> Seq.ofList, render, ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
+
+    /// 1. Invoke the supplied <c>decide</c> function with the present state, holding the <c>'result</c>
+    /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
+    ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
+    /// 3. Yield result
+    member _.Transact(decide : 'state -> 'result * 'event list, ?load, ?attempts) : Async<'result> = async {
+        let! ct = Async.CancellationToken
+        let inline decide' s = let r, es = decide s in struct (r, Seq.ofList es)
+        return! inner.Transact(decide', ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
+
+    /// 1. Invoke the supplied <c>decide</c> function with the present state, holding the <c>'result</c>
+    /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
+    ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
+    /// 3. Yields a final 'view produced by <c>mapResult</c> from the <c>'result</c> and/or the final persisted <c>'state</c>
+    member _.Transact(decide : 'state -> 'result * 'event list, mapResult : 'result -> 'state -> 'view, ?load, ?attempts) : Async<'view> = async {
+        let! ct = Async.CancellationToken
+        let inline decide' s = let r, es = decide s in struct (r, Seq.ofList es)
+        return! inner.Transact(decide', mapResult, ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
+
+    /// 1. Invoke the supplied <c>decide</c> function with the current complete context, holding the <c>'result</c>
+    /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
+    ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
+    /// 3. Yields <c>result</c>
+    member _.TransactEx(decide : ISyncContext<'state> -> 'result * 'event list, ?load, ?attempts) : Async<'result> = async {
+        let! ct = Async.CancellationToken
+        let inline decide' c = let r, es = decide c in struct (r, Seq.ofList es)
+        return! inner.TransactEx(decide = decide', ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
+
+    /// 1. Invoke the supplied <c>decide</c> function with the current complete context, holding the <c>'result</c>
+    /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
+    ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
+    /// 3. Yields a final 'view produced by <c>mapResult</c> from the <c>'result</c> and/or the final persisted <c>ISyncContext</c>
+    member _.TransactEx(decide : ISyncContext<'state> -> 'result * 'event list, mapResult : 'result -> ISyncContext<'state> -> 'view, ?load, ?attempts) : Async<'view> =  async {
+        // let inline decide (Context c) _ct = let r, e = decide c in Task.FromResult struct (r, e)
+        // let rec inline mapRes r (Context c) = mapResult r c
+        // Impl.transact (stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes)
+        let! ct = Async.CancellationToken
+        let inline decide' c = let r, es = decide c in struct (r, Seq.ofList es)
+        return! inner.TransactEx(decide = decide', mapResult = mapResult, ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
+
+    /// Project from the folded <c>'state</c>, but without executing a decision flow as <c>Transact</c> does
+    member _.Query(render : 'state -> 'view, ?load) : Async<'view> = async {
+        let! ct = Async.CancellationToken
+        return! inner.Query(render, ?load = load, ct = ct) |> Async.AwaitTaskCorrect }
+
+    /// Project from the stream's complete context, but without executing a decision flow as <c>TransactEx<c> does
+    member _.QueryEx(render : ISyncContext<'state> -> 'view, ?load) : Async<'view> =  async {
+        let! ct = Async.CancellationToken
+        return! inner.QueryEx(render, ?load = load, ct = ct) |> Async.AwaitTaskCorrect }
+
+    /// 1. Invoke the supplied <c>Async</c> <c>interpret</c> function with the present state
+    /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
+    ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
+    /// 3. Uses <c>render</c> to generate a 'view from the persisted final state
+    member _.TransactAsync(interpret : 'state -> Async<'event list>, render : 'state -> 'view, ?load, ?attempts) : Async<'view> =  async {
+        let! ct = Async.CancellationToken
+        let inline interpret' s ct = task { let! es = Async.StartImmediateAsTask(interpret s, ct) in return Seq.ofList es }
+        return! inner.TransactAsync(interpret', render, ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
+
+    /// 1. Invoke the supplied <c>Async</c> <c>decide</c> function with the present state, holding the <c>'result</c>
+    /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
+    ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
+    /// 3. Yield result
+    member _.TransactAsync(decide : 'state -> Async<'result * 'event list>, ?load, ?attempts) : Async<'result> =  async {
+        let! ct = Async.CancellationToken
+        let inline decide' s ct = task { let! r, es = Async.StartImmediateAsTask(decide s, ct) in return struct (r, Seq.ofList es) }
+        return! inner.TransactAsync(decide = decide', ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
+
+    /// 1. Invoke the supplied <c>Async</c> <c>decide</c> function with the current complete context, holding the <c>'result</c>
+    /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
+    ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
+    /// 3. Yield result
+    member _.TransactExAsync(decide : ISyncContext<'state> -> Async<'result * 'event list>, ?load, ?attempts) : Async<'result> =  async {
+        let! ct = Async.CancellationToken
+        let decide' c ct = task { let! r, es = Async.StartImmediateAsTask(decide c, ct) in return struct (r, Seq.ofList es) }
+        return! inner.TransactExAsync(decide = decide', ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
+
+    /// 1. Invoke the supplied <c>Async</c> <c>decide</c> function with the current complete context, holding the <c>'result</c>
+    /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
+    ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
+    /// 3. Yields a final 'view produced by <c>mapResult</c> from the <c>'result</c> and/or the final persisted <c>ISyncContext</c>
+    member _.TransactExAsync(decide : ISyncContext<'state> -> Async<'result * 'event list>, mapResult : 'result -> ISyncContext<'state> -> 'view, ?load, ?attempts) : Async<'view> =  async {
+        let! ct = Async.CancellationToken
+        let inline decide' c ct = task { let! r, es = Async.StartImmediateAsTask(decide c, ct) in return struct (r, Seq.ofList es) }
+        return! inner.TransactExAsync(decide = decide', mapResult = mapResult, ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
+
+/// Central Application-facing API. Wraps the handling of decision or query flows in a manner that is store agnostic
+and DeciderCore<'event, 'state>(stream : IStream<'event, 'state>) =
 
     let (|Context|) = SyncContext<'state>.Map
 
     /// 1.  Invoke the supplied <c>interpret</c> function with the present state to determine whether any write is to occur.
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
-    member _.Transact(interpret : 'state -> 'event list, ?load, ?attempts) : Async<unit> =
-        let inline decide struct (_t : Core.StreamToken, state) _ct = Task.FromResult struct ((), interpret state)
-        let inline mapRes () struct (_t : Core.StreamToken, _s : 'state) = ()
-        Core.Impl.transact(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes)
+    member _.Transact(interpret : Func<'state, 'event seq>,
+                      [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D(CancellationToken())>]?ct) : Task<unit> =
+        let inline decide struct (_t : StreamToken, state) _ct = Task.FromResult struct ((), interpret.Invoke state)
+        let inline mapRes () struct (_t : StreamToken, _s : 'state) = ()
+        Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
 
     /// 1. Invoke the supplied <c>interpret</c> function with the present state
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Uses <c>render</c> to generate a 'view from the persisted final state
-    member _.Transact(interpret : 'state -> 'event list, render : 'state -> 'view, ?load, ?attempts) : Async<'view> =
-        let inline decide struct (_token, state) _ct = Task.FromResult struct ((), interpret state)
-        let inline mapRes () struct (_token, state) = render state
-        Core.Impl.transact(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes)
+    member _.Transact(interpret : Func<'state, 'event seq>, render : Func<'state, 'view>,
+                      [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D(CancellationToken())>]?ct) : Task<'view> =
+        let inline decide struct (_token, state) _ct = Task.FromResult struct ((), interpret.Invoke state)
+        let inline mapRes () struct (_token, state) = render.Invoke state
+        Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
 
     /// 1. Invoke the supplied <c>decide</c> function with the present state, holding the <c>'result</c>
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yield result
-    member _.Transact(decide : 'state -> 'result * 'event list, ?load, ?attempts) : Async<'result> =
-        let inline decide struct (_token, state) _ct = let r, e = decide state in Task.FromResult struct (r, e)
+    member _.Transact(decide : Func<'state, struct ('result * 'event seq)>,
+                      [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct) : Task<'result> =
+        let inline decide struct (_token, state) _ct = decide.Invoke state |> Task.FromResult
         let inline mapRes r _ = r
-        Core.Impl.transact(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes)
+        Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
 
     /// 1. Invoke the supplied <c>decide</c> function with the present state, holding the <c>'result</c>
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yields a final 'view produced by <c>mapResult</c> from the <c>'result</c> and/or the final persisted <c>'state</c>
-    member _.Transact(decide : 'state -> 'result * 'event list, mapResult : 'result -> 'state -> 'view, ?load, ?attempts) : Async<'view> =
-        let inline decide struct (_token, state) _ct = let r, e = decide state in Task.FromResult struct (r, e)
-        let inline mapRes r struct (_, s) = mapResult r s
-        Core.Impl.transact (stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes)
+    member _.Transact(decide : Func<'state, struct ('result * 'event seq)>, mapResult : Func<'result, 'state, 'view>,
+                      [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct) : Task<'view> =
+        let inline decide struct (_token, state) _ct = decide.Invoke state |> Task.FromResult
+        let inline mapRes r struct (_, s) = mapResult.Invoke(r, s)
+        Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
 
     /// 1. Invoke the supplied <c>decide</c> function with the current complete context, holding the <c>'result</c>
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yields <c>result</c>
-    member _.TransactEx(decide : ISyncContext<'state> -> 'result * 'event list, ?load, ?attempts) : Async<'result> =
-        let inline decide (Context c) _ct = let r, e = decide c in Task.FromResult struct (r, e)
+    member _.TransactEx(decide : Func<ISyncContext<'state>, struct ('result * 'event seq)>,
+                        [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct) : Task<'result> =
+        let inline decide' (Context c) _ct = let r = decide.Invoke(c) in Task.FromResult r
         let inline mapRes r _ = r
-        Core.Impl.transact (stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes)
+        Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide', AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
 
     /// 1. Invoke the supplied <c>decide</c> function with the current complete context, holding the <c>'result</c>
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yields a final 'view produced by <c>mapResult</c> from the <c>'result</c> and/or the final persisted <c>ISyncContext</c>
-    member _.TransactEx(decide : ISyncContext<'state> -> 'result * 'event list, mapResult : 'result -> ISyncContext<'state> -> 'view, ?load, ?attempts) : Async<'view> =
-        let inline decide (Context c) _ct = let r, e = decide c in Task.FromResult struct (r, e)
-        let rec inline mapRes r (Context c) = mapResult r c
-        Core.Impl.transact (stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes)
+    member _.TransactEx(decide : Func<ISyncContext<'state>, struct ('result * 'event seq)>, mapResult : Func<'result, ISyncContext<'state>, 'view>,
+                        [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct) : Task<'view> =
+        let inline decide (Context c) _ct = c |> decide.Invoke |> Task.FromResult
+        let inline mapRes r (Context c) = mapResult.Invoke(r, c)
+        Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
 
     /// Project from the folded <c>'state</c>, but without executing a decision flow as <c>Transact</c> does
-    member _.Query(render : 'state -> 'view, ?load) : Async<'view> =
-        Core.Impl.query struct (stream, LoadPolicy.Fetch load, fun struct (_token, state) -> render state)
+    member _.Query(render : Func<'state, 'view>, [<O; D null>] ?load, [<O; D null>] ?ct) : Task<'view> =
+        Impl.QueryAsync(stream, LoadPolicy.Fetch load, (fun struct (_token, state) -> render.Invoke state), defaultArg ct CancellationToken.None)
 
     /// Project from the stream's complete context, but without executing a decision flow as <c>TransactEx<c> does
-    member _.QueryEx(render : ISyncContext<'state> -> 'view, ?load) : Async<'view> =
-        Core.Impl.query struct (stream, LoadPolicy.Fetch load, fun (Context c) -> render c)
+    member _.QueryEx(render : Func<ISyncContext<'state>, 'view>, [<O; D null>] ?load, [<O; D null>] ?ct) : Task<'view> =
+        Impl.QueryAsync(stream, LoadPolicy.Fetch load, (fun (Context c) -> render.Invoke c), defaultArg ct CancellationToken.None)
 
     /// 1. Invoke the supplied <c>Async</c> <c>interpret</c> function with the present state
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Uses <c>render</c> to generate a 'view from the persisted final state
-    member _.TransactAsync(interpret : 'state -> Async<'event list>, render : 'state -> 'view, ?load, ?attempts) : Async<'view> =
-        let inline decide struct (_token, state) _ct = task { let! es = interpret state in return struct ((), es) }
-        let rec inline mapRes () struct (_token, state) = render state
-        Core.Impl.transact (stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes)
+    member _.TransactAsync(interpret : Func<'state, CancellationToken, Task<'event seq>>, render : Func<'state, 'view>,
+                           [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct) : Task<'view> =
+        let inline decide struct (_token, state) ct = task { let! es = interpret.Invoke(state, ct) in return struct ((), es) }
+        let inline mapRes () struct (_token, state) = render.Invoke state
+        Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
 
     /// 1. Invoke the supplied <c>Async</c> <c>decide</c> function with the present state, holding the <c>'result</c>
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yield result
-    member _.TransactAsync(decide : 'state -> Async<'result * 'event list>, ?load, ?attempts) : Async<'result> =
-        let inline decide struct (_token, state) _ct = task { let! r, e = decide state in return struct (r, e) }
-        let rec inline mapRes r _ = r
-        Core.Impl.transact (stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes)
+    member _.TransactAsync(decide : Func<'state, CancellationToken, Task<struct ('result * 'event seq)>>,
+                           [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct) : Task<'result> =
+        let inline decide struct (_token, state) ct = task { let! r, e = decide.Invoke(state, ct) in return struct (r, e) }
+        let inline mapRes r _ = r
+        Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
 
     /// 1. Invoke the supplied <c>Async</c> <c>decide</c> function with the current complete context, holding the <c>'result</c>
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yield result
-    member _.TransactExAsync(decide : ISyncContext<'state> -> Async<'result * 'event list>, ?load, ?attempts) : Async<'result> =
-        let inline decide (Context c) _ct = task { let! r, e = decide c in return struct (r, e) }
-        let rec inline mapRes r _ = r
-        Core.Impl.transact (stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes)
+    member _.TransactExAsync(decide : Func<ISyncContext<'state>, CancellationToken, Task<struct ('result * 'event seq)>>,
+                             [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct) : Task<'result> =
+        let inline decide (Context c) ct = task { let! r, e = decide.Invoke (c, ct) in return struct (r, e) }
+        let inline mapRes r _ = r
+        Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
 
     /// 1. Invoke the supplied <c>Async</c> <c>decide</c> function with the current complete context, holding the <c>'result</c>
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yields a final 'view produced by <c>mapResult</c> from the <c>'result</c> and/or the final persisted <c>ISyncContext</c>
-    member _.TransactExAsync(decide : ISyncContext<'state> -> Async<'result * 'event list>, mapResult : 'result -> ISyncContext<'state> -> 'view, ?load, ?attempts) : Async<'view> =
-        let inline decide (Context c) _ct = task { let! r, e = decide c in return struct (r, e) }
-        let rec inline mapRes r (Context c) = mapResult r c
-        Core.Impl.transact (stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes)
+    member _.TransactExAsync(decide : Func<ISyncContext<'state>, CancellationToken, Task<struct ('result * 'event seq)>>, mapResult : Func<'result, ISyncContext<'state>, 'view>,
+                             [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct) : Task<'view> =
+        let inline decide (Context c) ct = decide.Invoke(c, ct)
+        let inline mapRes r (Context c) = mapResult.Invoke(r, c)
+        Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
 
 (* Options to tune loading policy - default is RequireLoad*)
 
@@ -117,10 +236,10 @@ and [<NoComparison; NoEquality>] LoadOption<'state> =
     /// Inhibit load from database based on the fact that the stream is likely not to have been initialized yet, and we will be generating events
     | AssumeEmpty
     /// <summary>Instead of loading from database, seed the loading process with the supplied memento, obtained via <c>ISyncContext.CreateMemento()</c></summary>
-    | FromMemento of memento : struct (Core.StreamToken * 'state)
+    | FromMemento of memento : struct (StreamToken * 'state)
 and internal LoadPolicy() =
     static member Fetch<'state, 'event>(x : LoadOption<'state> option)
-        : Core.IStream<'event, 'state> -> System.Threading.CancellationToken -> Task<struct (Core.StreamToken * 'state)> =
+        : IStream<'event, 'state> -> CancellationToken -> Task<struct (StreamToken * 'state)> =
         match x with
         | None | Some RequireLoad ->                 fun stream ct ->   stream.Load(allowStale = false, ct = ct)
         | Some AllowStale ->                         fun stream ct ->   stream.Load(allowStale = true, ct = ct)
@@ -136,14 +255,13 @@ and internal AttemptsPolicy() =
 
     static member Validate(opt : Attempts option) =
         let maxAttempts = match opt with Some (Attempts.Max n) -> n | None -> 3
-        if maxAttempts < 1 then raise <| System.ArgumentOutOfRangeException(nameof opt, maxAttempts, "should be >= 1")
+        if maxAttempts < 1 then raise <| ArgumentOutOfRangeException(nameof opt, maxAttempts, "should be >= 1")
         fun attempt -> if attempt = maxAttempts then raise (MaxResyncsExhaustedException attempt)
 
 /// Exception yielded by Decider.Transact after `count` attempts have yielded conflicts at the point of syncing with the Store
 and MaxResyncsExhaustedException(count) =
    inherit exn(sprintf "Concurrency violation; aborting after %i attempts." count)
 
-(* Extended context interface exposed by TransactEx / QueryEx *)
 
 /// Exposed by TransactEx / QueryEx, providing access to extended state information for cases where that's required
 and ISyncContext<'state> =
@@ -162,11 +280,11 @@ and ISyncContext<'state> =
     abstract member State : 'state
 
     /// Represents a Checkpoint position on a Stream's timeline; Can be used to manage continuations via LoadOption.FromMemento
-    abstract member CreateMemento : unit -> struct (Core.StreamToken * 'state)
+    abstract member CreateMemento : unit -> struct (StreamToken * 'state)
 
 and internal SyncContext<'state> =
 
-    static member Map(struct (token : Core.StreamToken, state : 'state)) =
+    static member Map(struct (token : StreamToken, state : 'state)) =
         { new ISyncContext<'state> with
             member _.State = state
             member _.Version = token.version

--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -27,7 +27,7 @@ module Cart =
         |> Cart.create
     /// Trigger looking in Tip (we want those calls to occur, but without leaning on snapshots, which would reduce the paths covered)
     let createServiceWithEmptyUnfolds log context =
-        let unfArgs = Cart.Fold.isOrigin, fun _ -> Seq.empty
+        let unfArgs = Cart.Fold.isOrigin, fun _ -> Array.empty
         StoreCategory(context, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.MultiSnapshot unfArgs)
         |> Equinox.Decider.resolve log
         |> Cart.create

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -77,7 +77,7 @@ type Category<'event, 'state, 'context> = EventStoreCategory<'event, 'state, 'co
 #endif
 #endif
 
-let createContext connection batchSize = Context(connection, BatchingPolicy(maxBatchSize = batchSize))
+let createContext connection batchSize = Context(connection, batchSize = batchSize)
 
 module Cart =
     let fold, initial = Cart.Fold.fold, Cart.Fold.initial

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -147,14 +147,14 @@ and DumpArguments(p: ParseResults<DumpParameters>) =
         let storeConfig = None, true
         match p.GetSubCommand() with
         | DumpParameters.Cosmos p ->
-            let storeLog = createStoreLog <| p.Contains Storage.Cosmos.Parameters.VerboseStore
+            let storeLog = createStoreLog <| p.Contains Storage.Cosmos.Parameters.StoreVerbose
             storeLog, Storage.Cosmos.config log storeConfig (Storage.Cosmos.Arguments p)
         | DumpParameters.Dynamo p ->
-            let storeLog = createStoreLog <| p.Contains Storage.Dynamo.Parameters.VerboseStore
+            let storeLog = createStoreLog <| p.Contains Storage.Dynamo.Parameters.StoreVerbose
             storeLog, Storage.Dynamo.config log storeConfig (Storage.Dynamo.Arguments p)
         | DumpParameters.Es p ->
-            let storeLog = createStoreLog <| p.Contains Storage.EventStore.Parameters.VerboseStore
-            storeLog, Storage.EventStore.config (log, storeLog) storeConfig p
+            let storeLog = createStoreLog <| p.Contains Storage.EventStore.Parameters.StoreVerbose
+            storeLog, Storage.EventStore.config log storeConfig p
         | DumpParameters.MsSql p ->
             let storeLog = createStoreLog false
             storeLog, Storage.Sql.Ms.config log storeConfig p
@@ -221,15 +221,15 @@ and TestArguments(p : ParseResults<TestParameters>) =
     member x.ConfigureStore(log : ILogger, createStoreLog) =
         let cache = if x.Cache then Equinox.Cache(appName, sizeMb = 50) |> Some else None
         match p.GetSubCommand() with
-        | Cosmos p ->   let storeLog = createStoreLog <| p.Contains Storage.Cosmos.Parameters.VerboseStore
+        | Cosmos p ->   let storeLog = createStoreLog <| p.Contains Storage.Cosmos.Parameters.StoreVerbose
                         log.Information("Running transactions in-process against CosmosDB with storage options: {options:l}", x.Options)
                         storeLog, Storage.Cosmos.config log (cache, x.Unfolds) (Storage.Cosmos.Arguments p)
-        | Dynamo p ->   let storeLog = createStoreLog <| p.Contains Storage.Dynamo.Parameters.VerboseStore
+        | Dynamo p ->   let storeLog = createStoreLog <| p.Contains Storage.Dynamo.Parameters.StoreVerbose
                         log.Information("Running transactions in-process against DynamoDB with storage options: {options:l}", x.Options)
                         storeLog, Storage.Dynamo.config log (cache, x.Unfolds) (Storage.Dynamo.Arguments p)
-        | Es p ->       let storeLog = createStoreLog <| p.Contains Storage.EventStore.Parameters.VerboseStore
+        | Es p ->       let storeLog = createStoreLog <| p.Contains Storage.EventStore.Parameters.StoreVerbose
                         log.Information("Running transactions in-process against EventStore with storage options: {options:l}", x.Options)
-                        storeLog, Storage.EventStore.config (log, storeLog) (cache, x.Unfolds) p
+                        storeLog, Storage.EventStore.config log (cache, x.Unfolds) p
         | MsSql p ->    let storeLog = createStoreLog false
                         log.Information("Running transactions in-process against MsSql with storage options: {options:l}", x.Options)
                         storeLog, Storage.Sql.Ms.config log (cache, x.Unfolds) p
@@ -306,7 +306,7 @@ module LoadTest =
         execute
     let private createResultLog fileName = LoggerConfiguration().WriteTo.File(fileName).CreateLogger()
     let run (log : ILogger) (verbose, verboseConsole, maybeSeq) reportFilename (p : ParseResults<TestParameters>) =
-        let createStoreLog verboseStore = createStoreLog verboseStore verboseConsole maybeSeq
+        let createStoreLog storeVerbose = createStoreLog storeVerbose verboseConsole maybeSeq
         let a = TestArguments p
         let storeLog, storeConfig, httpClient: ILogger * Storage.StorageConfig option * HttpClient option =
             match p.TryGetSubCommand() with
@@ -465,7 +465,7 @@ module Dump =
 
     let run (log : ILogger, verboseConsole, maybeSeq) (p : ParseResults<DumpParameters>) =
         let a = DumpArguments p
-        let createStoreLog verboseStore = createStoreLog verboseStore verboseConsole maybeSeq
+        let createStoreLog storeVerbose = createStoreLog storeVerbose verboseConsole maybeSeq
         let storeLog, storeConfig = a.ConfigureStore(log, createStoreLog)
         let doU, doE = not (p.Contains EventsOnly), not (p.Contains UnfoldsOnly)
         let doC, doJ, doS, doT = p.Contains Correlation, not (p.Contains JsonSkip), not (p.Contains Blobs), not (p.Contains TimeRegular)


### PR DESCRIPTION
- Provides C#-friendly signatures equivalent to ones on `Decider`
- Align Esdb-like stores with others, renaming `BatchingPolicy` to `BatchOptions`, add `StoreContext` shortcut-constructor