### PR TITLE
Write out the loop for better perf on chooseV

### DIFF
--- a/src/Equinox.Core/Infrastructure.fs
+++ b/src/Equinox.Core/Infrastructure.fs
@@ -71,4 +71,4 @@ module Seq =
 
 module Array =
 
-    let inline chooseV f = Array.choose (f >> ValueOption.toOption)
+    let inline chooseV f arr = [| for item in arr do match f item with ValueSome v -> yield v | ValueNone -> () |]

--- a/src/Equinox.Core/Infrastructure.fs
+++ b/src/Equinox.Core/Infrastructure.fs
@@ -60,15 +60,10 @@ module ValueTuple =
     let inline fst struct (f, _s) = f
     let inline snd struct (_f, s) = s
 
-module ValueOption =
-
-    let inline toOption x = match x with ValueSome x -> Some x | ValueNone -> None
-    let inline toArray x = match x with ValueSome e -> [| e |] | ValueNone -> [||]
-
 module Seq =
 
-    let inline chooseV f = Seq.choose (f >> ValueOption.toOption)
+    let inline chooseV f xs = seq { for x in xs do match f x with ValueSome v -> yield v | ValueNone -> () }
 
 module Array =
 
-    let inline chooseV f arr = [| for item in arr do match f item with ValueSome v -> yield v | ValueNone -> () |]
+    let inline chooseV f xs = [| for item in xs do match f item with ValueSome v -> yield v | ValueNone -> () |]


### PR DESCRIPTION
See a comparioson of the ASM [here](https://sharplab.io/#v2:DYLgZgzgNALiCGEC2UAmIDUAfJB7VArsAKYAEAKgBYCWAdgOYCwAUCyTKQMaW64TEA1UgAowIUnQ4BaAHwTaHAG64ADjGq5aAShHwATnvGTS+vfACeOgLykA2llJhceiTGJJ5Jg6VS5SSeBhuR1d3UgB3ahhKUgF4YAJiAGVcJDJFUllSc2piYFRSDIc4hOIAOU0yLOEdLABdFjZiDhhcAHk1DVpSGzACWk51TVj4xJS0wsy5cfTSYtHyyqnSCtpiJo5uXn4BACYRMXlpOWNlTs1rUgBBAwsAOi2+MlFSGTlWjqHtIA=)

the new version doesn't need to allocate an option for each voption either.

Here's the result from a Benchmark.NET run as well

|     Method |     Mean |    Error |   StdDev |   Gen0 | Allocated |
|----------- |---------:|---------:|---------:|-------:|----------:|
| ChooseVOld | 48.85 ns | 0.167 ns | 0.148 ns | 0.0162 |     136 B |
| ChooseVNew | 32.74 ns | 0.725 ns | 1.923 ns | 0.0076 |      64 B |

The old method allocates a new array and options, the new one only allocates the array
