### PR TITLE
Add Equinox.StreamId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - `Equinox`: `Decider.Transact`, `TransactAsync`, `TransactExAsync` overloads [#325](https://github.com/jet/equinox/pull/325)
-- `Equinox`: `StreamId` replaces usage of `FsCodec.StreamName` [#353](https://github.com/jet/equinox/pull/353)
+- `Equinox`: `Target` replaces usage of `FsCodec.StreamName` [#353](https://github.com/jet/equinox/pull/353)
 - `Equinox.LoadOption.RequireLeader`: support for requesting a consistent read of a stream [#341](https://github.com/jet/equinox/pull/341)
 - `Equinox.Core`: `Category` base class, with `Decider` and `Stream` helper `module`s [#337](https://github.com/jet/equinox/pull/337)
 - `Equinox.DeciderCore`: C# friendly equivalent of `Decider` (i.e. `Func` and `Task`) [#338](https://github.com/jet/equinox/pull/338)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - `Equinox`: `Decider.Transact`, `TransactAsync`, `TransactExAsync` overloads [#325](https://github.com/jet/equinox/pull/325)
+- `Equinox`: `StreamId` replaces usage of `FsCodec.StreamName` [#353](https://github.com/jet/equinox/pull/353)
 - `Equinox.LoadOption.RequireLeader`: support for requesting a consistent read of a stream [#341](https://github.com/jet/equinox/pull/341)
 - `Equinox.Core`: `Category` base class, with `Decider` and `Stream` helper `module`s [#337](https://github.com/jet/equinox/pull/337)
 - `Equinox.DeciderCore`: C# friendly equivalent of `Decider` (i.e. `Func` and `Task`) [#338](https://github.com/jet/equinox/pull/338)

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -316,7 +316,7 @@ module Aggregate
 (* StreamName section *)
 
 let [<Literal>] Category = "category"
-let target = Equinox.Target.gen Category Id.toString
+let streamId = Equinox.StreamId.gen Id.toString
 
 (* Optionally, Helpers/Types *)
 
@@ -546,7 +546,7 @@ brevity, that implements all the relevant functions above:
 (* Event stream naming + schemas *)
 
 let [<Literal>] Category = "Favorites"
-let target = Equinox.Target.gen Category ClientId.toString
+let streamId = Equinox.StreamId.gen ClientId.toString
 
 type Item = { id: int; name: string; added: DateTimeOffset }
 type Event =
@@ -616,7 +616,7 @@ type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.
         read clientId
 
 let create resolve : Service =
-    Service(target >> resolve)
+    Service(streamId >> resolve Category)
 ```
 
 <a name="api"></a>
@@ -831,10 +831,10 @@ context
 #### `Decider` usage
 
 ```fsharp
-let [<Literal>] Category = Favorites
-let target = Equinox.Target.gen Category id
+let [<Literal>] Category = "Favorites"
+let streamId = Equinox.StreamId.gen ClientId.toString
 
-type Service internal (resolve : string -> Equinox.Decider<Events.Event, Fold.State>) =
+type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.State>) =
 
     let execute clientId command : Async<unit> =
         let decider = resolve clientId
@@ -844,7 +844,7 @@ type Service internal (resolve : string -> Equinox.Decider<Events.Event, Fold.St
         let decider = resolve clientId
         decider.Query id
 
-let create resolve = Service(target >> resolve)
+let create resolve = Service(streamId >> resolve Category)
 ```
 
 `Read` above will do a roundtrip to the Store in order to fetch the most recent

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -451,9 +451,9 @@ events on a given category of stream:
 - `Category`: the common part of the [Stream Name](https://github.com/fscodec#streamname),
   i.e., the `"Favorites"` part of the `"Favorites-clientId"`
 
-- `streamName`: function responsible for mapping from the input elements that define the Aggregate's identity
-  to a `struct` tuple of a) the `Category` b) the `streamId` portion that's used by the Store's `Category` to obtain
-  the `Decider`. In general, the inputs should be [strongly typed ids](https://github.com/jet/FsCodec#strongly-typed-stream-ids-using-fsharpumx))
+- `streamId`: function responsible for mapping from the input elements that define the Aggregate's identity
+  to the `streamId` portion of the `{categoryName}-{streamId}` StreamName that's used within the concrete store.
+  In general, the inputs should be [strongly typed ids](https://github.com/jet/FsCodec#strongly-typed-stream-ids-using-fsharpumx)
 
 - `'event`: a discriminated union representing all the possible Events from
   which a state can be `evolve`d (see `e`vents and `u`nfolds in the

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -832,7 +832,7 @@ context
 
 ```fsharp
 let [<Literal>] Category = Favorites
-let streamName (clientId : String) = FsCodec.StreamName.create Category clientId
+let streamId = Equinox.StreamId.create Category id
 
 type Service internal (resolve : string -> Equinox.Decider<Events.Event, Fold.State>) =
 
@@ -844,7 +844,7 @@ type Service internal (resolve : string -> Equinox.Decider<Events.Event, Fold.St
         let decider = resolve clientId
         decider.Query id
 
-let create resolve = Service(streamName >> resolve)
+let create resolve = Service(streamId >> resolve)
 ```
 
 `Read` above will do a roundtrip to the Store in order to fetch the most recent

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -380,7 +380,7 @@ type Service internal (resolve : Id -> Equinox.Decider<Events.Event, Fold.State)
         let decider = resolve id
         decider.Transact(decideX inputs)
 
-let create category = Service(target >> Equinox.Decider.resolve Serilog.Log.Logger category)
+let create category = Service(streamId >> Equinox.Decider.resolve Serilog.Log.Logger category)
 ```
 
 - `Service`'s constructor is `internal`; `create` is the main way in which one
@@ -592,7 +592,7 @@ let toSnapshot state = [Event.Snapshotted (Array.ofList state)]
 (*
  * The Service defines operations in business terms, neutral to any concrete
  * store selection or implementation supplied only a `resolve` function that can
- * be used to map from ids (as supplied to the `target` function) to an
+ * be used to map from ids (as supplied to the `streamId` function) to an
  * Equinox.Decider; Typically the service should be a stateless Singleton
  *)
 
@@ -1079,7 +1079,7 @@ type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.
        and/or simplifications when compared to aspects that might present in a
        more complete implementation.
 
-- the `target` helper (and optional [`Match` Active Patterns](https://github.com/jet/fscodec#adding-matchers-to-the-event-contract))
+- the `streamId` helper (and optional [`Match` Active Patterns](https://github.com/jet/fscodec#adding-matchers-to-the-event-contract))
   provide succinct ways to map an incoming `clientId` (which is not a `string`
   in the real implementation but instead an id using
   [`FSharp.UMX`](https://github.com/fsprojects/FSharp.UMX) in an unobtrusive

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The components within this repository are delivered as multi-targeted Nuget pack
 
 ## Core library
 
-- `Equinox` [![NuGet](https://img.shields.io/nuget/v/Equinox.svg)](https://www.nuget.org/packages/Equinox/): Store-agnostic decision flow runner that manages the optimistic concurrency protocol and application-level API surface. ([depends](https://www.fuget.org/packages/Equinox) only on `FSharp.Core` v `6.0.0`
+- `Equinox` [![NuGet](https://img.shields.io/nuget/v/Equinox.svg)](https://www.nuget.org/packages/Equinox/): Store-agnostic decision flow runner that manages the optimistic concurrency protocol and application-level API surface. ([depends](https://www.fuget.org/packages/Equinox) only on `FSharp.Core` v `6.0.0`, `FSharp.UMX` v `1.1.0`
 
 ## Serialization support
 

--- a/samples/Store/Domain/Cart.fs
+++ b/samples/Store/Domain/Cart.fs
@@ -1,6 +1,6 @@
 ﻿module Domain.Cart
 
-let streamId = Equinox.StreamId.map "Cart" CartId.toString
+let target = Equinox.Target.gen "Cart" CartId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 [<RequireQualifiedAccess>]
@@ -165,4 +165,4 @@ type Service internal (resolve : CartId -> Equinox.Decider<Events.Event, Fold.St
         decider.Query(id, Equinox.LoadOption.AllowStale)
 
 let create resolve =
-    Service(streamId >> resolve)
+    Service(target >> resolve)

--- a/samples/Store/Domain/Cart.fs
+++ b/samples/Store/Domain/Cart.fs
@@ -1,6 +1,7 @@
 ﻿module Domain.Cart
 
-let target = Equinox.Target.gen "Cart" CartId.toString
+let [<Literal>] Category = "Cart"
+let streamId = Equinox.StreamId.gen CartId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 [<RequireQualifiedAccess>]
@@ -165,4 +166,4 @@ type Service internal (resolve : CartId -> Equinox.Decider<Events.Event, Fold.St
         decider.Query(id, Equinox.LoadOption.AllowStale)
 
 let create resolve =
-    Service(target >> resolve)
+    Service(streamId >> resolve Category)

--- a/samples/Store/Domain/Cart.fs
+++ b/samples/Store/Domain/Cart.fs
@@ -1,6 +1,6 @@
 ﻿module Domain.Cart
 
-let streamName (id: CartId) = struct ("Cart", CartId.toString id)
+let streamId = Equinox.StreamId.map "Cart" CartId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 [<RequireQualifiedAccess>]
@@ -165,4 +165,4 @@ type Service internal (resolve : CartId -> Equinox.Decider<Events.Event, Fold.St
         decider.Query(id, Equinox.LoadOption.AllowStale)
 
 let create resolve =
-    Service(streamName >> resolve)
+    Service(streamId >> resolve)

--- a/samples/Store/Domain/ContactPreferences.fs
+++ b/samples/Store/Domain/ContactPreferences.fs
@@ -1,7 +1,7 @@
 ﻿module Domain.ContactPreferences
 
 type Id = Id of email: string
-let streamName (Id email) = struct ("ContactPreferences", email) // TODO hash >> base64
+let streamId (Id email) = Equinox.StreamId.map "ContactPreferences" id email // TODO hash >> base64
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -57,4 +57,4 @@ type Service internal (resolve : Id -> Equinox.Decider<Events.Event, Fold.State>
         decider.Query(id, Equinox.AllowStale)
 
 let create resolve =
-    Service(streamName >> resolve)
+    Service(streamId >> resolve)

--- a/samples/Store/Domain/ContactPreferences.fs
+++ b/samples/Store/Domain/ContactPreferences.fs
@@ -1,7 +1,7 @@
 ﻿module Domain.ContactPreferences
 
 type Id = Id of email: string
-let streamId (Id email) = Equinox.StreamId.map "ContactPreferences" id email // TODO hash >> base64
+let target (Id email) = Equinox.Target.gen "ContactPreferences" id email // TODO hash >> base64
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -57,4 +57,4 @@ type Service internal (resolve : Id -> Equinox.Decider<Events.Event, Fold.State>
         decider.Query(id, Equinox.AllowStale)
 
 let create resolve =
-    Service(streamId >> resolve)
+    Service(target >> resolve)

--- a/samples/Store/Domain/ContactPreferences.fs
+++ b/samples/Store/Domain/ContactPreferences.fs
@@ -1,7 +1,10 @@
 ﻿module Domain.ContactPreferences
 
-type Id = Id of email: string
-let target (Id email) = Equinox.Target.gen "ContactPreferences" id email // TODO hash >> base64
+type ClientId = ClientId of email: string
+module ClientId = let toString (ClientId email) = email
+
+let [<Literal>] Category = "ContactPreferences"
+let streamId = Equinox.StreamId.gen ClientId.toString // TODO hash >> base64
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -38,11 +41,11 @@ let interpret command (state : Fold.State) =
         if state = preferences then [] else
         [ Events.Updated value ]
 
-type Service internal (resolve : Id -> Equinox.Decider<Events.Event, Fold.State>) =
+type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.State>) =
 
     let update email value : Async<unit> =
         let decider = resolve email
-        let command = let (Id email) = email in Update { email = email; preferences = value }
+        let command = let (ClientId email) = email in Update { email = email; preferences = value }
         decider.Transact(interpret command)
 
     member _.Update(email, value) =
@@ -57,4 +60,4 @@ type Service internal (resolve : Id -> Equinox.Decider<Events.Event, Fold.State>
         decider.Query(id, Equinox.AllowStale)
 
 let create resolve =
-    Service(target >> resolve)
+    Service(streamId >> resolve Category)

--- a/samples/Store/Domain/Favorites.fs
+++ b/samples/Store/Domain/Favorites.fs
@@ -1,6 +1,7 @@
 ﻿module Domain.Favorites
 
-let target = Equinox.Target.gen "Favorites" ClientId.toString
+let [<Literal>] Category = "Favorites"
+let streamId = Equinox.StreamId.gen ClientId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -78,4 +79,4 @@ type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.
         decider.TransactEx((fun c -> (), decideUnfavorite sku c.State), fun () c -> c.Version)
 
 let create resolve =
-    Service(target >> resolve)
+    Service(streamId >> resolve Category)

--- a/samples/Store/Domain/Favorites.fs
+++ b/samples/Store/Domain/Favorites.fs
@@ -1,6 +1,6 @@
 ﻿module Domain.Favorites
 
-let streamName (id: ClientId) = struct ("Favorites", ClientId.toString id)
+let streamId = Equinox.StreamId.map "Favorites" ClientId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -78,4 +78,4 @@ type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.
         decider.TransactEx((fun c -> (), decideUnfavorite sku c.State), fun () c -> c.Version)
 
 let create resolve =
-    Service(streamName >> resolve)
+    Service(streamId >> resolve)

--- a/samples/Store/Domain/Favorites.fs
+++ b/samples/Store/Domain/Favorites.fs
@@ -1,6 +1,6 @@
 ﻿module Domain.Favorites
 
-let streamId = Equinox.StreamId.map "Favorites" ClientId.toString
+let target = Equinox.Target.gen "Favorites" ClientId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -78,4 +78,4 @@ type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.
         decider.TransactEx((fun c -> (), decideUnfavorite sku c.State), fun () c -> c.Version)
 
 let create resolve =
-    Service(streamId >> resolve)
+    Service(target >> resolve)

--- a/samples/Store/Domain/InventoryItem.fs
+++ b/samples/Store/Domain/InventoryItem.fs
@@ -3,7 +3,8 @@ module Domain.InventoryItem
 
 open System
 
-let target = Equinox.Target.gen "InventoryItem" InventoryItemId.toString
+let [<Literal>] Category = "InventoryItem"
+let streamId = Equinox.StreamId.gen InventoryItemId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -67,4 +68,4 @@ type Service internal (resolve : InventoryItemId -> Equinox.Decider<Events.Event
         decider.Query id
 
 let create resolve =
-    Service(target >> resolve)
+    Service(streamId >> resolve Category)

--- a/samples/Store/Domain/InventoryItem.fs
+++ b/samples/Store/Domain/InventoryItem.fs
@@ -3,7 +3,7 @@ module Domain.InventoryItem
 
 open System
 
-let streamName (id : InventoryItemId) = struct ("InventoryItem", InventoryItemId.toString id)
+let target = Equinox.Target.gen "InventoryItem" InventoryItemId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -67,4 +67,4 @@ type Service internal (resolve : InventoryItemId -> Equinox.Decider<Events.Event
         decider.Query id
 
 let create resolve =
-    Service(streamName >> resolve)
+    Service(target >> resolve)

--- a/samples/Store/Domain/SavedForLater.fs
+++ b/samples/Store/Domain/SavedForLater.fs
@@ -3,7 +3,8 @@
 open System
 open System.Collections.Generic
 
-let target = Equinox.Target.gen "SavedForLater" ClientId.toString
+let [<Literal>] Category = "SavedForLater"
+let streamId = Equinox.StreamId.gen ClientId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -143,4 +144,4 @@ type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.
         return! execute targetId (Merge state) }
 
 let create maxSavedItems resolve =
-    Service(target >> resolve, maxSavedItems)
+    Service(streamId >> resolve Category, maxSavedItems)

--- a/samples/Store/Domain/SavedForLater.fs
+++ b/samples/Store/Domain/SavedForLater.fs
@@ -3,7 +3,7 @@
 open System
 open System.Collections.Generic
 
-let streamName (id: ClientId) = struct ("SavedForLater", ClientId.toString id)
+let streamId = Equinox.StreamId.map "SavedForLater" ClientId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -143,4 +143,4 @@ type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.
         return! execute targetId (Merge state) }
 
 let create maxSavedItems resolve =
-    Service(streamName >> resolve, maxSavedItems)
+    Service(streamId >> resolve, maxSavedItems)

--- a/samples/Store/Domain/SavedForLater.fs
+++ b/samples/Store/Domain/SavedForLater.fs
@@ -3,7 +3,7 @@
 open System
 open System.Collections.Generic
 
-let streamId = Equinox.StreamId.map "SavedForLater" ClientId.toString
+let target = Equinox.Target.gen "SavedForLater" ClientId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -143,4 +143,4 @@ type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.
         return! execute targetId (Merge state) }
 
 let create maxSavedItems resolve =
-    Service(streamId >> resolve, maxSavedItems)
+    Service(target >> resolve, maxSavedItems)

--- a/samples/Store/Integration/CartIntegration.fs
+++ b/samples/Store/Integration/CartIntegration.fs
@@ -12,8 +12,8 @@ let snapshot = Cart.Fold.isOrigin, Cart.Fold.snapshot
 let createMemoryStore () = MemoryStore.VolatileStore<ReadOnlyMemory<byte>>()
 let createServiceMemory log store =
     MemoryStore.MemoryStoreCategory(store, Cart.Events.codec, fold, initial)
-    |> Decider.resolve Serilog.Log.Logger |> Cart.create
-
+    |> Decider.resolve log
+    |> Cart.create
 
 let codec = Cart.Events.codec
 let codecJe = Cart.Events.codecJe

--- a/samples/Store/Integration/Infrastructure.fs
+++ b/samples/Store/Integration/Infrastructure.fs
@@ -9,5 +9,5 @@ type FsCheckGenerators =
     static member ContactPreferencesId =
         Arb.generate<Guid>
         |> Gen.map (fun x -> sprintf "%s@test.com" (x.ToString("N")))
-        |> Gen.map ContactPreferences.Id
+        |> Gen.map ContactPreferences.ClientId
         |> Arb.fromGen

--- a/samples/TodoBackend/Todo.fs
+++ b/samples/TodoBackend/Todo.fs
@@ -5,7 +5,7 @@ open Domain
 // The TodoBackend spec does not dictate having multiple lists, tenants or clients
 // Here, we implement such a discriminator in order to allow each virtual client to maintain independent state
 let Category = "Todos"
-let streamId = Equinox.StreamId.map Category ClientId.toString
+let target = Equinox.Target.gen Category ClientId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -80,4 +80,4 @@ type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.
         let! state' = handle clientId (Command.Update item)
         return List.find (fun x -> x.id = item.id) state' }
 
-let create resolve = Service(streamId >> resolve)
+let create resolve = Service(target >> resolve)

--- a/samples/TodoBackend/Todo.fs
+++ b/samples/TodoBackend/Todo.fs
@@ -4,8 +4,8 @@ open Domain
 
 // The TodoBackend spec does not dictate having multiple lists, tenants or clients
 // Here, we implement such a discriminator in order to allow each virtual client to maintain independent state
-let Category = "Todos"
-let target = Equinox.Target.gen Category ClientId.toString
+let [<Literal>] Category = "Todos"
+let streamId = Equinox.StreamId.gen ClientId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -80,4 +80,4 @@ type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.
         let! state' = handle clientId (Command.Update item)
         return List.find (fun x -> x.id = item.id) state' }
 
-let create resolve = Service(target >> resolve)
+let create resolve = Service(streamId >> resolve Category)

--- a/samples/TodoBackend/Todo.fs
+++ b/samples/TodoBackend/Todo.fs
@@ -5,7 +5,7 @@ open Domain
 // The TodoBackend spec does not dictate having multiple lists, tenants or clients
 // Here, we implement such a discriminator in order to allow each virtual client to maintain independent state
 let Category = "Todos"
-let streamName (id : ClientId) = struct (Category, ClientId.toString id)
+let streamId = Equinox.StreamId.map Category ClientId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -80,4 +80,4 @@ type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.
         let! state' = handle clientId (Command.Update item)
         return List.find (fun x -> x.id = item.id) state' }
 
-let create resolve = Service(streamName >> resolve)
+let create resolve = Service(streamId >> resolve)

--- a/samples/Tutorial/AsAt.fsx
+++ b/samples/Tutorial/AsAt.fsx
@@ -177,8 +177,8 @@ module Cosmos =
     let cat = CosmosStoreCategory(context, Events.codecJe, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
     let resolve = Equinox.Decider.resolve Log.log cat
 
-let service = Service(target >> EventStore.resolve)
-//let service= Service(target >> Cosmos.resolve)
+let service = Service(streamId >> EventStore.resolve)
+//let service= Service(streamId >> Cosmos.resolve)
 
 let client = "ClientA"
 service.Add(client, 1) |> Async.RunSynchronously

--- a/samples/Tutorial/AsAt.fsx
+++ b/samples/Tutorial/AsAt.fsx
@@ -45,7 +45,7 @@
 #endif
 open System
 
-let streamName clientId = struct ("Account", clientId)
+let target = Equinox.Target.gen "Account" id
 
 module Events =
 
@@ -176,8 +176,8 @@ module Cosmos =
     let cat = CosmosStoreCategory(context, Events.codecJe, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
     let resolve = Equinox.Decider.resolve Log.log cat
 
-let service = Service(streamName >> EventStore.resolve)
-//let service= Service(streamName >> Cosmos.resolve)
+let service = Service(target >> EventStore.resolve)
+//let service= Service(target >> Cosmos.resolve)
 
 let client = "ClientA"
 service.Add(client, 1) |> Async.RunSynchronously

--- a/samples/Tutorial/AsAt.fsx
+++ b/samples/Tutorial/AsAt.fsx
@@ -45,7 +45,8 @@
 #endif
 open System
 
-let target = Equinox.Target.gen "Account" id
+let [<Literal>] Category = "Account"
+let streamId = Equinox.StreamId.gen id
 
 module Events =
 

--- a/samples/Tutorial/Cosmos.fsx
+++ b/samples/Tutorial/Cosmos.fsx
@@ -83,7 +83,7 @@ module Favorites =
             let decider = resolve clientId
             decider.Query id
 
-    let create resolve = Service(target >> resolve)
+    let create resolve = Service(streamId >> resolve Category)
 
     module Cosmos =
 

--- a/samples/Tutorial/Cosmos.fsx
+++ b/samples/Tutorial/Cosmos.fsx
@@ -43,7 +43,7 @@ module Log =
 module Favorites =
 
     let Category = "Favorites"
-    let streamName clientId = struct (Category, clientId)
+    let target = Equinox.Target.gen Category id
 
     module Events =
 
@@ -83,7 +83,7 @@ module Favorites =
             let decider = resolve clientId
             decider.Query id
 
-    let create resolve = Service(streamName >> resolve)
+    let create resolve = Service(target >> resolve)
 
     module Cosmos =
 

--- a/samples/Tutorial/Cosmos.fsx
+++ b/samples/Tutorial/Cosmos.fsx
@@ -43,7 +43,7 @@ module Log =
 module Favorites =
 
     let Category = "Favorites"
-    let target = Equinox.Target.gen Category id
+    let streamId = Equinox.StreamId.gen id
 
     module Events =
 

--- a/samples/Tutorial/Counter.fsx
+++ b/samples/Tutorial/Counter.fsx
@@ -30,7 +30,8 @@ type Event =
     | Cleared of Cleared
     interface TypeShape.UnionContract.IUnionContract
 (* Kind of DDD aggregate ID *)
-let streamName (id : string) = struct ("Counter", id)
+let streamName (id : string) = let streamId id = Equinox.StreamId.map Category SequenceId.toString
+
 
 type State = State of int
 let initial : State = State 0

--- a/samples/Tutorial/Favorites.fsx
+++ b/samples/Tutorial/Favorites.fsx
@@ -101,7 +101,7 @@ let store = Equinox.MemoryStore.VolatileStore()
 // For demo purposes we emit those to the log (which emits to the console)
 let logEvents stream (events : FsCodec.ITimelineEvent<_>[]) =
     log.Information("Committed to {stream}, events: {@events}", stream, seq { for x in events -> x.EventType })
-let _ = store.Committed.Subscribe(fun (s, xs) -> logEvents s xs)
+let _ = store.Committed.Subscribe(fun struct (c, s, xs) -> logEvents c s xs)
 
 let codec =
     // For this example, we hand-code; normally one uses one of the FsCodec auto codecs, which codegen something similar
@@ -158,8 +158,9 @@ type Service(deciderFor : string -> Handler) =
 
 (* See Counter.fsx and Cosmos.fsx for a more compact representation which makes the Handler wiring less obtrusive *)
 let streamFor (clientId: string) =
-    let target = Equinox.Target.gen "Favorites" id clientId
-    let decider = Equinox.Decider.resolve log cat target
+    let [<Literal>] Category = "Favorites"
+    let streamId = Equinox.StreamId.gen id
+    let decider = Equinox.Decider.resolve log cat Category streamId 
     Handler(decider)
 
 let service = Service(streamFor)

--- a/samples/Tutorial/Favorites.fsx
+++ b/samples/Tutorial/Favorites.fsx
@@ -158,8 +158,8 @@ type Service(deciderFor : string -> Handler) =
 
 (* See Counter.fsx and Cosmos.fsx for a more compact representation which makes the Handler wiring less obtrusive *)
 let streamFor (clientId: string) =
-    let streamIds = struct ("Favorites", clientId)
-    let decider = Equinox.Decider.resolve log cat streamIds
+    let target = Equinox.Target.gen "Favorites" id clientId
+    let decider = Equinox.Decider.resolve log cat target
     Handler(decider)
 
 let service = Service(streamFor)

--- a/samples/Tutorial/FulfilmentCenter.fsx
+++ b/samples/Tutorial/FulfilmentCenter.fsx
@@ -50,7 +50,7 @@ module Types =
 
 module FulfilmentCenter =
 
-    let streamName id = struct ("FulfilmentCenter", id)
+    let target = Equinox.Target.gen "FulfilmentCenter"
 
     module Events =
 
@@ -146,7 +146,7 @@ let service =
     let resolve =
         CosmosStoreCategory(Store.context, Events.codec, Fold.fold, Fold.initial, Store.cacheStrategy, AccessStrategy.Unoptimized)
         |> Equinox.Decider.resolve Log.log
-    Service(streamName >> resolve)
+    Service(target >> resolve)
 
 let fc = "fc0"
 service.UpdateName(fc, { code="FC000"; name="Head" }) |> Async.RunSynchronously
@@ -157,7 +157,7 @@ Log.dumpMetrics ()
 /// Manages ingestion of summary events tagged with the version emitted from FulfilmentCenter.Service.QueryWithVersion
 module FulfilmentCenterSummary =
 
-    let streamName id = struct ("FulfilmentCenterSummary", id)
+    let target = Equinox.Target.gen "FulfilmentCenterSummary" id
 
     module Events =
         type UpdatedData = { version : int64; state : Summary }

--- a/samples/Tutorial/FulfilmentCenter.fsx
+++ b/samples/Tutorial/FulfilmentCenter.fsx
@@ -50,7 +50,8 @@ module Types =
 
 module FulfilmentCenter =
 
-    let target = Equinox.Target.gen "FulfilmentCenter"
+    let [<Literal>] Category = "FulfilmentCenter"
+    let streamId = Equinox.StreamId.gen id
 
     module Events =
 
@@ -157,7 +158,8 @@ Log.dumpMetrics ()
 /// Manages ingestion of summary events tagged with the version emitted from FulfilmentCenter.Service.QueryWithVersion
 module FulfilmentCenterSummary =
 
-    let target = Equinox.Target.gen "FulfilmentCenterSummary" id
+    let [<Literal>] Category = "FulfilmentCenter"
+    let streamId = Equinox.StreamId.gen id
 
     module Events =
         type UpdatedData = { version : int64; state : Summary }

--- a/samples/Tutorial/FulfilmentCenter.fsx
+++ b/samples/Tutorial/FulfilmentCenter.fsx
@@ -146,7 +146,7 @@ let service =
     let resolve =
         CosmosStoreCategory(Store.context, Events.codec, Fold.fold, Fold.initial, Store.cacheStrategy, AccessStrategy.Unoptimized)
         |> Equinox.Decider.resolve Log.log
-    Service(target >> resolve)
+    Service(streamId >> resolve Category)
 
 let fc = "fc0"
 service.UpdateName(fc, { code="FC000"; name="Head" }) |> Async.RunSynchronously

--- a/samples/Tutorial/Gapless.fs
+++ b/samples/Tutorial/Gapless.fs
@@ -5,7 +5,7 @@ module Gapless
 open System
 
 let [<Literal>] Category = "Gapless"
-let target = Equinox.StreamId.gen SequenceId.toString
+let streamId = Equinox.StreamId.gen SequenceId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -80,7 +80,7 @@ module Cosmos =
     let private create (context, cache, accessStrategy) =
         let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
         let cat = CosmosStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
-        Service(target >> Equinox.Decider.resolve Serilog.Log.Logger cat Category)
+        Service(streamId >> Equinox.Decider.resolve Serilog.Log.Logger cat Category)
 
     module Snapshot =
 

--- a/samples/Tutorial/Gapless.fs
+++ b/samples/Tutorial/Gapless.fs
@@ -5,7 +5,7 @@ module Gapless
 open System
 
 let [<Literal>] Category = "Gapless"
-let streamId id = Equinox.StreamId.map Category SequenceId.toString id
+let target = Equinox.Target.gen Category SequenceId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -80,7 +80,7 @@ module Cosmos =
     let private create (context, cache, accessStrategy) =
         let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
         let cat = CosmosStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
-        Service(streamId >> Equinox.Decider.resolve Serilog.Log.Logger cat)
+        Service(target >> Equinox.Decider.resolve Serilog.Log.Logger cat)
 
     module Snapshot =
 

--- a/samples/Tutorial/Gapless.fs
+++ b/samples/Tutorial/Gapless.fs
@@ -5,7 +5,7 @@ module Gapless
 open System
 
 let [<Literal>] Category = "Gapless"
-let target = Equinox.Target.gen Category SequenceId.toString
+let target = Equinox.StreamId.gen SequenceId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -80,7 +80,7 @@ module Cosmos =
     let private create (context, cache, accessStrategy) =
         let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
         let cat = CosmosStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
-        Service(target >> Equinox.Decider.resolve Serilog.Log.Logger cat)
+        Service(target >> Equinox.Decider.resolve Serilog.Log.Logger cat Category)
 
     module Snapshot =
 

--- a/samples/Tutorial/Gapless.fs
+++ b/samples/Tutorial/Gapless.fs
@@ -5,7 +5,7 @@ module Gapless
 open System
 
 let [<Literal>] Category = "Gapless"
-let streamName id = struct (Category, SequenceId.toString id)
+let streamId id = Equinox.StreamId.map Category SequenceId.toString id
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -80,7 +80,7 @@ module Cosmos =
     let private create (context, cache, accessStrategy) =
         let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
         let cat = CosmosStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
-        Service(streamName >> Equinox.Decider.resolve Serilog.Log.Logger cat)
+        Service(streamId >> Equinox.Decider.resolve Serilog.Log.Logger cat)
 
     module Snapshot =
 

--- a/samples/Tutorial/Index.fs
+++ b/samples/Tutorial/Index.fs
@@ -1,7 +1,7 @@
 module Index
 
 let [<Literal>] Category = "Index"
-let streamId id = Equinox.StreamId.map Category IndexId.toString id
+let target id = Equinox.Target.gen Category IndexId.toString id
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -46,7 +46,7 @@ type Service<'t> internal (decider : Equinox.Decider<Events.Event<'t>, Fold.Stat
         decider.Query id
 
 let create<'t> resolve indexId =
-    Service(streamId indexId |> resolve)
+    Service(target indexId |> resolve)
 
 module Cosmos =
 

--- a/samples/Tutorial/Index.fs
+++ b/samples/Tutorial/Index.fs
@@ -1,7 +1,7 @@
 module Index
 
 let [<Literal>] Category = "Index"
-let streamName indexId = struct (Category, IndexId.toString indexId)
+let streamId id = Equinox.StreamId.map Category IndexId.toString id
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -46,7 +46,7 @@ type Service<'t> internal (decider : Equinox.Decider<Events.Event<'t>, Fold.Stat
         decider.Query id
 
 let create<'t> resolve indexId =
-    Service(streamName indexId |> resolve)
+    Service(streamId indexId |> resolve)
 
 module Cosmos =
 

--- a/samples/Tutorial/Index.fs
+++ b/samples/Tutorial/Index.fs
@@ -1,7 +1,7 @@
 module Index
 
 let [<Literal>] Category = "Index"
-let target id = Equinox.Target.gen Category IndexId.toString id
+let streamId = Equinox.StreamId.gen IndexId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -46,7 +46,7 @@ type Service<'t> internal (decider : Equinox.Decider<Events.Event<'t>, Fold.Stat
         decider.Query id
 
 let create<'t> resolve indexId =
-    Service(target indexId |> resolve)
+    Service(streamId indexId |> resolve Category)
 
 module Cosmos =
 

--- a/samples/Tutorial/Sequence.fs
+++ b/samples/Tutorial/Sequence.fs
@@ -5,7 +5,7 @@ module Sequence
 open System
 
 let [<Literal>] Category = "Sequence"
-let target = Equinox.Target.gen Category SequenceId.toString
+let streamId = Equinox.StreamId.gen SequenceId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -36,7 +36,7 @@ type Service internal (resolve : SequenceId -> Equinox.Decider<Events.Event, Fol
         let decider = resolve series
         decider.Transact(decideReserve (defaultArg count 1))
 
-let create resolve = Service(target >> resolve)
+let create resolve = Service(streamId >> resolve Category)
 
 module Cosmos =
 

--- a/samples/Tutorial/Sequence.fs
+++ b/samples/Tutorial/Sequence.fs
@@ -5,7 +5,7 @@ module Sequence
 open System
 
 let [<Literal>] Category = "Sequence"
-let streamName id = struct (Category, SequenceId.toString id)
+let streamId = Equinox.StreamId.map Category SequenceId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -36,7 +36,7 @@ type Service internal (resolve : SequenceId -> Equinox.Decider<Events.Event, Fol
         let decider = resolve series
         decider.Transact(decideReserve (defaultArg count 1))
 
-let create resolve = Service(streamName >> resolve)
+let create resolve = Service(streamId >> resolve)
 
 module Cosmos =
 

--- a/samples/Tutorial/Sequence.fs
+++ b/samples/Tutorial/Sequence.fs
@@ -5,7 +5,7 @@ module Sequence
 open System
 
 let [<Literal>] Category = "Sequence"
-let streamId = Equinox.StreamId.map Category SequenceId.toString
+let target = Equinox.Target.gen Category SequenceId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -36,7 +36,7 @@ type Service internal (resolve : SequenceId -> Equinox.Decider<Events.Event, Fol
         let decider = resolve series
         decider.Transact(decideReserve (defaultArg count 1))
 
-let create resolve = Service(streamId >> resolve)
+let create resolve = Service(target >> resolve)
 
 module Cosmos =
 

--- a/samples/Tutorial/Set.fs
+++ b/samples/Tutorial/Set.fs
@@ -1,7 +1,7 @@
 module Set
 
 let [<Literal>] Category = "Set"
-let streamId id = Equinox.StreamId.map Category SetId.toString id
+let target = Equinox.Target.gen Category SetId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -47,7 +47,7 @@ type Service internal (decider : Equinox.Decider<Events.Event, Fold.State>) =
         decider.Query id
 
 let create resolve setId =
-    Service(streamId setId |> resolve)
+    Service(target setId |> resolve)
 
 module Cosmos =
 

--- a/samples/Tutorial/Set.fs
+++ b/samples/Tutorial/Set.fs
@@ -1,7 +1,7 @@
 module Set
 
 let [<Literal>] Category = "Set"
-let streamName id = struct (Category, SetId.toString id)
+let streamId id = Equinox.StreamId.map Category SetId.toString id
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -47,7 +47,7 @@ type Service internal (decider : Equinox.Decider<Events.Event, Fold.State>) =
         decider.Query id
 
 let create resolve setId =
-    Service(streamName setId |> resolve)
+    Service(streamId setId |> resolve)
 
 module Cosmos =
 

--- a/samples/Tutorial/Set.fs
+++ b/samples/Tutorial/Set.fs
@@ -1,7 +1,7 @@
 module Set
 
 let [<Literal>] Category = "Set"
-let target = Equinox.Target.gen Category SetId.toString
+let streamId = Equinox.StreamId.gen SetId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -47,7 +47,7 @@ type Service internal (decider : Equinox.Decider<Events.Event, Fold.State>) =
         decider.Query id
 
 let create resolve setId =
-    Service(target setId |> resolve)
+    Service(streamId setId |> resolve Category)
 
 module Cosmos =
 

--- a/samples/Tutorial/Todo.fsx
+++ b/samples/Tutorial/Todo.fsx
@@ -29,7 +29,7 @@ open System
    This tutorial stresses different aspects *)
 
 let Category = "Todos"
-let target = Equinox.Target.gen Category id
+let streamId = Equinox.StreamId.gen id
 
 type Todo =             { id: int; order: int; title: string; completed: bool }
 type DeletedInfo =      { id: int }
@@ -139,7 +139,7 @@ module TodosCategory =
     let resolve = CosmosStoreCategory(Store.context, codec, fold, initial, Store.cacheStrategy, access=access)
                   |> Equinox.Decider.resolve log
 
-let service = Service(target >> TodosCategory.resolve)
+let service = Service(streamId >> TodosCategory.resolve Category)
 
 let client = "ClientJ"
 let item = { id = 0; order = 0; title = "Feed cat"; completed = false }

--- a/samples/Tutorial/Todo.fsx
+++ b/samples/Tutorial/Todo.fsx
@@ -29,7 +29,7 @@ open System
    This tutorial stresses different aspects *)
 
 let Category = "Todos"
-let streamName (id : string) = struct (Category, id)
+let target = Equinox.Target.gen Category id
 
 type Todo =             { id: int; order: int; title: string; completed: bool }
 type DeletedInfo =      { id: int }
@@ -139,7 +139,7 @@ module TodosCategory =
     let resolve = CosmosStoreCategory(Store.context, codec, fold, initial, Store.cacheStrategy, access=access)
                   |> Equinox.Decider.resolve log
 
-let service = Service(streamName >> TodosCategory.resolve)
+let service = Service(target >> TodosCategory.resolve)
 
 let client = "ClientJ"
 let item = { id = 0; order = 0; title = "Feed cat"; completed = false }

--- a/samples/Tutorial/Upload.fs
+++ b/samples/Tutorial/Upload.fs
@@ -15,7 +15,7 @@ module CompanyId =
     let toString (value : CompanyId) : string = %value
 
 let [<Literal>] Category = "Upload"
-let target = Equinox.Target.gen2 Category CompanyId.toString PurchaseOrderId.toString
+let streamId = Equinox.StreamId.gen2 CompanyId.toString PurchaseOrderId.toString
 
 type UploadId = string<uploadId>
 and [<Measure>] uploadId
@@ -52,7 +52,7 @@ type Service internal (resolve : struct (CompanyId * PurchaseOrderId) -> Equinox
         let decider = resolve (companyId, purchaseOrderId)
         decider.Transact(decide value)
 
-let create resolve = Service(target >> resolve)
+let create resolve = Service(streamId >> resolve Category)
 
 module Cosmos =
 

--- a/samples/Tutorial/Upload.fs
+++ b/samples/Tutorial/Upload.fs
@@ -46,7 +46,7 @@ let decide (value : UploadId) (state : Fold.State) : Choice<UploadId,UploadId> *
     | None -> Choice1Of2 value, [Events.IdAssigned { value = value}]
     | Some value -> Choice2Of2 value, []
 
-type Service internal (resolve : CompanyId * PurchaseOrderId -> Equinox.Decider<Events.Event, Fold.State>) =
+type Service internal (resolve : struct (CompanyId * PurchaseOrderId) -> Equinox.Decider<Events.Event, Fold.State>) =
 
     member _.Sync(companyId, purchaseOrderId, value) : Async<Choice<UploadId,UploadId>> =
         let decider = resolve (companyId, purchaseOrderId)

--- a/samples/Tutorial/Upload.fs
+++ b/samples/Tutorial/Upload.fs
@@ -15,7 +15,7 @@ module CompanyId =
     let toString (value : CompanyId) : string = %value
 
 let [<Literal>] Category = "Upload"
-let streamName (companyId, purchaseOrderId) = struct (Category, FsCodec.StreamName.createStreamId [PurchaseOrderId.toString purchaseOrderId; CompanyId.toString companyId])
+let streamId = Equinox.StreamId.map2 Category CompanyId.toString PurchaseOrderId.toString
 
 type UploadId = string<uploadId>
 and [<Measure>] uploadId
@@ -52,7 +52,7 @@ type Service internal (resolve : CompanyId * PurchaseOrderId -> Equinox.Decider<
         let decider = resolve (companyId, purchaseOrderId)
         decider.Transact(decide value)
 
-let create resolve = Service(streamName >> resolve)
+let create resolve = Service(streamId >> resolve)
 
 module Cosmos =
 

--- a/samples/Tutorial/Upload.fs
+++ b/samples/Tutorial/Upload.fs
@@ -15,7 +15,7 @@ module CompanyId =
     let toString (value : CompanyId) : string = %value
 
 let [<Literal>] Category = "Upload"
-let streamId = Equinox.StreamId.map2 Category CompanyId.toString PurchaseOrderId.toString
+let target = Equinox.Target.gen2 Category CompanyId.toString PurchaseOrderId.toString
 
 type UploadId = string<uploadId>
 and [<Measure>] uploadId
@@ -52,7 +52,7 @@ type Service internal (resolve : struct (CompanyId * PurchaseOrderId) -> Equinox
         let decider = resolve (companyId, purchaseOrderId)
         decider.Transact(decide value)
 
-let create resolve = Service(streamId >> resolve)
+let create resolve = Service(target >> resolve)
 
 module Cosmos =
 

--- a/src/Equinox.Core/Category.fs
+++ b/src/Equinox.Core/Category.fs
@@ -46,7 +46,7 @@ type Category<'event, 'state, 'context>(
 type private Stream =
 
     static member Resolve(cat : Category<'event, 'state, 'context>, log, context) : System.Func<Target, Core.IStream<'event, 'state>> =
-        System.Func<_, _>(fun target -> cat.Stream(log, context, target.categoryName, target.streamId))
+        System.Func<_, _>(fun target -> cat.Stream(log, context, target.category, target.streamId))
 
 [<System.Runtime.CompilerServices.Extension>]
 type DeciderCore =

--- a/src/Equinox.Core/Category.fs
+++ b/src/Equinox.Core/Category.fs
@@ -56,7 +56,7 @@ type DeciderCore =
         DeciderCore.Resolve(cat, log, ())
 
 module Decider =
-    let resolveWithContext log (cat : Category<'event, 'state, 'context>) context categoryName streamId =
+    let resolveWithContext log (cat : Category<'event, 'state, 'context>) categoryName context streamId =
         DeciderCore.Resolve(cat, log, context).Invoke(categoryName, streamId) |> Decider
     let resolve log (cat : Category<'event, 'state, unit>) categoryName streamId =
-        resolveWithContext log cat () categoryName streamId
+        resolveWithContext log cat categoryName () streamId

--- a/src/Equinox.Core/Category.fs
+++ b/src/Equinox.Core/Category.fs
@@ -45,20 +45,20 @@ type Category<'event, 'state, 'context>(
 
 type private Stream =
 
-    static member Resolve(cat : Category<'event, 'state, 'context>, log, context) : System.Func<StreamId, Core.IStream<'event, 'state>> =
-        System.Func<_, _>(fun sid -> cat.Stream(log, context, sid.categoryName, sid.streamId))
+    static member Resolve(cat : Category<'event, 'state, 'context>, log, context) : System.Func<Target, Core.IStream<'event, 'state>> =
+        System.Func<_, _>(fun target -> cat.Stream(log, context, target.categoryName, target.streamId))
 
 [<System.Runtime.CompilerServices.Extension>]
 type DeciderCore =
     [<System.Runtime.CompilerServices.Extension>]
-    static member Resolve(cat : Category<'event, 'state, 'context>, log, context) : System.Func<StreamId, DeciderCore<'event, 'state>> =
+    static member Resolve(cat : Category<'event, 'state, 'context>, log, context) : System.Func<Target, DeciderCore<'event, 'state>> =
          Stream.Resolve(cat, log, context).Invoke >> DeciderCore
     [<System.Runtime.CompilerServices.Extension>]
-    static member Resolve(cat : Category<'event, 'state, unit>, log) : System.Func<StreamId, DeciderCore<'event, 'state>> =
+    static member Resolve(cat : Category<'event, 'state, unit>, log) : System.Func<Target, DeciderCore<'event, 'state>> =
         DeciderCore.Resolve(cat, log, ())
 
 module Decider =
     let resolveWithContext log (cat : Category<'event, 'state, 'context>) context =
         DeciderCore.Resolve(cat, log, context).Invoke >> Decider
-    let resolve log (cat : Category<'event, 'state, unit>) sid =
-        resolveWithContext log cat () sid
+    let resolve log (cat : Category<'event, 'state, unit>) =
+        resolveWithContext log cat ()

--- a/src/Equinox.Core/Infrastructure.fs
+++ b/src/Equinox.Core/Infrastructure.fs
@@ -67,3 +67,13 @@ module Seq =
 module Array =
 
     let inline chooseV f xs = [| for item in xs do match f item with ValueSome v -> yield v | ValueNone -> () |]
+
+module StreamName =
+
+    /// Throws if a candidate category includes a '-', is null, or is empty
+    let inline validateCategoryName (rawCategory : string) =
+        if rawCategory |> System.String.IsNullOrEmpty then invalidArg "rawCategory" "may not be null or empty"
+        if rawCategory.IndexOf '-' <> -1 then invalidArg "rawCategory" "may not contain embedded '-' symbols"
+    let render categoryName streamId =
+        validateCategoryName categoryName
+        System.String.Concat(categoryName, '-', streamId)

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -1296,7 +1296,7 @@ type CosmosStoreClient
         [<O; D null>] ?archiveDatabaseId,
         // Container Name to use for locating missing events. Default: use <c>containerId</c>
         [<O; D null>] ?archiveContainerId) =
-        let genStreamName (categoryName, streamId) = if categoryName = null then streamId else Equinox.StreamId.Render(categoryName, streamId)
+        let genStreamName (categoryName, streamId) = if categoryName = null then streamId else Equinox.Target.Render(categoryName, streamId)
         let catAndStreamToDatabaseContainerStream (categoryName, streamId) = databaseId, containerId, genStreamName (categoryName, streamId)
         let primaryContainer (d, c) = (client : CosmosClient).GetDatabase(d).GetContainer(c)
         let fallbackContainer =

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -1296,9 +1296,7 @@ type CosmosStoreClient
         [<O; D null>] ?archiveDatabaseId,
         // Container Name to use for locating missing events. Default: use <c>containerId</c>
         [<O; D null>] ?archiveContainerId) =
-        let genStreamName (categoryName, streamId) =
-            if categoryName = null then streamId
-            else FsCodec.StreamName.Internal.ofCategoryAndStreamId (categoryName, streamId)
+        let genStreamName (categoryName, streamId) = if categoryName = null then streamId else Equinox.StreamId.Render(categoryName, streamId)
         let catAndStreamToDatabaseContainerStream (categoryName, streamId) = databaseId, containerId, genStreamName (categoryName, streamId)
         let primaryContainer (d, c) = (client : CosmosClient).GetDatabase(d).GetContainer(c)
         let fallbackContainer =

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -1296,7 +1296,7 @@ type CosmosStoreClient
         [<O; D null>] ?archiveDatabaseId,
         // Container Name to use for locating missing events. Default: use <c>containerId</c>
         [<O; D null>] ?archiveContainerId) =
-        let genStreamName (categoryName, streamId) = if categoryName = null then streamId else Equinox.Target.Render(categoryName, streamId)
+        let genStreamName (categoryName, streamId) = if categoryName = null then streamId else StreamName.render categoryName streamId
         let catAndStreamToDatabaseContainerStream (categoryName, streamId) = databaseId, containerId, genStreamName (categoryName, streamId)
         let primaryContainer (d, c) = (client : CosmosClient).GetDatabase(d).GetContainer(c)
         let fallbackContainer =

--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -1252,7 +1252,7 @@ type DynamoStoreClient
             [<O; D null>] ?archiveTableName,
             // Client to use for archive store. Default: (if <c>archiveTableName</c> specified) use same <c>archiveTableName</c> but via <c>client</c>.
             [<O; D null>] ?archiveClient : Amazon.DynamoDBv2.IAmazonDynamoDB) =
-        let genStreamName (categoryName, streamId) = if categoryName = null then streamId else Equinox.Target.Render(categoryName, streamId)
+        let genStreamName (categoryName, streamId) = if categoryName = null then streamId else StreamName.render categoryName streamId
         let catAndStreamToTableStream (categoryName, streamId) = tableName, genStreamName (categoryName, streamId)
         let primaryContainer t = Container.Create(client, t)
         let fallbackContainer =

--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -1252,9 +1252,7 @@ type DynamoStoreClient
             [<O; D null>] ?archiveTableName,
             // Client to use for archive store. Default: (if <c>archiveTableName</c> specified) use same <c>archiveTableName</c> but via <c>client</c>.
             [<O; D null>] ?archiveClient : Amazon.DynamoDBv2.IAmazonDynamoDB) =
-        let genStreamName (categoryName, streamId) =
-            if categoryName = null then streamId else
-            FsCodec.StreamName.Internal.ofCategoryAndStreamId (categoryName, streamId)
+        let genStreamName (categoryName, streamId) = if categoryName = null then streamId else Equinox.StreamId.Render(categoryName, streamId)
         let catAndStreamToTableStream (categoryName, streamId) = tableName, genStreamName (categoryName, streamId)
         let primaryContainer t = Container.Create(client, t)
         let fallbackContainer =

--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -1252,7 +1252,7 @@ type DynamoStoreClient
             [<O; D null>] ?archiveTableName,
             // Client to use for archive store. Default: (if <c>archiveTableName</c> specified) use same <c>archiveTableName</c> but via <c>client</c>.
             [<O; D null>] ?archiveClient : Amazon.DynamoDBv2.IAmazonDynamoDB) =
-        let genStreamName (categoryName, streamId) = if categoryName = null then streamId else Equinox.StreamId.Render(categoryName, streamId)
+        let genStreamName (categoryName, streamId) = if categoryName = null then streamId else Equinox.Target.Render(categoryName, streamId)
         let catAndStreamToTableStream (categoryName, streamId) = tableName, genStreamName (categoryName, streamId)
         let primaryContainer t = Container.Create(client, t)
         let fallbackContainer =

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -542,7 +542,7 @@ type EventStoreCategory<'event, 'state, 'context>(resolveInner, empty) =
                 Caching.applyCacheUpdatesWithFixedTimeSpan cache null period folder Token.supersedes
             | Some (CachingStrategy.SlidingWindowPrefixed (cache, window, prefix)) ->
                 Caching.applyCacheUpdatesWithSlidingExpiration cache prefix window folder Token.supersedes
-        let resolveInner struct (cat, sid) = struct (category, Equinox.StreamId.Render(cat, sid), ValueNone)
+        let resolveInner struct (cat, sid) = struct (category, Equinox.Target.Render(cat, sid), ValueNone)
         let empty = struct (context.TokenEmpty, initial)
         EventStoreCategory(resolveInner, empty)
 

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -542,7 +542,7 @@ type EventStoreCategory<'event, 'state, 'context>(resolveInner, empty) =
                 Caching.applyCacheUpdatesWithFixedTimeSpan cache null period folder Token.supersedes
             | Some (CachingStrategy.SlidingWindowPrefixed (cache, window, prefix)) ->
                 Caching.applyCacheUpdatesWithSlidingExpiration cache prefix window folder Token.supersedes
-        let resolveInner struct (cat, sid) = struct (category, Equinox.Target.Render(cat, sid), ValueNone)
+        let resolveInner struct (cat, sid) = struct (category, StreamName.render cat sid, ValueNone)
         let empty = struct (context.TokenEmpty, initial)
         EventStoreCategory(resolveInner, empty)
 

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -542,7 +542,7 @@ type EventStoreCategory<'event, 'state, 'context>(resolveInner, empty) =
                 Caching.applyCacheUpdatesWithFixedTimeSpan cache null period folder Token.supersedes
             | Some (CachingStrategy.SlidingWindowPrefixed (cache, window, prefix)) ->
                 Caching.applyCacheUpdatesWithSlidingExpiration cache prefix window folder Token.supersedes
-        let resolveInner streamIds = struct (category, FsCodec.StreamName.Internal.ofCategoryAndStreamId streamIds, ValueNone)
+        let resolveInner struct (cat, sid) = struct (category, Equinox.StreamId.Render(cat, sid), ValueNone)
         let empty = struct (context.TokenEmpty, initial)
         EventStoreCategory(resolveInner, empty)
 

--- a/src/Equinox.EventStoreDb/EventStoreDb.fs
+++ b/src/Equinox.EventStoreDb/EventStoreDb.fs
@@ -478,7 +478,7 @@ type EventStoreCategory<'event, 'state, 'context>(resolveInner, empty) =
                 Caching.applyCacheUpdatesWithFixedTimeSpan cache null period folder Token.supersedes
             | Some (CachingStrategy.SlidingWindowPrefixed (cache, window, prefix)) ->
                 Caching.applyCacheUpdatesWithSlidingExpiration cache prefix window folder Token.supersedes
-        let resolveInner struct (cat, sid) = struct (category, Equinox.Target.Render(cat, sid), ValueNone)
+        let resolveInner struct (cat, sid) = struct (category, StreamName.render cat sid, ValueNone)
         let empty = struct (context.TokenEmpty, initial)
         EventStoreCategory(resolveInner, empty)
 

--- a/src/Equinox.EventStoreDb/EventStoreDb.fs
+++ b/src/Equinox.EventStoreDb/EventStoreDb.fs
@@ -478,7 +478,7 @@ type EventStoreCategory<'event, 'state, 'context>(resolveInner, empty) =
                 Caching.applyCacheUpdatesWithFixedTimeSpan cache null period folder Token.supersedes
             | Some (CachingStrategy.SlidingWindowPrefixed (cache, window, prefix)) ->
                 Caching.applyCacheUpdatesWithSlidingExpiration cache prefix window folder Token.supersedes
-        let resolveInner streamIds = struct (category, FsCodec.StreamName.Internal.ofCategoryAndStreamId streamIds, ValueNone)
+        let resolveInner struct (cat, sid) = struct (category, Equinox.StreamId.Render(cat, sid), ValueNone)
         let empty = struct (context.TokenEmpty, initial)
         EventStoreCategory(resolveInner, empty)
 

--- a/src/Equinox.EventStoreDb/EventStoreDb.fs
+++ b/src/Equinox.EventStoreDb/EventStoreDb.fs
@@ -478,7 +478,7 @@ type EventStoreCategory<'event, 'state, 'context>(resolveInner, empty) =
                 Caching.applyCacheUpdatesWithFixedTimeSpan cache null period folder Token.supersedes
             | Some (CachingStrategy.SlidingWindowPrefixed (cache, window, prefix)) ->
                 Caching.applyCacheUpdatesWithSlidingExpiration cache prefix window folder Token.supersedes
-        let resolveInner struct (cat, sid) = struct (category, Equinox.StreamId.Render(cat, sid), ValueNone)
+        let resolveInner struct (cat, sid) = struct (category, Equinox.Target.Render(cat, sid), ValueNone)
         let empty = struct (context.TokenEmpty, initial)
         EventStoreCategory(resolveInner, empty)
 

--- a/src/Equinox.MemoryStore/Equinox.MemoryStore.fsproj
+++ b/src/Equinox.MemoryStore/Equinox.MemoryStore.fsproj
@@ -17,6 +17,7 @@
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
     <PackageReference Include="FSharp.Core" Version="6.0.0" />
+    <PackageReference Include="FsCodec" Version="3.0.0-rc.7.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Equinox.MemoryStore/Equinox.MemoryStore.fsproj
+++ b/src/Equinox.MemoryStore/Equinox.MemoryStore.fsproj
@@ -17,8 +17,6 @@
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
     <PackageReference Include="FSharp.Core" Version="6.0.0" />
-
-    <PackageReference Include="FsCodec" Version="3.0.0-rc.7.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Equinox.MemoryStore/MemoryStore.fs
+++ b/src/Equinox.MemoryStore/MemoryStore.fs
@@ -80,6 +80,6 @@ type MemoryStoreCategory<'event, 'state, 'Format, 'context>(resolveInner, empty)
     inherit Equinox.Category<'event, 'state, 'context>(resolveInner, empty)
     new (store : VolatileStore<'Format>, codec : FsCodec.IEventCodec<'event, 'Format, 'context>, fold, initial) =
         let impl = Category<'event, 'state, 'context, 'Format>(store, codec, fold, initial)
-        let resolveInner struct (cat, sid) = struct (impl :> ICategory<_, _, _>, Equinox.Target.Render(cat, sid), ValueNone)
+        let resolveInner struct (cat, sid) = struct (impl :> ICategory<_, _, _>, StreamName.render cat sid, ValueNone)
         let empty = struct (Token.ofEmpty, initial)
         MemoryStoreCategory(resolveInner, empty)

--- a/src/Equinox.MemoryStore/MemoryStore.fs
+++ b/src/Equinox.MemoryStore/MemoryStore.fs
@@ -80,6 +80,6 @@ type MemoryStoreCategory<'event, 'state, 'Format, 'context>(resolveInner, empty)
     inherit Equinox.Category<'event, 'state, 'context>(resolveInner, empty)
     new (store : VolatileStore<'Format>, codec : FsCodec.IEventCodec<'event, 'Format, 'context>, fold, initial) =
         let impl = Category<'event, 'state, 'context, 'Format>(store, codec, fold, initial)
-        let resolveInner struct (cat, sid) = struct (impl :> ICategory<_, _, _>, Equinox.StreamId.Render(cat, sid), ValueNone)
+        let resolveInner struct (cat, sid) = struct (impl :> ICategory<_, _, _>, Equinox.Target.Render(cat, sid), ValueNone)
         let empty = struct (Token.ofEmpty, initial)
         MemoryStoreCategory(resolveInner, empty)

--- a/src/Equinox.MemoryStore/MemoryStore.fs
+++ b/src/Equinox.MemoryStore/MemoryStore.fs
@@ -80,6 +80,6 @@ type MemoryStoreCategory<'event, 'state, 'Format, 'context>(resolveInner, empty)
     inherit Equinox.Category<'event, 'state, 'context>(resolveInner, empty)
     new (store : VolatileStore<'Format>, codec : FsCodec.IEventCodec<'event, 'Format, 'context>, fold, initial) =
         let impl = Category<'event, 'state, 'context, 'Format>(store, codec, fold, initial)
-        let resolveInner streamIds = struct (impl :> ICategory<_, _, _>, FsCodec.StreamName.Internal.ofCategoryAndStreamId streamIds, ValueNone)
+        let resolveInner struct (cat, sid) = struct (impl :> ICategory<_, _, _>, Equinox.StreamId.Render(cat, sid), ValueNone)
         let empty = struct (Token.ofEmpty, initial)
         MemoryStoreCategory(resolveInner, empty)

--- a/src/Equinox.MemoryStore/MemoryStore.fs
+++ b/src/Equinox.MemoryStore/MemoryStore.fs
@@ -57,7 +57,7 @@ module private Token =
     let ofValue (value : 'event array) = streamTokenOfEventCount value.Length
 
 /// Represents the state of a set of streams in a style consistent withe the concrete Store types - no constraints on memory consumption (but also no persistence!).
-type Category<'event, 'state, 'context, 'Format>(store : VolatileStore<'Format>, codec : FsCodec.IEventCodec<'event, 'Format, 'context>, fold, initial) =
+type private Category<'event, 'state, 'context, 'Format>(store : VolatileStore<'Format>, codec : FsCodec.IEventCodec<'event, 'Format, 'context>, fold, initial) =
     interface ICategory<'event, 'state, 'context> with
         member _.Load(_log, _categoryName, _streamId, streamName, _allowStale, _requireLeader, _ct) =
             match store.Load(streamName) with

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -410,7 +410,7 @@ type MessageDbCategory<'event, 'state, 'context>(resolveInner, empty) =
                 Caching.applyCacheUpdatesWithFixedTimeSpan cache null period folder Token.supersedes
             | Some (CachingStrategy.SlidingWindowPrefixed (cache, window, prefix)) ->
                 Caching.applyCacheUpdatesWithSlidingExpiration cache prefix window folder Token.supersedes
-        let resolveInner struct (cat, sid) = struct (category, Equinox.Target.Render(cat, sid), ValueNone)
+        let resolveInner struct (cat, sid) = struct (category, StreamName.render cat sid, ValueNone)
         let empty = struct (context.TokenEmpty, initial)
         MessageDbCategory(resolveInner, empty)
 

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -410,7 +410,7 @@ type MessageDbCategory<'event, 'state, 'context>(resolveInner, empty) =
                 Caching.applyCacheUpdatesWithFixedTimeSpan cache null period folder Token.supersedes
             | Some (CachingStrategy.SlidingWindowPrefixed (cache, window, prefix)) ->
                 Caching.applyCacheUpdatesWithSlidingExpiration cache prefix window folder Token.supersedes
-        let resolveInner streamIds = struct (category, StreamName.Internal.ofCategoryAndStreamId streamIds, ValueNone)
+        let resolveInner struct (cat, sid) = struct (category, Equinox.StreamId.Render(cat, sid), ValueNone)
         let empty = struct (context.TokenEmpty, initial)
         MessageDbCategory(resolveInner, empty)
 

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -410,7 +410,7 @@ type MessageDbCategory<'event, 'state, 'context>(resolveInner, empty) =
                 Caching.applyCacheUpdatesWithFixedTimeSpan cache null period folder Token.supersedes
             | Some (CachingStrategy.SlidingWindowPrefixed (cache, window, prefix)) ->
                 Caching.applyCacheUpdatesWithSlidingExpiration cache prefix window folder Token.supersedes
-        let resolveInner struct (cat, sid) = struct (category, Equinox.StreamId.Render(cat, sid), ValueNone)
+        let resolveInner struct (cat, sid) = struct (category, Equinox.Target.Render(cat, sid), ValueNone)
         let empty = struct (context.TokenEmpty, initial)
         MessageDbCategory(resolveInner, empty)
 

--- a/src/Equinox.SqlStreamStore/SqlStreamStore.fs
+++ b/src/Equinox.SqlStreamStore/SqlStreamStore.fs
@@ -522,7 +522,7 @@ type SqlStreamStoreCategory<'event, 'state, 'context>(resolveInner, empty) =
                 Caching.applyCacheUpdatesWithFixedTimeSpan cache null period folder Token.supersedes
             | Some (CachingStrategy.SlidingWindowPrefixed (cache, window, prefix)) ->
                 Caching.applyCacheUpdatesWithSlidingExpiration cache prefix window folder Token.supersedes
-        let resolveInner struct (cat, sid) = struct (category, Equinox.Target.Render(cat, sid), ValueNone)
+        let resolveInner struct (cat, sid) = struct (category, StreamName.render cat sid, ValueNone)
         let empty = struct (context.TokenEmpty, initial)
         SqlStreamStoreCategory(resolveInner, empty)
 

--- a/src/Equinox.SqlStreamStore/SqlStreamStore.fs
+++ b/src/Equinox.SqlStreamStore/SqlStreamStore.fs
@@ -522,7 +522,7 @@ type SqlStreamStoreCategory<'event, 'state, 'context>(resolveInner, empty) =
                 Caching.applyCacheUpdatesWithFixedTimeSpan cache null period folder Token.supersedes
             | Some (CachingStrategy.SlidingWindowPrefixed (cache, window, prefix)) ->
                 Caching.applyCacheUpdatesWithSlidingExpiration cache prefix window folder Token.supersedes
-        let resolveInner struct (cat, sid) = struct (category, Equinox.StreamId.Render(cat, sid), ValueNone)
+        let resolveInner struct (cat, sid) = struct (category, Equinox.Target.Render(cat, sid), ValueNone)
         let empty = struct (context.TokenEmpty, initial)
         SqlStreamStoreCategory(resolveInner, empty)
 

--- a/src/Equinox.SqlStreamStore/SqlStreamStore.fs
+++ b/src/Equinox.SqlStreamStore/SqlStreamStore.fs
@@ -522,7 +522,7 @@ type SqlStreamStoreCategory<'event, 'state, 'context>(resolveInner, empty) =
                 Caching.applyCacheUpdatesWithFixedTimeSpan cache null period folder Token.supersedes
             | Some (CachingStrategy.SlidingWindowPrefixed (cache, window, prefix)) ->
                 Caching.applyCacheUpdatesWithSlidingExpiration cache prefix window folder Token.supersedes
-        let resolveInner streamIds = struct (category, FsCodec.StreamName.Internal.ofCategoryAndStreamId streamIds, ValueNone)
+        let resolveInner struct (cat, sid) = struct (category, Equinox.StreamId.Render(cat, sid), ValueNone)
         let empty = struct (context.TokenEmpty, initial)
         SqlStreamStoreCategory(resolveInner, empty)
 

--- a/src/Equinox/Core.fs
+++ b/src/Equinox/Core.fs
@@ -61,4 +61,3 @@ type internal Impl() =
                              projection : Func<struct (StreamToken * 's), 'v>, ct) : Task<'v> = task {
         let! tokenAndState = fetch stream ct
         return projection.Invoke tokenAndState }
-

--- a/src/Equinox/Decider.fs
+++ b/src/Equinox/Decider.fs
@@ -7,9 +7,7 @@ open System.Threading.Tasks
 
 /// Central Application-facing API. Wraps the handling of decision or query flows in a manner that is store agnostic
 /// NOTE: For C#, direct usage of DeciderCore is recommended
-type Decider<'event, 'state>(stream : IStream<'event, 'state>) =
-
-    let inner = DeciderCore(stream)
+type Decider<'event, 'state>(inner : DeciderCore<'event, 'state>) =
 
     /// 1.  Invoke the supplied <c>interpret</c> function with the present state to determine whether any write is to occur.
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
@@ -322,5 +320,5 @@ module StreamId =
     let private mapElements (elements : string seq) : string =
         for x in elements do Internal.validateElement x
         String.Join("_", elements)
-    let map2 category f f2 (id1, id2) = Internal.create category (mapElements (seq { yield f id1; yield f2 id2 }))
-    let map3 category f f2 f3 (id1, id2, id3) = Internal.create category (mapElements (seq { yield f id1; yield f2 id2; yield f3 id3 }))
+    let map2 category f f2 struct (id1, id2) = Internal.create category (mapElements (seq { yield f id1; yield f2 id2 }))
+    let map3 category f f2 f3 struct (id1, id2, id3) = Internal.create category (mapElements (seq { yield f id1; yield f2 id2; yield f3 id3 }))

--- a/src/Equinox/Decider.fs
+++ b/src/Equinox/Decider.fs
@@ -294,7 +294,8 @@ and internal SyncContext<'state> =
 [<Struct>]
 type StreamId =
     { categoryName : string; streamId : string }
-    override x.ToString() = String.Concat(x.categoryName, '-', x.streamId)
+    static member Render(categoryName, streamId) = String.Concat(categoryName, '-', streamId)
+    override x.ToString() = StreamId.Render(x.categoryName, x.streamId)
 
 module StreamId =
 

--- a/src/Equinox/Decider.fs
+++ b/src/Equinox/Decider.fs
@@ -290,3 +290,36 @@ and internal SyncContext<'state> =
             member _.Version = token.version
             member _.StreamEventBytes = match token.streamBytes with -1L -> ValueNone | b -> ValueSome b
             member _.CreateMemento() = token, state }
+
+[<Struct>]
+type StreamId =
+    { categoryName : string; streamId : string }
+    override x.ToString() = String.Concat(x.categoryName, '-', x.streamId)
+
+module StreamId =
+
+    module Internal =
+        /// Throws if a candidate category includes a '-', is null, or is empty
+        let inline validateCategory (rawCategory : string) =
+            if rawCategory |> String.IsNullOrEmpty then invalidArg "rawCategory" "may not be null or empty"
+            if rawCategory.IndexOf '-' <> -1 then invalidArg "rawCategory" "may not contain embedded '-' symbols"
+
+        /// Throws if a candidate id element includes a '_', is null, or is empty
+        let inline validateElement (rawElement : string) =
+            if rawElement |> String.IsNullOrEmpty then invalidArg "rawElement" "may not contain null or empty components"
+            if rawElement.IndexOf '_' <> -1 then invalidArg "rawElement" "may not contain embedded '_' symbols"
+
+        /// Low level helper used to gate ingestion from a canonical form
+        /// Does NOT validate the StreamId portion wrt numbers of embedded `_` or `-` chars
+        let create category sid =
+            validateCategory category
+            { categoryName = category; streamId = sid }
+        let toString (x : StreamId) = string x
+
+    let private mapElement f id = let t = f id in Internal.validateElement t; t
+    let map category f id = Internal.create category (mapElement f id)
+    let private mapElements (elements : string seq) : string =
+        for x in elements do Internal.validateElement x
+        String.Join("_", elements)
+    let map2 category f f2 (id1, id2) = Internal.create category (mapElements (seq { yield f id1; yield f2 id2 }))
+    let map3 category f f2 f3 (id1, id2, id3) = Internal.create category (mapElements (seq { yield f id1; yield f2 id2; yield f3 id3 }))

--- a/src/Equinox/Decider.fs
+++ b/src/Equinox/Decider.fs
@@ -291,9 +291,9 @@ and internal SyncContext<'state> =
 
 [<Struct>]
 type Target =
-    { categoryName : string; streamId : string }
+    { category : string; streamId : string }
     static member Render(categoryName, streamId) = String.Concat(categoryName, '-', streamId)
-    override x.ToString() = Target.Render(x.categoryName, x.streamId)
+    override x.ToString() = Target.Render(x.category, x.streamId)
 
 module Target =
     module Internal =
@@ -307,15 +307,15 @@ module Target =
             if rawElement.IndexOf '_' <> -1 then invalidArg "rawElement" "may not contain embedded '_' symbols"
         /// Low level helper used to gate ingestion from a canonical form
         /// Does NOT validate the {streamId} portion wrt numbers of embedded `_` or `-` chars
-        let create categoryName streamId =
-            validateCategory categoryName
-            { categoryName = categoryName; streamId = streamId }
+        let create category streamId =
+            validateCategory category
+            { category = category; streamId = streamId }
         let toString (x : Target) = string x
 
     let private streamIdOfElement f id = let t = f id in Internal.validateElement t; t
-    let gen categoryName f id = Internal.create categoryName (streamIdOfElement f id)
+    let gen category f id = Internal.create category (streamIdOfElement f id)
     let private streamIdOfElements (elements : string seq) : string =
         for x in elements do Internal.validateElement x
         String.Join("_", elements)
-    let gen2 categoryName f f2 struct (id1, id2) = Internal.create categoryName (streamIdOfElements (seq { yield f id1; yield f2 id2 }))
-    let gen3 categoryName f f2 f3 struct (id1, id2, id3) = Internal.create categoryName (streamIdOfElements (seq { yield f id1; yield f2 id2; yield f3 id3 }))
+    let gen2 category f f2 struct (id1, id2) = Internal.create category (streamIdOfElements (seq { yield f id1; yield f2 id2 }))
+    let gen3 category f f2 f3 struct (id1, id2, id3) = Internal.create category (streamIdOfElements (seq { yield f id1; yield f2 id2; yield f3 id3 }))

--- a/src/Equinox/Decider.fs
+++ b/src/Equinox/Decider.fs
@@ -307,4 +307,3 @@ module StreamId =
     let toString : StreamId -> string = UMX.untag
     let gen2 f f2 struct (id1, id2) = seq { yield f id1; yield f2 id2 } |> streamIdOfElements
     let gen3 f f2 f3 struct (id1, id2, id3) = seq { yield f id1; yield f2 id2; yield f3 id3 } |> streamIdOfElements
-    let withContext target resolve context ids = target ids |> resolve context

--- a/src/Equinox/Decider.fs
+++ b/src/Equinox/Decider.fs
@@ -312,10 +312,14 @@ module Target =
             { category = category; streamId = streamId }
         let toString (x : Target) = string x
 
-    let private streamIdOfElement f id = let t = f id in Internal.validateElement t; t
-    let gen category f id = Internal.create category (streamIdOfElement f id)
+    let private genStreamId f id =
+        let element = f id
+        Internal.validateElement element
+        element
+    let gen category f id = Internal.create category (genStreamId f id)
     let private streamIdOfElements (elements : string seq) : string =
         for x in elements do Internal.validateElement x
         String.Join("_", elements)
     let gen2 category f f2 struct (id1, id2) = Internal.create category (streamIdOfElements (seq { yield f id1; yield f2 id2 }))
     let gen3 category f f2 f3 struct (id1, id2, id3) = Internal.create category (streamIdOfElements (seq { yield f id1; yield f2 id2; yield f3 id3 }))
+    let withContext target resolve context ids = target ids |> resolve context

--- a/src/Equinox/Equinox.fsproj
+++ b/src/Equinox/Equinox.fsproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
+    <PackageReference Include="FsCodec" Version="3.0.0-rc.7.1" />
     <PackageReference Include="FSharp.Core" Version="6.0.0">
       <!-- Workaround for malformed FSharp.Core packages https://github.com/dotnet/fsharp/issues/12706 via https://github.com/fsprojects/Paket/issues/4149-->
       <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/src/Equinox/Equinox.fsproj
+++ b/src/Equinox/Equinox.fsproj
@@ -13,11 +13,11 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-    <PackageReference Include="FsCodec" Version="3.0.0-rc.7.1" />
     <PackageReference Include="FSharp.Core" Version="6.0.0">
       <!-- Workaround for malformed FSharp.Core packages https://github.com/dotnet/fsharp/issues/12706 via https://github.com/fsprojects/Paket/issues/4149-->
       <ExcludeAssets>contentFiles</ExcludeAssets>
     </PackageReference>
+    
+    <PackageReference Include="FSharp.UMX" Version="1.1.0"/>
   </ItemGroup>
-
 </Project>

--- a/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
+++ b/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
@@ -32,7 +32,7 @@ module WiringHelpers =
 /// This is especially relevant when events are spread between a Tip page and preceding pages as the Tip reading logic is special cased compared to querying
 module SequenceCheck =
 
-    let streamId = Equinox.StreamId.map "_SequenceCheck" (fun (g : Guid) -> g.ToString "N")
+    let target = Equinox.Target.gen "_SequenceCheck" (fun (g : Guid) -> g.ToString "N")
 
     module Events =
 
@@ -69,7 +69,7 @@ module SequenceCheck =
             decider.Transact(decide (value, count), id)
 
     let private create resolve =
-        Service(streamId >> resolve)
+        Service(target >> resolve)
 
     module Config =
 

--- a/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
+++ b/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
@@ -32,7 +32,7 @@ module WiringHelpers =
 /// This is especially relevant when events are spread between a Tip page and preceding pages as the Tip reading logic is special cased compared to querying
 module SequenceCheck =
 
-    let streamName (id : Guid) = struct ("_SequenceCheck", id.ToString "N")
+    let streamId = Equinox.StreamId.map "_SequenceCheck" (fun (g : Guid) -> g.ToString "N")
 
     module Events =
 
@@ -69,7 +69,7 @@ module SequenceCheck =
             decider.Transact(decide (value, count), id)
 
     let private create resolve =
-        Service(streamName >> resolve)
+        Service(streamId >> resolve)
 
     module Config =
 

--- a/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
+++ b/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
@@ -32,7 +32,8 @@ module WiringHelpers =
 /// This is especially relevant when events are spread between a Tip page and preceding pages as the Tip reading logic is special cased compared to querying
 module SequenceCheck =
 
-    let target = Equinox.Target.gen "_SequenceCheck" (fun (g : Guid) -> g.ToString "N")
+    let [<Literal>] Category = "_SequenceCheck"
+    let streamId = Equinox.StreamId.gen (fun (g : Guid) -> g.ToString "N")
 
     module Events =
 
@@ -69,7 +70,7 @@ module SequenceCheck =
             decider.Transact(decide (value, count), id)
 
     let private create resolve =
-        Service(target >> resolve)
+        Service(streamId >> resolve Category)
 
     module Config =
 

--- a/tests/Equinox.CosmosStore.Integration/CosmosFixturesInfrastructure.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosFixturesInfrastructure.fs
@@ -9,7 +9,7 @@ type FsCheckGenerators =
     static member ContactPreferencesId =
         Arb.generate<Guid>
         |> Gen.map (fun x -> sprintf "%s@test.com" (x.ToString("N")))
-        |> Gen.map ContactPreferences.Id
+        |> Gen.map ContactPreferences.ClientId
         |> Arb.fromGen
 
 [<AutoOpen>]

--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -242,7 +242,7 @@ type Tests(testOutputHelper) =
         // Needs to share the same context (with inner CosmosClient) for the session token to be threaded through
         // If we run on an independent context, we won't see (and hence prune) the full set of events
         let ctx = Core.EventsContext(context, log)
-        let streamName = ContactPreferences.streamName id |> FsCodec.StreamName.Internal.ofCategoryAndStreamId
+        let streamName = ContactPreferences.streamId id |> Equinox.StreamId.Internal.toString
 
         // Prune all the events
         let! deleted, deferred, trimmedPos = Core.Events.pruneUntil ctx streamName 14L
@@ -410,7 +410,7 @@ type Tests(testOutputHelper) =
         (* Verify pruning does not affect snapshots, though Tip is re-read in this scenario due to lack of caching *)
 
         let ctx = Core.EventsContext(context, log)
-        let streamName = Cart.streamName cartId |> FsCodec.StreamName.Internal.ofCategoryAndStreamId
+        let streamName = Cart.streamId cartId |> Equinox.StreamId.Internal.toString
         // Prune all the events
         let! deleted, deferred, trimmedPos = Core.Events.pruneUntil ctx streamName 11L
         test <@ deleted = 12 && deferred = 0 && trimmedPos = 12L @>
@@ -471,7 +471,7 @@ type Tests(testOutputHelper) =
         (* Verify pruning does not affect snapshots, and does not touch the Tip *)
 
         let ctx = Core.EventsContext(context, log)
-        let streamName = Cart.streamName cartId |> FsCodec.StreamName.Internal.ofCategoryAndStreamId
+        let streamName = Cart.streamId cartId |> Equinox.StreamId.Internal.toString
         // Prune all the events
         let! deleted, deferred, trimmedPos = Core.Events.pruneUntil ctx streamName 12L
         test <@ deleted = 13 && deferred = 0 && trimmedPos = 13L @>

--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -242,7 +242,7 @@ type Tests(testOutputHelper) =
         // Needs to share the same context (with inner CosmosClient) for the session token to be threaded through
         // If we run on an independent context, we won't see (and hence prune) the full set of events
         let ctx = Core.EventsContext(context, log)
-        let streamName = ContactPreferences.streamId id |> Equinox.StreamId.Internal.toString
+        let streamName = ContactPreferences.target id |> Equinox.Target.Internal.toString
 
         // Prune all the events
         let! deleted, deferred, trimmedPos = Core.Events.pruneUntil ctx streamName 14L
@@ -410,7 +410,7 @@ type Tests(testOutputHelper) =
         (* Verify pruning does not affect snapshots, though Tip is re-read in this scenario due to lack of caching *)
 
         let ctx = Core.EventsContext(context, log)
-        let streamName = Cart.streamId cartId |> Equinox.StreamId.Internal.toString
+        let streamName = Cart.target cartId |> Equinox.Target.Internal.toString
         // Prune all the events
         let! deleted, deferred, trimmedPos = Core.Events.pruneUntil ctx streamName 11L
         test <@ deleted = 12 && deferred = 0 && trimmedPos = 12L @>
@@ -471,7 +471,7 @@ type Tests(testOutputHelper) =
         (* Verify pruning does not affect snapshots, and does not touch the Tip *)
 
         let ctx = Core.EventsContext(context, log)
-        let streamName = Cart.streamId cartId |> Equinox.StreamId.Internal.toString
+        let streamName = Cart.target cartId |> Equinox.Target.Internal.toString
         // Prune all the events
         let! deleted, deferred, trimmedPos = Core.Events.pruneUntil ctx streamName 12L
         test <@ deleted = 13 && deferred = 0 && trimmedPos = 13L @>

--- a/tests/Equinox.EventStore.Integration/Infrastructure.fs
+++ b/tests/Equinox.EventStore.Integration/Infrastructure.fs
@@ -9,7 +9,7 @@ type FsCheckGenerators =
     static member ContactPreferencesId =
         Arb.generate<Guid>
         |> Gen.map (fun x -> sprintf "%s@test.com" (x.ToString("N")))
-        |> Gen.map ContactPreferences.Id
+        |> Gen.map ContactPreferences.ClientId
         |> Arb.fromGen
 
 #if STORE_POSTGRES || STORE_MSSQL || STORE_MYSQL

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -107,15 +107,19 @@ module SimplestThing =
     let evolve (state: Event) (event: Event) = event
     let fold = Seq.fold evolve
     let initial = StuffHappened
-    let resolve log context = Category(context, codec, fold, initial) |> Equinox.Decider.resolve log
+    let resolve log context =
+        Category(context, codec, fold, initial)
+        |> Equinox.Decider.resolve log
+    let [<Literal>] Category = "SimplestThing"
 
 module Cart =
     let fold, initial = Cart.Fold.fold, Cart.Fold.initial
     let codec = Cart.Events.codec
     let snapshot = Cart.Fold.isOrigin, Cart.Fold.snapshot
-    let createCategory log context = Category(context, codec, fold, initial) |> Equinox.Decider.resolve log
     let createServiceWithoutOptimization log context =
-        createCategory log context |> Cart.create
+        Category(context, codec, fold, initial)
+        |> Equinox.Decider.resolve log
+        |> Cart.create
 
     #if !STORE_MESSAGEDB
     let createServiceWithCompaction log context =
@@ -502,8 +506,9 @@ type Tests(testOutputHelper) =
 
         let batchSize = 3
         let context = createContext connection batchSize
-        let id = $"{Guid.NewGuid():N}"
-        let decider = SimplestThing.resolve log context struct("SimplestThing", id)
+        let id = Guid.NewGuid()
+        let toStreamId (x : Guid) = x.ToString "N"
+        let decider = SimplestThing.resolve log context (Equinox.StreamId.map SimplestThing.Category toStreamId id)
 
         let! before, after = decider.TransactEx(
             (fun state -> state.Version, [SimplestThing.StuffHappened]),

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -508,7 +508,7 @@ type Tests(testOutputHelper) =
         let context = createContext connection batchSize
         let id = Guid.NewGuid()
         let toStreamId (x : Guid) = x.ToString "N"
-        let decider = SimplestThing.resolve log context (Equinox.Target.gen SimplestThing.Category toStreamId id)
+        let decider = SimplestThing.resolve log context SimplestThing.Category (Equinox.StreamId.gen toStreamId id)
 
         let! before, after = decider.TransactEx(
             (fun state -> state.Version, [SimplestThing.StuffHappened]),

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -508,7 +508,7 @@ type Tests(testOutputHelper) =
         let context = createContext connection batchSize
         let id = Guid.NewGuid()
         let toStreamId (x : Guid) = x.ToString "N"
-        let decider = SimplestThing.resolve log context (Equinox.StreamId.map SimplestThing.Category toStreamId id)
+        let decider = SimplestThing.resolve log context (Equinox.Target.gen SimplestThing.Category toStreamId id)
 
         let! before, after = decider.TransactEx(
             (fun state -> state.Version, [SimplestThing.StuffHappened]),

--- a/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
+++ b/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
@@ -69,9 +69,9 @@ type ChangeFeed(testOutputHelper) =
             let xs = events.ToArray()
             events.Clear()
             List.ofArray xs
-        use _ = store.Committed.Subscribe(fun struct (c, s, xs) -> events.Add((Equinox.Target.Internal.create c s, List.ofArray xs)))
+        use _ = store.Committed.Subscribe(fun struct (_c, sid, xs) -> events.Add(sid, List.ofArray xs))
         let service = createFavoritesServiceMemory store log
-        let expectedStream = Favorites.target clientId
+        let expectedStream = Favorites.streamId clientId |> Equinox.StreamId.toString
 
         do! service.Favorite(clientId, [sku])
         let written = takeCaptured ()

--- a/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
+++ b/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
@@ -69,9 +69,9 @@ type ChangeFeed(testOutputHelper) =
             let xs = events.ToArray()
             events.Clear()
             List.ofArray xs
-        use _ = store.Committed.Subscribe(fun struct (c, s, xs) -> events.Add((struct (c, s), List.ofArray xs)))
+        use _ = store.Committed.Subscribe(fun struct (c, s, xs) -> events.Add((Equinox.StreamId.Internal.create c s, List.ofArray xs)))
         let service = createFavoritesServiceMemory store log
-        let expectedStream = Favorites.streamName clientId
+        let expectedStream = Favorites.streamId clientId
 
         do! service.Favorite(clientId, [sku])
         let written = takeCaptured ()

--- a/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
+++ b/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
@@ -69,9 +69,9 @@ type ChangeFeed(testOutputHelper) =
             let xs = events.ToArray()
             events.Clear()
             List.ofArray xs
-        use _ = store.Committed.Subscribe(fun struct (c, s, xs) -> events.Add((Equinox.StreamId.Internal.create c s, List.ofArray xs)))
+        use _ = store.Committed.Subscribe(fun struct (c, s, xs) -> events.Add((Equinox.Target.Internal.create c s, List.ofArray xs)))
         let service = createFavoritesServiceMemory store log
-        let expectedStream = Favorites.streamId clientId
+        let expectedStream = Favorites.target clientId
 
         do! service.Favorite(clientId, [sku])
         let written = takeCaptured ()

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -506,7 +506,7 @@ module Dump =
                  with e -> log.Warning(e, "UTF-8 Parse failure - use --Blobs option to inhibit"); reraise()
         let dumpEvents (streamName : FsCodec.StreamName) = async {
             let resolve = store.Category(idCodec, fold, initial, isOriginAndSnapshot) |> Equinox.Decider.resolve storeLog
-            let decider = let struct (cat, sid) = FsCodec.StreamName.splitCategoryAndStreamId streamName in Equinox.Target.Internal.create cat sid |> resolve
+            let decider = let struct (cat, sid) = FsCodec.StreamName.splitCategoryAndStreamId streamName in resolve cat (UMX.tag sid)
             let! streamBytes, events = decider.QueryEx(fun c -> c.StreamEventBytes, c.State)
             let mutable prevTs = None
             for x in events |> Seq.filter (fun e -> (e.IsUnfold && doU) || (not e.IsUnfold && doE)) do

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -504,7 +504,7 @@ module Dump =
                                  with e -> log.ForContext("str", s).Warning(e, "JSON Parse failure - use --JsonSkip option to inhibit"); reraise()
                      else $"(%d{s.Length} chars)"
                  with e -> log.Warning(e, "UTF-8 Parse failure - use --Blobs option to inhibit"); reraise()
-        let readStream (streamName : FsCodec.StreamName) = async {
+        let dumpEvents (streamName : FsCodec.StreamName) = async {
             let resolve = store.Category(idCodec, fold, initial, isOriginAndSnapshot) |> Equinox.Decider.resolve storeLog
             let decider = let struct (cat, sid) = FsCodec.StreamName.splitCategoryAndStreamId streamName in Equinox.Target.Internal.create cat sid |> resolve
             let! streamBytes, events = decider.QueryEx(fun c -> c.StreamEventBytes, c.State)
@@ -532,7 +532,7 @@ module Dump =
         let streams = p.GetResults DumpParameters.Stream
         log.ForContext("streams",streams).Information("Reading...")
         streams
-        |> Seq.map readStream
+        |> Seq.map dumpEvents
         |> Async.Parallel
         |> Async.Ignore<unit[]>
         |> Async.RunSynchronously

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -506,7 +506,7 @@ module Dump =
                  with e -> log.Warning(e, "UTF-8 Parse failure - use --Blobs option to inhibit"); reraise()
         let readStream (streamName : FsCodec.StreamName) = async {
             let resolve = store.Category(idCodec, fold, initial, isOriginAndSnapshot) |> Equinox.Decider.resolve storeLog
-            let decider = let struct (cat, sid) = FsCodec.StreamName.splitCategoryAndStreamId streamName in Equinox.StreamId.Internal.create cat sid |> resolve
+            let decider = let struct (cat, sid) = FsCodec.StreamName.splitCategoryAndStreamId streamName in Equinox.Target.Internal.create cat sid |> resolve
             let! streamBytes, events = decider.QueryEx(fun c -> c.StreamEventBytes, c.State)
             let mutable prevTs = None
             for x in events |> Seq.filter (fun e -> (e.IsUnfold && doU) || (not e.IsUnfold && doE)) do

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -506,7 +506,7 @@ module Dump =
                  with e -> log.Warning(e, "UTF-8 Parse failure - use --Blobs option to inhibit"); reraise()
         let readStream (streamName : FsCodec.StreamName) = async {
             let resolve = store.Category(idCodec, fold, initial, isOriginAndSnapshot) |> Equinox.Decider.resolve storeLog
-            let decider = resolve (FsCodec.StreamName.splitCategoryAndStreamId streamName)
+            let decider = let struct (cat, sid) = FsCodec.StreamName.splitCategoryAndStreamId streamName in Equinox.StreamId.Internal.create cat sid |> resolve
             let! streamBytes, events = decider.QueryEx(fun c -> c.StreamEventBytes, c.State)
             let mutable prevTs = None
             for x in events |> Seq.filter (fun e -> (e.IsUnfold && doU) || (not e.IsUnfold && doE)) do


### PR DESCRIPTION
Polishes the ids -> stream name -> Decider resolution process 
- removes ugly `struct` tuples from primary APIs (temp state from earlier performance work)

The major credit must go to @nordfjord who provided the impetus for this effort, and had the final late night insight that leaves us with a well-named and Simple mechanism that resolves all the forces in the mapping process neatly