### PR TITLE
Add tracing to MessageDb module in an additive manner

### DIFF
--- a/src/Equinox.Core/Internal.fs
+++ b/src/Equinox.Core/Internal.fs
@@ -1,8 +1,6 @@
 [<AutoOpen>]
 module internal Equinox.Core.Internal
 
-open System.Diagnostics
-
 module Log =
 
     // Sidestep Log.ForContext converting to a string; see https://github.com/serilog/serilog/issues/1124
@@ -13,35 +11,3 @@ module Log =
     let [<return: Struct>] (|ScalarValue|_|) : Serilog.Events.LogEventPropertyValue -> obj voption = function
         | :? Serilog.Events.ScalarValue as x -> ValueSome x.Value
         | _ -> ValueNone
-
-
-[<System.Runtime.CompilerServices.Extension>]
-type ActivityExtensions =
-
-    [<System.Runtime.CompilerServices.Extension>]
-    static member AddStreamName(act: Activity, streamName: string) = act.AddTag("eqx.stream_name", streamName)
-
-    [<System.Runtime.CompilerServices.Extension>]
-    static member AddExpectedVersion(act: Activity, version: int64) = act.AddTag("eqx.expected_version", version)
-
-    [<System.Runtime.CompilerServices.Extension>]
-    static member AddVersion(act: Activity, version: int64) = act.AddTag("eqx.last_version", version)
-
-    [<System.Runtime.CompilerServices.Extension>]
-    static member AddMetric(act: Activity, count: int, bytes: int) = act.AddTag("eqx.count", count).AddTag("eqx.bytes", bytes)
-
-    [<System.Runtime.CompilerServices.Extension>]
-    static member AddBatchSize(act: Activity, size: int64) = act.AddTag("eqx.batch_size", size)
-
-    [<System.Runtime.CompilerServices.Extension>]
-    static member AddBatchInformation(act: Activity, size: int64, index: int) = act.AddBatchSize(size).AddTag("eqx.batch_index", index)
-
-    [<System.Runtime.CompilerServices.Extension>]
-    static member AddStartPosition(act: Activity, pos: int64) = act.AddTag("eqx.start_position", pos)
-
-    [<System.Runtime.CompilerServices.Extension>]
-    static member AddLeader(act: Activity, requiresLeader) = if requiresLeader then act.AddTag("eqx.requires_leader", true) else act
-
-    [<System.Runtime.CompilerServices.Extension>]
-    static member RecordConflict(act: Activity) = act.AddTag("eqx.conflict", true).AddEvent(ActivityEvent("WrongExpectedVersion"))
-

--- a/src/Equinox.Core/Internal.fs
+++ b/src/Equinox.Core/Internal.fs
@@ -1,6 +1,8 @@
 [<AutoOpen>]
 module internal Equinox.Core.Internal
 
+open System.Diagnostics
+
 module Log =
 
     // Sidestep Log.ForContext converting to a string; see https://github.com/serilog/serilog/issues/1124
@@ -11,3 +13,35 @@ module Log =
     let [<return: Struct>] (|ScalarValue|_|) : Serilog.Events.LogEventPropertyValue -> obj voption = function
         | :? Serilog.Events.ScalarValue as x -> ValueSome x.Value
         | _ -> ValueNone
+
+
+[<System.Runtime.CompilerServices.Extension>]
+type ActivityExtensions =
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member AddStreamName(act: Activity, streamName: string) = act.AddTag("eqx.stream_name", streamName)
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member AddExpectedVersion(act: Activity, version: int64) = act.AddTag("eqx.expected_version", version)
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member AddVersion(act: Activity, version: int64) = act.AddTag("eqx.last_version", version)
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member AddMetric(act: Activity, count: int, bytes: int) = act.AddTag("eqx.count", count).AddTag("eqx.bytes", bytes)
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member AddBatchSize(act: Activity, size: int64) = act.AddTag("eqx.batch_size", size)
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member AddBatchInformation(act: Activity, size: int64, index: int) = act.AddBatchSize(size).AddTag("eqx.batch_index", index)
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member AddStartPosition(act: Activity, pos: int64) = act.AddTag("eqx.start_position", pos)
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member AddLeader(act: Activity, requiresLeader) = if requiresLeader then act.AddTag("eqx.requires_leader", true) else act
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member RecordConflict(act: Activity) = act.AddTag("eqx.conflict", true).AddEvent(ActivityEvent("WrongExpectedVersion"))
+

--- a/src/Equinox.MessageDb/Equinox.MessageDb.fsproj
+++ b/src/Equinox.MessageDb/Equinox.MessageDb.fsproj
@@ -26,9 +26,7 @@
 
     <ItemGroup>
         <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
-
         <PackageReference Include="FSharp.Core" Version="6.0.0" />
-
         <PackageReference Include="FSharp.Control.AsyncSeq" Version="3.2.1" />
         <PackageReference Include="FsCodec" Version="3.0.0-rc.7.1" />
         <PackageReference Include="Npgsql" Version="6.0.7" />

--- a/src/Equinox.MessageDb/Equinox.MessageDb.fsproj
+++ b/src/Equinox.MessageDb/Equinox.MessageDb.fsproj
@@ -15,12 +15,13 @@
         <Compile Include="..\Equinox.Core\Internal.fs">
             <Link>Internal.fs</Link>
         </Compile>
-        <Compile Include="MessageDbClient.fs"/>
-        <Compile Include="MessageDb.fs"/>
+        <Compile Include="Tracing.fs" />
+        <Compile Include="MessageDbClient.fs" />
+        <Compile Include="MessageDb.fs" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Equinox.Core\Equinox.Core.fsproj"/>
+        <ProjectReference Include="..\Equinox.Core\Equinox.Core.fsproj" />
     </ItemGroup>
 
     <ItemGroup>
@@ -28,9 +29,9 @@
 
         <PackageReference Include="FSharp.Core" Version="6.0.0" />
 
-        <PackageReference Include="FSharp.Control.AsyncSeq" Version="3.2.1"/>
-        <PackageReference Include="FsCodec" Version="3.0.0-rc.7.1"/>
-        <PackageReference Include="Npgsql" Version="6.0.7"/>
+        <PackageReference Include="FSharp.Control.AsyncSeq" Version="3.2.1" />
+        <PackageReference Include="FsCodec" Version="3.0.0-rc.7.1" />
+        <PackageReference Include="Npgsql" Version="6.0.7" />
     </ItemGroup>
 
 </Project>

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -183,7 +183,7 @@ module Read =
     let inline len (bytes : EventBody) = bytes.Length
     let private resolvedEventLen (x : ITimelineEvent<EventBody>) = len x.Data + len x.Meta
     let private resolvedEventBytes events = events |> Array.sumBy resolvedEventLen
-    let private loggedReadSlice reader (streamName: string) (batchSize: int64) (batchIndex: int) (startPos: int64) (requiresLeader: bool) (log : ILogger) : Async<_> = async {
+    let private loggedReadSlice reader streamName batchSize batchIndex startPos requiresLeader (log : ILogger) : Async<_> = async {
         use act = source.StartActivity("ReadSlice", ActivityKind.Client)
         if act <> null then
             act.AddStreamName(streamName).AddBatchInformation(batchSize, batchIndex)

--- a/src/Equinox.MessageDb/Tracing.fs
+++ b/src/Equinox.MessageDb/Tracing.fs
@@ -1,0 +1,40 @@
+[<AutoOpen>]
+module internal Equinox.MessageDb.Tracing
+
+
+open System.Diagnostics
+
+let source = new ActivitySource("Equinox.MessageDb")
+
+[<System.Runtime.CompilerServices.Extension>]
+type ActivityExtensions =
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member AddStreamName(act: Activity, streamName: string) = act.AddTag("eqx.stream_name", streamName)
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member AddExpectedVersion(act: Activity, version: int64) = act.AddTag("eqx.expected_version", version)
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member AddVersion(act: Activity, version: int64) = act.AddTag("eqx.last_version", version)
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member AddMetric(act: Activity, count: int, bytes: int) = act.AddTag("eqx.count", count).AddTag("eqx.bytes", bytes)
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member AddBatchSize(act: Activity, size: int64) = act.AddTag("eqx.batch_size", size)
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member AddBatchInformation(act: Activity, size: int64, index: int) = act.AddBatchSize(size).AddTag("eqx.batch_index", index)
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member AddStartPosition(act: Activity, pos: int64) = act.AddTag("eqx.start_position", pos)
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member AddLeader(act: Activity, requiresLeader) = if requiresLeader then act.AddTag("eqx.requires_leader", true) else act
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member RecordConflict(act: Activity) = act.AddTag("eqx.conflict", true).AddEvent(ActivityEvent("WrongExpectedVersion"))
+
+
+

--- a/src/Equinox.MessageDb/Tracing.fs
+++ b/src/Equinox.MessageDb/Tracing.fs
@@ -6,6 +6,8 @@ open System.Diagnostics
 
 let source = new ActivitySource("Equinox.MessageDb")
 
+let addRetryAttempt (attempt: int) (act: Activity) = if act <> null then act.AddTag("eqx.op_attempt", attempt) |> ignore
+
 [<System.Runtime.CompilerServices.Extension>]
 type ActivityExtensions =
 
@@ -25,7 +27,10 @@ type ActivityExtensions =
     static member AddBatchSize(act: Activity, size: int64) = act.AddTag("eqx.batch_size", size)
 
     [<System.Runtime.CompilerServices.Extension>]
-    static member AddBatchInformation(act: Activity, size: int64, index: int) = act.AddBatchSize(size).AddTag("eqx.batch_index", index)
+    static member AddBatch(act: Activity, size: int64, index: int) = act.AddBatchSize(size).AddTag("eqx.batch_index", index)
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member AddBatches(act: Activity, batches: int, count: int) = act.AddTag("eqx.batches", batches).AddTag("eqx.event_count", count)
 
     [<System.Runtime.CompilerServices.Extension>]
     static member AddStartPosition(act: Activity, pos: int64) = act.AddTag("eqx.start_position", pos)

--- a/src/Equinox.MessageDb/Tracing.fs
+++ b/src/Equinox.MessageDb/Tracing.fs
@@ -6,7 +6,7 @@ open System.Diagnostics
 
 let source = new ActivitySource("Equinox.MessageDb")
 
-let addRetryAttempt (attempt: int) (act: Activity) = if act <> null then act.AddTag("eqx.op_attempt", attempt) |> ignore
+let addOpAttempt (attempt: int) (act: Activity) = if act <> null then act.AddTag("eqx.op_attempt", attempt) |> ignore
 
 [<System.Runtime.CompilerServices.Extension>]
 type ActivityExtensions =
@@ -18,7 +18,7 @@ type ActivityExtensions =
     static member AddExpectedVersion(act: Activity, version: int64) = act.AddTag("eqx.expected_version", version)
 
     [<System.Runtime.CompilerServices.Extension>]
-    static member AddVersion(act: Activity, version: int64) = act.AddTag("eqx.last_version", version)
+    static member AddLastVersion(act: Activity, version: int64) = act.AddTag("eqx.last_version", version)
 
     [<System.Runtime.CompilerServices.Extension>]
     static member AddMetric(act: Activity, count: int, bytes: int) = act.AddTag("eqx.count", count).AddTag("eqx.bytes", bytes)

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -94,7 +94,9 @@ type Category<'event, 'state, 'context> = EventStoreCategory<'event, 'state, 'co
 
 let createContext connection batchSize = Context(connection, batchSize = batchSize)
 
+#if NET
 let source = new ActivitySource("StoreIntegration")
+#endif
 
 module SimplestThing =
     type Event =
@@ -186,7 +188,9 @@ type Tests(testOutputHelper) =
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
     let ``Can roundtrip against Store, correctly batching the reads [without any optimizations]`` (ctx, skuId) = Async.RunSynchronously <| async {
+        #if NET
         use _ = source.StartActivity("Can roundtrip against Store, correctly batching the reads [without any optimizations]")
+        #endif
         let log, capture = output.CreateLoggerWithCapture()
         let! connection = connectToLocalStore log
 
@@ -216,7 +220,9 @@ type Tests(testOutputHelper) =
 
     [<AutoData(MaxTest = 2, SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
     let ``Can roundtrip against Store, managing sync conflicts by retrying [without any optimizations]`` (ctx, initialState) = Async.RunSynchronously <| async {
+        #if NET
         use _ = source.StartActivity("Can roundtrip against Store, managing sync conflicts by retrying [without any optimizations]")
+        #endif
         let log1, capture1 = output.CreateLoggerWithCapture()
 
         let! connection = connectToLocalStore log1
@@ -307,6 +313,9 @@ type Tests(testOutputHelper) =
 #if !STORE_MESSAGEDB
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
     let ``Can roundtrip against Store, correctly compacting to avoid redundant reads`` (ctx, skuId) = Async.RunSynchronously <| async {
+        #if NET
+        use _ = source.StartActivity("Can roundtrip against Store, correctly compacting to avoid redundant reads")
+        #endif
         let log, capture = output.CreateLoggerWithCapture()
         let! client = connectToLocalStore log
         let batchSize = 10
@@ -349,7 +358,9 @@ type Tests(testOutputHelper) =
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
     let ``Can correctly read and update against Store, with LatestKnownEvent Access Strategy`` id value = Async.RunSynchronously <| async {
+        #if NET
         use _ = source.StartActivity("Can correctly read and update against Store, with LatestKnownEvent Access Strategy")
+        #endif
         let log, capture = output.CreateLoggerWithCapture()
         let! client = connectToLocalStore log
         let service = ContactPreferences.createService log client
@@ -371,7 +382,9 @@ type Tests(testOutputHelper) =
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
     let ``Can roundtrip against Store, correctly caching to avoid redundant reads`` (ctx, skuId) = Async.RunSynchronously <| async {
+        #if NET
         use _ = source.StartActivity("Can roundtrip against Store, correctly caching to avoid redundant reads")
+        #endif
         let log, capture = output.CreateLoggerWithCapture()
         let! client = connectToLocalStore log
         let batchSize = 10
@@ -481,7 +494,9 @@ type Tests(testOutputHelper) =
 #endif
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
     let ``Version is 0-based`` () = Async.RunSynchronously <| async {
+        #if NET
         use _ = source.StartActivity("Version is 0-based")
+        #endif
         let log, _ = output.CreateLoggerWithCapture()
         let! connection = connectToLocalStore log
 

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -1,5 +1,6 @@
 ﻿module Equinox.Store.Integration.StoreIntegration
 
+open System.Diagnostics
 open Domain
 open FSharp.UMX
 open Serilog
@@ -49,6 +50,10 @@ type Category<'event, 'state, 'context> = SqlStreamStoreCategory<'event, 'state,
 #endif
 #if STORE_MESSAGEDB
 open Equinox.MessageDb
+open OpenTelemetry
+open OpenTelemetry.Trace
+open OpenTelemetry.Resources
+
 let connectToLocalStore _ = async {
   let connectionString = "Host=localhost; Username=message_store; Password=; Database=message_store; Port=5433; Maximum Pool Size=10"
   let connector = MessageDbConnector(connectionString)
@@ -88,6 +93,8 @@ type Category<'event, 'state, 'context> = EventStoreCategory<'event, 'state, 'co
 #endif
 
 let createContext connection batchSize = Context(connection, batchSize = batchSize)
+
+let source = new ActivitySource("StoreIntegration")
 
 module SimplestThing =
     type Event =
@@ -143,6 +150,16 @@ module ContactPreferences =
         |> ContactPreferences.create
 
 type Tests(testOutputHelper) =
+    #if STORE_MESSAGEDB
+    let sdk =
+        Sdk.CreateTracerProviderBuilder()
+           .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(serviceName = "mdbi"))
+           .AddSource("Equinox.MessageDb")
+           .AddSource("StoreIntegration")
+           .AddSource("Npqsl")
+           .AddOtlpExporter(fun opts -> opts.Endpoint <- Uri("http://localhost:4317"))
+           .Build()
+    #endif
 
     let output = TestContext(testOutputHelper)
 
@@ -169,6 +186,7 @@ type Tests(testOutputHelper) =
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
     let ``Can roundtrip against Store, correctly batching the reads [without any optimizations]`` (ctx, skuId) = Async.RunSynchronously <| async {
+        use _ = source.StartActivity("Can roundtrip against Store, correctly batching the reads [without any optimizations]")
         let log, capture = output.CreateLoggerWithCapture()
         let! connection = connectToLocalStore log
 
@@ -198,6 +216,7 @@ type Tests(testOutputHelper) =
 
     [<AutoData(MaxTest = 2, SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
     let ``Can roundtrip against Store, managing sync conflicts by retrying [without any optimizations]`` (ctx, initialState) = Async.RunSynchronously <| async {
+        use _ = source.StartActivity("Can roundtrip against Store, managing sync conflicts by retrying [without any optimizations]")
         let log1, capture1 = output.CreateLoggerWithCapture()
 
         let! connection = connectToLocalStore log1
@@ -330,6 +349,7 @@ type Tests(testOutputHelper) =
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
     let ``Can correctly read and update against Store, with LatestKnownEvent Access Strategy`` id value = Async.RunSynchronously <| async {
+        use _ = source.StartActivity("Can correctly read and update against Store, with LatestKnownEvent Access Strategy")
         let log, capture = output.CreateLoggerWithCapture()
         let! client = connectToLocalStore log
         let service = ContactPreferences.createService log client
@@ -351,6 +371,7 @@ type Tests(testOutputHelper) =
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
     let ``Can roundtrip against Store, correctly caching to avoid redundant reads`` (ctx, skuId) = Async.RunSynchronously <| async {
+        use _ = source.StartActivity("Can roundtrip against Store, correctly caching to avoid redundant reads")
         let log, capture = output.CreateLoggerWithCapture()
         let! client = connectToLocalStore log
         let batchSize = 10
@@ -460,6 +481,7 @@ type Tests(testOutputHelper) =
 #endif
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
     let ``Version is 0-based`` () = Async.RunSynchronously <| async {
+        use _ = source.StartActivity("Version is 0-based")
         let log, _ = output.CreateLoggerWithCapture()
         let! connection = connectToLocalStore log
 
@@ -473,3 +495,8 @@ type Tests(testOutputHelper) =
             mapResult = (fun result ctx-> result, ctx.Version))
         test <@ [before; after] = [0L; 1L] @>
     }
+
+#if STORE_MESSAGEDB
+    interface IDisposable with
+      member _.Dispose() = sdk.Shutdown() |> ignore
+#endif

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -1,10 +1,10 @@
 ﻿module Equinox.Store.Integration.StoreIntegration
 
-open System.Diagnostics
 open Domain
 open FSharp.UMX
 open Serilog
 open Swensen.Unquote
+open System.Diagnostics
 open System.Threading
 open System
 

--- a/tests/Equinox.MessageDb.Integration/Equinox.MessageDb.Integration.fsproj
+++ b/tests/Equinox.MessageDb.Integration/Equinox.MessageDb.Integration.fsproj
@@ -21,6 +21,8 @@
   <ItemGroup>
     <PackageReference Include="FsCheck.xUnit" Version="2.16.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.4.0-beta.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0-beta.3" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.0" />
     <PackageReference Include="unquote" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
I'm too used to tracing to not have it 😅 .

Wonder if we can compromise on this one and add tracing in an additive way like here.

There are three activities defined: 

- TrySync: when writing to a stream
- ReadBatch: when reading from a stream
- ReadSlice: child of read batch for each slice that's fetched
- ReadLast: Reading the last event of a stream

Screenshots of the integration tests
<img width="816" alt="Screenshot 2022-11-14 at 8 43 02 PM" src="https://user-images.githubusercontent.com/3721521/201805899-e122a8be-d07d-45c8-983e-bc77a7b903a6.png">
<img width="812" alt="Screenshot 2022-11-14 at 8 43 30 PM" src="https://user-images.githubusercontent.com/3721521/201805962-5be078ad-f314-4283-aea2-0bd1e76843bd.png">
<img width="810" alt="Screenshot 2022-11-14 at 8 43 51 PM" src="https://user-images.githubusercontent.com/3721521/201806001-5aad7aec-3f27-4a1b-9fb7-eb8d529278a2.png">

