### PR TITLE
MessageDB polish and fixes

### DIFF
--- a/src/Equinox.MessageDb/MessageDbClient.fs
+++ b/src/Equinox.MessageDb/MessageDbClient.fs
@@ -104,7 +104,4 @@ type MessageDbReader internal (connectionString : string, leaderConnectionString
         cmd.Parameters.AddWithValue("BatchSize", NpgsqlDbType.Bigint, batchSize) |> ignore
         use! reader = cmd.ExecuteReaderAsync(ct)
 
-        let events = ResizeArray()
-        while reader.Read() do
-            events.Add(parseRow reader)
-        return events.ToArray() }
+        return [| while reader.Read() do parseRow reader |] }

--- a/src/Equinox.MessageDb/MessageDbClient.fs
+++ b/src/Equinox.MessageDb/MessageDbClient.fs
@@ -104,4 +104,4 @@ type MessageDbReader internal (connectionString : string, leaderConnectionString
         cmd.Parameters.AddWithValue("BatchSize", NpgsqlDbType.Bigint, batchSize) |> ignore
         use! reader = cmd.ExecuteReaderAsync(ct)
 
-        return [| while reader.Read() do parseRow reader |] }
+        return [| while reader.Read() do yield parseRow reader |] }


### PR DESCRIPTION
I did some debugging and found that Npgsql loads the chunk in memory when doing `ExecuteReadAsync` so there's no reason to use the `ReadAsync` method. The behavior now mirrors what [Npgsql.Fsharp](https://github.com/Zaid-Ajaj/Npgsql.FSharp/blob/master/src/Npgsql.FSharp.fs#L455) does

Then I also noticed that a string was being allocated by npgsql for the data and meta fields so the getting of the field as a byte[] wasn't providing any benefit. I've made the change to UTF8 bytes explicit.

It also turns out that postgres can store nullable nulls 😂 

```sql
create table if not exists test (id int not null, json jsonb, primary key (id));
insert into test(id, json) values (1, null);
insert into test(id, json) values (2, 'null');
select * from test;
 id | json
----+------
  1 |
  2 | null
(2 rows)

insert into test(id, json) values (3, '');
ERROR:  invalid input syntax for type json
LINE 1: insert into test(id, json) values (3, '');
                                              ^
DETAIL:  The input string ended unexpectedly.
CONTEXT:  JSON data, line 1:
```