### PR TITLE
add snapshotting to message-db

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ _If you're looking to learn more about and/or discuss Event Sourcing and it's my
 - [Amazon Dynamo DB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Introduction.html): Shares most features with `Equinox.CosmosStore` ([from which it was ported in #321](https://github.com/jet/equinox/pull/321)). See above for detailed comparison.
 - [Azure Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db): contains some fragments of code dating back to 2016, however [the storage model](DOCUMENTATION.md#Cosmos-Storage-Model) was arrived at based on intensive benchmarking (squash-merged in [#42](https://github.com/jet/equinox/pull/42)). The V2 and V3 release lines are being used in production systems. (The V3 release provides support for significantly more efficient packing of events ([storing events in the 'Tip'](https://github.com/jet/equinox/pull/251))).
 - [EventStoreDB](https://eventstore.org/): this codebase itself has been in production since 2017 (see commit history), with key elements dating back to approx 2016. Current versions require EventStoreDB Server editions `21.10` or later, and communicate over the modern gRPC interface.
-- [message-db](http://docs.eventide-project.org/user-guide/message-db): bindings for the `message-db` Postgres event storage system. [See `message-db` docs](http://docs.eventide-project.org/user-guide/message-db). :pray: [@nordfjord](https://github.com/nordfjord)
+- [MessageDB](http://docs.eventide-project.org/user-guide/message-db): bindings for the `message-db` Postgres event storage system. [See `MessageDB` docs](http://docs.eventide-project.org/user-guide/message-db). :pray: [@nordfjord](https://github.com/nordfjord)
 - [SqlStreamStore](https://github.com/SQLStreamStore/SQLStreamStore): bindings for the powerful and widely used (**but presently unmaintained**) SQL-backed Event Storage system, derived from the EventStoreDB adapter. [See SqlStreamStore docs](https://sqlstreamstore.readthedocs.io/en/latest/#introduction). :pray: [@rajivhost](https://github.com/rajivhost)
 
   __NOTE: The underlying `SqlStreamStore` project is presently unmaintained; as such its hard to recommend using it for production scenarios__
@@ -133,7 +133,7 @@ _If you're looking to learn more about and/or discuss Event Sourcing and it's my
 
   - For MySql, it's pretty much the same as for SQL Server, with the proviso that it's likely that it's had (and has) significantly lower adoption and/or proper scrutiny.
   
-  - For Postgres, _`Equinox.MessageDb`_ is a better choice as the underlying [message-db](http://docs.eventide-project.org/user-guide/message-db/) project is actively maintained and has significantly better documentation than SqlStreamStore. The other thing to point out is that `Equinox.SqlStreamStore.Postgres` does not depend on the final version of `SqlStreamStore.Postgres` as there are no equivalent releases of the `.Mysql` and `.SqlServer` variants.
+  - For Postgres, _`Equinox.MessageDb`_ is a better choice as the underlying [MessageDB](http://docs.eventide-project.org/user-guide/message-db/) project is actively maintained and has significantly better documentation than SqlStreamStore. The other thing to point out is that `Equinox.SqlStreamStore.Postgres` does not depend on the final version of `SqlStreamStore.Postgres` as there are no equivalent releases of the `.Mysql` and `.SqlServer` variants.
 
 # Components
 
@@ -184,7 +184,7 @@ Equinox does not focus on projection logic - each store brings its own strengths
 - `Propulsion.DynamoStore.Lambda` [![Propulsion.DynamoStore.Lambda NuGet](https://img.shields.io/nuget/v/Propulsion.DynamoStore.Lambda.svg)](https://www.nuget.org/packages/Propulsion.DynamoStore.Lambda/): Indexes events written by `Equinox.DynamoStore` via a DynamoDB Streams-triggered Lambda. (Depends on `Propulsion.DynamoStore`)
 - `Propulsion.EventStore` [![Propulsion.EventStore NuGet](https://img.shields.io/nuget/v/Propulsion.EventStore.svg)](https://www.nuget.org/packages/Propulsion.EventStore/) Used in the [`propulsion project es`](dotnet-tool-provisioning--benchmarking-tool) tool command; see [`dotnet new proSync` to generate a sample app](#quickstart) using it. ([depends](https://www.fuget.org/packages/Propulsion.EventStore) on `Equinox.EventStore`)
 - `Propulsion.EventStoreDb` [![Propulsion.EventStoreDb NuGet](https://img.shields.io/nuget/v/Propulsion.EventStoreDb.svg)](https://www.nuget.org/packages/Propulsion.EventStoreDb/) Consumes from `EventStoreDB` v `21.10` or later using the gRPC interface. ([depends](https://www.fuget.org/packages/Propulsion.EventStoreDb) on `Equinox.EventStoreDb`)
-- `Propulsion.MessageDb` [![Propulsion.MessageDb NuGet](https://img.shields.io/nuget/v/Propulsion.MessageDb.svg)](https://www.nuget.org/packages/Propulsion.MessageDb) Consumes from a `message-db` store (in Postgres) using `Npgsql`. ([depends](https://www.fuget.org/packages/Propulsion.MessageDb) on `Npgsql`, `Propulsion.Feed`)
+- `Propulsion.MessageDb` [![Propulsion.MessageDb NuGet](https://img.shields.io/nuget/v/Propulsion.MessageDb.svg)](https://www.nuget.org/packages/Propulsion.MessageDb) Consumes from a `MessageDB` store (in Postgres) using `Npgsql`. ([depends](https://www.fuget.org/packages/Propulsion.MessageDb) on `Npgsql`, `Propulsion.Feed`)
 - `Propulsion.Kafka` [![Propulsion.Kafka NuGet](https://img.shields.io/nuget/v/Propulsion.Kafka.svg)](https://www.nuget.org/packages/Propulsion.Kafka/): Provides a canonical `RenderedSpan` that can be used as a default format when projecting events via e.g. the Producer/Consumer pair in `dotnet new proProjector -k; dotnet new proConsumer`. ([depends](https://www.fuget.org/packages/Propulsion.Kafka) on `Newtonsoft.Json >= 11.0.2`, `Propulsion`, `FsKafka`)
 
 ## `dotnet tool` provisioning / benchmarking tool
@@ -513,7 +513,20 @@ MessageDb support is provided in the samples and the `eqx` tool:
 - being able to supply `mdb` flag to `eqx dump`, e.g. `eqx dump -CU "Favorites-ab25cc9f24464d39939000aeb37ea11a" mdb -c "pgconnectionstring"`
 - being able to supply `mdb` flag to Web sample, e.g. `dotnet run --project samples/Web/ -- mdb -c "pgconnectionstring"`
 
-Equinox does not provide utilities for configuring or installing message-db. See [MessageDB's installation documentation](http://docs.eventide-project.org/user-guide/message-db/install.html).
+Equinox does not provide utilities for configuring or installing MessageDB. See [MessageDB's installation documentation](http://docs.eventide-project.org/user-guide/message-db/install.html).
+
+In addition to the default access strategy of reading the whole stream forwards in batches, the following access strategies are supported in MessageDb:
+
+`AccesStrategy.LatestKnownEvent`
+- Uses message-db's `get_last_stream_message` API to only ever fetch the last event in a stream
+- This is useful for aggregates whose entire state can be constructed from the latest event (e.g. a stream that stores checkpoints)
+- NOTE: The last event MUST be decodable by the supplied codec. Otherwise the stream is assumed to be empty
+
+`AccessStrategy.AdjacentSnapshots`
+- Generates and stores a snapshot event in an adjacent `{Category}:snapshot-{StreamId}` stream
+- The generation happens every `batchSize` events. This means the state of the stream can be reconstructed with exactly 2 round-trips to the database.
+  - The first round-trip fetches the most recent event of type `snapshotEventCaseName` from the snapshot stream.
+  - The second round-trip fetches `batchSize` events from the position of the snapshot
 
 <a name="dynamodb"></a>
 ### Use [Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Introduction.html)

--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ In addition to the default access strategy of reading the whole stream forwards 
 `AccesStrategy.LatestKnownEvent`
 - Uses message-db's `get_last_stream_message` API to only ever fetch the last event in a stream
 - This is useful for aggregates whose entire state can be constructed from the latest event (e.g. a stream that stores checkpoints)
-- NOTE: The last event MUST be decodable by the supplied codec. Otherwise the stream is assumed to be empty
+- NOTE: The last event should be decodable by the supplied codec. Otherwise you'll receive the initial state.
 
 `AccessStrategy.AdjacentSnapshots`
 - Generates and stores a snapshot event in an adjacent `{Category}:snapshot-{StreamId}` stream

--- a/samples/Store/Domain/Cart.fs
+++ b/samples/Store/Domain/Cart.fs
@@ -38,6 +38,7 @@ module Fold =
         let ofSnapshot (s: Events.Compaction.State) : State =
             { items = [ for i in s.items -> { skuId = i.skuId; quantity = i.quantity; returnsWaived = i.returnsWaived } ] }
     let initial = { items = [] }
+    // Should match the event type that is stored, which does not necessarily match the case name
     let snapshotEventCaseName = nameof Events.Snapshotted
     let evolve (state : State) event =
         let updateItems f = { state with items = f state.items }

--- a/samples/Store/Domain/Cart.fs
+++ b/samples/Store/Domain/Cart.fs
@@ -38,7 +38,7 @@ module Fold =
         let ofSnapshot (s: Events.Compaction.State) : State =
             { items = [ for i in s.items -> { skuId = i.skuId; quantity = i.quantity; returnsWaived = i.returnsWaived } ] }
     let initial = { items = [] }
-    let originEventType = nameof Events.Snapshotted
+    let snapshotEventCaseName = nameof Events.Snapshotted
     let evolve (state : State) event =
         let updateItems f = { state with items = f state.items }
         match event with

--- a/samples/Store/Domain/Cart.fs
+++ b/samples/Store/Domain/Cart.fs
@@ -38,7 +38,8 @@ module Fold =
         let ofSnapshot (s: Events.Compaction.State) : State =
             { items = [ for i in s.items -> { skuId = i.skuId; quantity = i.quantity; returnsWaived = i.returnsWaived } ] }
     let initial = { items = [] }
-    // Should match the event type that is stored, which does not necessarily match the case name
+    // NOTE Should match the event type that is stored, which does not necessarily match the case name
+    // e.g. if you override the name via [<DataMember(Name="snapshot-2")>], it needs to reflect that
     let snapshotEventCaseName = nameof Events.Snapshotted
     let evolve (state : State) event =
         let updateItems f = { state with items = f state.items }

--- a/samples/Store/Domain/Cart.fs
+++ b/samples/Store/Domain/Cart.fs
@@ -38,6 +38,7 @@ module Fold =
         let ofSnapshot (s: Events.Compaction.State) : State =
             { items = [ for i in s.items -> { skuId = i.skuId; quantity = i.quantity; returnsWaived = i.returnsWaived } ] }
     let initial = { items = [] }
+    let originEventType = nameof Events.Snapshotted
     let evolve (state : State) event =
         let updateItems f = { state with items = f state.items }
         match event with

--- a/src/Equinox.Core/Infrastructure.fs
+++ b/src/Equinox.Core/Infrastructure.fs
@@ -67,3 +67,4 @@ module Seq =
 module Array =
 
     let inline chooseV f xs = [| for item in xs do match f item with ValueSome v -> yield v | ValueNone -> () |]
+    let inline tryExactlyOneV (xs : _ array) = if xs.Length = 0 then ValueNone else ValueSome xs[0]

--- a/src/Equinox.Core/Infrastructure.fs
+++ b/src/Equinox.Core/Infrastructure.fs
@@ -67,4 +67,4 @@ module Seq =
 module Array =
 
     let inline chooseV f xs = [| for item in xs do match f item with ValueSome v -> yield v | ValueNone -> () |]
-    let inline tryExactlyOneV (xs : _ array) = if xs.Length = 0 then ValueNone else ValueSome xs[0]
+    let inline tryFirstV (xs : _ array) = if xs.Length = 0 then ValueNone else ValueSome xs[0]

--- a/src/Equinox.MessageDb/Equinox.MessageDb.fsproj
+++ b/src/Equinox.MessageDb/Equinox.MessageDb.fsproj
@@ -15,8 +15,8 @@
         <Compile Include="..\Equinox.Core\Internal.fs">
             <Link>Internal.fs</Link>
         </Compile>
-        <Compile Include="Tracing.fs" />
         <Compile Include="MessageDbClient.fs" />
+        <Compile Include="Tracing.fs" />
         <Compile Include="MessageDb.fs" />
     </ItemGroup>
 

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -1,14 +1,14 @@
 ﻿namespace Equinox.MessageDb
 
-open System.Text.Json
 open Equinox.Core
+open Equinox.Core.Tracing
 open Equinox.MessageDb.Core
 open FsCodec
 open FsCodec.Core
 open Serilog
 open System
 open System.Diagnostics
-open Equinox.Core.Tracing
+open System.Text.Json
 
 type EventBody = ReadOnlyMemory<byte>
 

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -126,7 +126,7 @@ module Log =
 
 module private Write =
 
-    let private writeEventsAsync (writer: MessageDbWriter) (streamName : string) (version : int64 option) (events : IEventData<EventBody> array)
+    let private writeEventsAsync (writer : MessageDbWriter) (streamName : string) (version : int64 option) (events : IEventData<EventBody> array)
         : Async<MdbSyncResult> = async {
         let! ct = Async.CancellationToken
         return! writer.WriteMessages(streamName, events, ct, ?version = version) |> Async.AwaitTaskCorrect }
@@ -181,7 +181,7 @@ module Read =
         let isLast = int64 page.Length < batchSize
         return toSlice page isLast }
 
-    let private readLastEventAsync (reader : MessageDbReader) (streamName : string) (requiresLeader : bool) (eventType: string option) ct = task {
+    let private readLastEventAsync (reader : MessageDbReader) (streamName : string) (requiresLeader : bool) (eventType : string option) ct = task {
         let! events = reader.ReadLastEvent(streamName, requiresLeader, ct, ?eventType = eventType)
         return toSlice events false }
 
@@ -297,7 +297,7 @@ module private Token =
 module private Snapshot =
     let inline snapshotCategory original = original + ":snapshot"
     let inline streamName category (streamId : string) = Equinox.Core.StreamName.render (snapshotCategory category) streamId
-    type Meta = {| streamVersion: int64 |} // STJ doesn't want to serialize it unless its anonymous
+    type Meta = {| streamVersion : int64 |} // STJ doesn't want to serialize it unless its anonymous
     let private streamVersion (evt: ITimelineEvent<EventBody>) =
         let meta = evt.Meta // avoid defensive copy
         JsonSerializer.Deserialize<Meta>(meta.Span).streamVersion

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -384,6 +384,7 @@ type private Category<'event, 'state, 'context>(context : MessageDbContext, code
         | None -> context.LoadBatched(streamName, requireLeader, log, codec.TryDecode)
         | Some AccessStrategy.LatestKnownEvent -> context.LoadLast(streamName, requireLeader, log, codec.TryDecode)
         | Some (AccessStrategy.AdjacentSnapshots (snapshotType, _)) -> async {
+
             match! context.LoadSnapshot(category, streamId, requireLeader, log, codec.TryDecode, snapshotType) with
             | ValueSome (pos, snapshotEvent) ->
                 let! token, rest = context.Reload(streamName, requireLeader, log, pos, codec.TryDecode)

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -420,8 +420,8 @@ type private Category<'event, 'state, 'context>(context : MessageDbContext, code
             match access with
             | None | Some AccessStrategy.LatestKnownEvent -> ()
             | Some (AccessStrategy.AdjacentSnapshots(_, toSnap)) ->
-              if Token.shouldSnapshot context.BatchOptions.BatchSize token token' then
-                do! x.StoreSnapshot(categoryName, streamId, log, ctx, token', toSnap state')
+                if Token.shouldSnapshot context.BatchOptions.BatchSize token token' then
+                    do! x.StoreSnapshot(categoryName, streamId, log, ctx, token', toSnap state')
             return SyncResult.Written   (token', state') }
 
 type private Folder<'event, 'state, 'context>(category : Category<'event, 'state, 'context>, fold : 'state -> 'event seq -> 'state, initial : 'state, ?readCache) =

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -302,7 +302,7 @@ module private Snapshot =
         let meta = evt.Meta // avoid defensive copy
         JsonSerializer.Deserialize<Meta>(meta.Span).streamVersion
     let decode tryDecode (events : ITimelineEvent<EventBody> array) =
-        match events |> Array.tryExactlyOneV |> ValueOption.bind tryDecode with
+        match events |> Array.tryFirstV |> ValueOption.bind tryDecode with
         | ValueSome decoded -> ValueSome struct(events[0] |> streamVersion |> Token.create, decoded)
         | ValueNone -> ValueNone
 

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -128,9 +128,7 @@ module Log =
 module private Write =
 
     let private writeEventsAsync (writer : MessageDbWriter) streamName version events ct : Task<MdbSyncResult> =
-        writer.WriteMessages(streamName, events, ct, ?version = version)
-
-
+        writer.WriteMessages(streamName, events, version, ct)
     let inline len (bytes: EventBody) = bytes.Length
     let private eventDataLen (x : IEventData<EventBody>) = len x.Data + len x.Meta
     let private eventDataBytes events = events |> Array.sumBy eventDataLen

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -384,7 +384,6 @@ type private Category<'event, 'state, 'context>(context : MessageDbContext, code
         | None -> context.LoadBatched(streamName, requireLeader, log, codec.TryDecode)
         | Some AccessStrategy.LatestKnownEvent -> context.LoadLast(streamName, requireLeader, log, codec.TryDecode)
         | Some (AccessStrategy.AdjacentSnapshots (snapshotType, _)) -> async {
-
             match! context.LoadSnapshot(category, streamId, requireLeader, log, codec.TryDecode, snapshotType) with
             | ValueSome (pos, snapshotEvent) ->
                 let! token, rest = context.Reload(streamName, requireLeader, log, pos, codec.TryDecode)

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -340,7 +340,7 @@ type MessageDbContext(connection : MessageDbConnection, batchOptions : BatchOpti
     member _.StoreSnapshot(category, streamId, log, event) = async {
         let snapshotStream = Snapshot.streamName category streamId
         let category = Snapshot.snapshotCategory category
-        do! Write.writeEvents log None connection.Writer (category, streamId, snapshotStream) None [| event |] |> Async.Ignore }
+        do! Write.writeEvents log None connection.Writer (category, streamId, snapshotStream) Any [| event |] |> Async.Ignore }
 
     member _.Reload(streamName, requireLeader, log, token, tryDecode)
         : Async<StreamToken * 'event array> = async {
@@ -351,7 +351,7 @@ type MessageDbContext(connection : MessageDbConnection, batchOptions : BatchOpti
 
     member _.TrySync(log, category, streamId, streamName, token, encodedEvents : IEventData<EventBody> array): Async<GatewaySyncResult> = async {
         let streamVersion = Token.streamVersion token
-        match! Write.writeEvents log connection.WriteRetryPolicy connection.Writer (category, streamId, streamName) (Some streamVersion) encodedEvents with
+        match! Write.writeEvents log connection.WriteRetryPolicy connection.Writer (category, streamId, streamName) (StreamVersion streamVersion) encodedEvents with
         | MdbSyncResult.ConflictUnknown ->
             return GatewaySyncResult.ConflictUnknown
         | MdbSyncResult.Written version' ->

--- a/src/Equinox.MessageDb/MessageDbClient.fs
+++ b/src/Equinox.MessageDb/MessageDbClient.fs
@@ -14,11 +14,11 @@ type MdbSyncResult = Written of int64 | ConflictUnknown
 type private Format = ReadOnlyMemory<byte>
 
 module private Sql =
-    let addNullableInt64 (name, value: int64 option) (p: NpgsqlParameterCollection) =
+    let addNullableInt64 name (value : int64 option) (p: NpgsqlParameterCollection) =
         match value with
         | Some value -> p.AddWithValue(name, NpgsqlDbType.Bigint, value) |> ignore
         | None       -> p.AddWithValue(name, NpgsqlDbType.Bigint, DBNull.Value) |> ignore
-    let addNullableString (name, value: string option) (p: NpgsqlParameterCollection) =
+    let addNullableString name (value : string option) (p: NpgsqlParameterCollection) =
         match value with
         | Some value -> p.AddWithValue(name, NpgsqlDbType.Text, value) |> ignore
         | None       -> p.AddWithValue(name, NpgsqlDbType.Text, DBNull.Value) |> ignore
@@ -50,7 +50,7 @@ type MessageDbWriter(connectionString : string) =
         cmd.Parameters.AddWithValue("EventType", NpgsqlDbType.Text, e.EventType) |> ignore
         cmd.Parameters |> Json.addParameter "Data" e.Data
         cmd.Parameters |> Json.addParameter "Meta" e.Meta
-        cmd.Parameters |> Sql.addNullableInt64("ExpectedVersion", expectedVersion)
+        cmd.Parameters |> Sql.addNullableInt64 "ExpectedVersion" expectedVersion
 
         cmd
 
@@ -97,7 +97,7 @@ type MessageDbReader internal (connectionString : string, leaderConnectionString
                time
              from get_last_stream_message(@StreamName, @EventType);")
         cmd.Parameters.AddWithValue("StreamName", NpgsqlDbType.Text, streamName) |> ignore
-        cmd.Parameters |> Sql.addNullableString("EventType", eventType)
+        cmd.Parameters |> Sql.addNullableString "EventType" eventType
         use! reader = cmd.ExecuteReaderAsync(ct)
 
         if reader.Read() then return [| parseRow reader |]

--- a/src/Equinox.MessageDb/MessageDbClient.fs
+++ b/src/Equinox.MessageDb/MessageDbClient.fs
@@ -19,7 +19,7 @@ module private Sql =
     let addExpectedVersion name (value : ExpectedVersion) (p: NpgsqlParameterCollection) =
         match value with
         | StreamVersion value -> p.AddWithValue(name, NpgsqlDbType.Bigint, value) |> ignore
-        | Any           -> p.AddWithValue(name, NpgsqlDbType.Bigint, DBNull.Value) |> ignore
+        | Any                 -> p.AddWithValue(name, NpgsqlDbType.Bigint, DBNull.Value) |> ignore
     let addNullableString name (value : string option) (p: NpgsqlParameterCollection) =
         match value with
         | Some value -> p.AddWithValue(name, NpgsqlDbType.Text, value) |> ignore

--- a/src/Equinox.MessageDb/MessageDbClient.fs
+++ b/src/Equinox.MessageDb/MessageDbClient.fs
@@ -54,7 +54,7 @@ type MessageDbWriter(connectionString : string) =
 
         cmd
 
-    member _.WriteMessages(streamName, events : _ array, ct, ?version : int64) = task {
+    member _.WriteMessages(streamName, events : _ array, version, ct) = task {
         use! conn = Npgsql.connect connectionString ct
         use transaction = conn.BeginTransaction()
         use batch = new NpgsqlBatch(conn, transaction)

--- a/src/Equinox.MessageDb/Tracing.fs
+++ b/src/Equinox.MessageDb/Tracing.fs
@@ -19,8 +19,12 @@ type ActivityExtensions =
         act
 
     [<System.Runtime.CompilerServices.Extension>]
+<<<<<<< Updated upstream
     static member AddExpectedVersion(act: Activity, version: int64) =
         act.AddTag("eqx.expected_version", version)
+=======
+    static member AddExpectedVersion(act: Activity, version: int64 option) = act.AddTag("eqx.expected_version", version)
+>>>>>>> Stashed changes
 
     [<System.Runtime.CompilerServices.Extension>]
     static member AddLastVersion(act: Activity, version: int64) =

--- a/src/Equinox.MessageDb/Tracing.fs
+++ b/src/Equinox.MessageDb/Tracing.fs
@@ -20,7 +20,7 @@ type ActivityExtensions =
 
     [<System.Runtime.CompilerServices.Extension>]
     static member AddExpectedVersion(act: Activity, version: int64 option) =
-        act.AddTag("eqx.expected_version", version)
+        match version with Some v -> act.AddTag("eqx.expected_version", v) | None -> act
 
     [<System.Runtime.CompilerServices.Extension>]
     static member AddLastVersion(act: Activity, version: int64) =

--- a/src/Equinox.MessageDb/Tracing.fs
+++ b/src/Equinox.MessageDb/Tracing.fs
@@ -19,12 +19,8 @@ type ActivityExtensions =
         act
 
     [<System.Runtime.CompilerServices.Extension>]
-<<<<<<< Updated upstream
-    static member AddExpectedVersion(act: Activity, version: int64) =
+    static member AddExpectedVersion(act: Activity, version: int64 option) =
         act.AddTag("eqx.expected_version", version)
-=======
-    static member AddExpectedVersion(act: Activity, version: int64 option) = act.AddTag("eqx.expected_version", version)
->>>>>>> Stashed changes
 
     [<System.Runtime.CompilerServices.Extension>]
     static member AddLastVersion(act: Activity, version: int64) =

--- a/src/Equinox.MessageDb/Tracing.fs
+++ b/src/Equinox.MessageDb/Tracing.fs
@@ -3,6 +3,7 @@ module internal Equinox.MessageDb.Tracing
 
 open Equinox.Core.Tracing
 open System.Diagnostics
+open Equinox.MessageDb.Core
 
 let source = new ActivitySource("Equinox.MessageDb")
 
@@ -19,8 +20,8 @@ type ActivityExtensions =
         act
 
     [<System.Runtime.CompilerServices.Extension>]
-    static member AddExpectedVersion(act: Activity, version: int64 option) =
-        match version with Some v -> act.AddTag("eqx.expected_version", v) | None -> act
+    static member AddExpectedVersion(act: Activity, version) =
+        match version with StreamVersion v -> act.AddTag("eqx.expected_version", v) | Any -> act
 
     [<System.Runtime.CompilerServices.Extension>]
     static member AddLastVersion(act: Activity, version: int64) =

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -507,7 +507,7 @@ type Tests(testOutputHelper) =
 
 #if STORE_MESSAGEDB
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
-    let ``Can combine compaction with caching against Store`` (ctx, skuId) = Async.RunSynchronously <| async {
+    let ``Can combine snapshotting with caching against Store`` (ctx, skuId) = Async.RunSynchronously <| async {
         let log, capture = output.CreateLoggerWithCapture()
         let! client = connectToLocalStore log
         let batchSize = 10

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -325,13 +325,11 @@ type Tests(testOutputHelper) =
     let batchBackwardsAndAppend = singleBatchBackwards @ [EsAct.Append]
 #endif
 
+    #if !STORE_MESSAGEDB
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
     let ``Can roundtrip against Store, correctly compacting to avoid redundant reads`` (ctx, skuId) = Async.RunSynchronously <| async {
         #if NET
         use _ = source.StartActivity("Can roundtrip against Store, correctly compacting to avoid redundant reads")
-        #endif
-        #if STORE_MESSAGEDB
-        let singleBatchBackwards = readSnapshotted
         #endif
         let log, capture = output.CreateLoggerWithCapture()
         let! client = connectToLocalStore log
@@ -345,22 +343,12 @@ type Tests(testOutputHelper) =
         let! _ = service.Read cartId
 
         // ... should see a single read as we are inside the batch threshold
-        #if STORE_MESSAGEDB
-        // The number of events is equal to the batch size, so it will append
-        // a snapshot event
-        test <@ readSnapshotted @ [EsAct.Append; EsAct.Append] @ readSnapshotted = capture.ExternalCalls @>
-        #else
         test <@ batchBackwardsAndAppend @ singleBatchBackwards = capture.ExternalCalls @>
-        #endif
 
         // Add two more, which should push it over the threshold and hence trigger inclusion of a snapshot event (but not incurr extra roundtrips)
         capture.Clear()
         do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 1
-        #if STORE_MESSAGEDB
-        test <@ readSnapshotted @ [EsAct.Append] = capture.ExternalCalls @>
-        #else
         test <@ batchBackwardsAndAppend = capture.ExternalCalls @>
-        #endif
 
         // While we now have 13 events, we should be able to read them with a single call
         capture.Clear()
@@ -370,11 +358,7 @@ type Tests(testOutputHelper) =
         // Add 8 more; total of 21 should not trigger snapshotting as Event Number 12 (the 13th one) is a shapshot
         capture.Clear()
         do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 4
-        #if STORE_MESSAGEDB
-        test <@ readSnapshotted @ [EsAct.Append; EsAct.Append] = capture.ExternalCalls @>
-        #else
         test <@ batchBackwardsAndAppend = capture.ExternalCalls @>
-        #endif
 
         // While we now have 21 events, we should be able to read them with a single call
         capture.Clear()
@@ -383,12 +367,55 @@ type Tests(testOutputHelper) =
         do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 1
         // and reload the 24 events with a single read
         let! _ = service.Read cartId
-        #if STORE_MESSAGEDB
-        test <@ readSnapshotted @ readSnapshotted @ [EsAct.Append] @ readSnapshotted = capture.ExternalCalls @>
-        #else
         test <@ singleBatchBackwards @ batchBackwardsAndAppend @ singleBatchBackwards = capture.ExternalCalls @>
-        #endif
     }
+    #else
+    [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
+    let ``Can roundtrip against Store, correctly snapshotting to avoid redundant reads`` (ctx, skuId) = Async.RunSynchronously <| async {
+        #if NET
+        use _ = source.StartActivity("Can roundtrip against Store, correctly snapshotting to avoid redundant reads")
+        #endif
+        let log, capture = output.CreateLoggerWithCapture()
+        let! client = connectToLocalStore log
+        let batchSize = 10
+        let context = createContext client batchSize
+        let service = Cart.createServiceWithCompaction log context
+
+        // Trigger 8 events, then reload
+        let cartId = % Guid.NewGuid()
+        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 4
+        let! _ = service.Read cartId
+
+        test <@ readSnapshotted @ [EsAct.Append] @ readSnapshotted = capture.ExternalCalls @>
+
+        // Add two more, which should push it over the threshold and hence trigger an append of a snapshot event
+        capture.Clear()
+        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 1
+        test <@ readSnapshotted @ [EsAct.Append; EsAct.Append] = capture.ExternalCalls @>
+
+        // We now have 10 events and should be able to read them with a single call
+        capture.Clear()
+        let! _ = service.Read cartId
+        test <@ readSnapshotted = capture.ExternalCalls @>
+
+        // Add 8 more; total of 18 should not trigger snapshotting as we snapshotted at Event Number 10
+        capture.Clear()
+        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 4
+        test <@ readSnapshotted @ [EsAct.Append] = capture.ExternalCalls @>
+
+        // While we now have 18 events, we should be able to read them with a single call
+        capture.Clear()
+        let! _ = service.Read cartId
+        test <@ readSnapshotted = capture.ExternalCalls @>
+
+        // add two more events, triggering a snapshot, then read it in a single snapshotted read
+        capture.Clear()
+        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 1
+        // and reload the 20 events with a single read
+        let! _ = service.Read cartId
+        test <@ readSnapshotted @ [EsAct.Append; EsAct.Append] @ readSnapshotted = capture.ExternalCalls @>
+    }
+    #endif
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
     let ``Can correctly read and update against Store, with LatestKnownEvent Access Strategy`` id value = Async.RunSynchronously <| async {

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -126,7 +126,7 @@ module Cart =
         |> Cart.create
 
     let createServiceWithCompaction log context =
-        Category(context, codec, fold, initial, access = AccessStrategy.RollingSnapshots snapshot)
+        Category(context, codec, fold, initial, access = AccessStrategy.AdjacentSnapshots snapshot)
         |> Equinox.Decider.resolve log
         |> Cart.create
 
@@ -138,7 +138,7 @@ module Cart =
 
     let createServiceWithCompactionAndCaching log context cache =
         let sliding20m = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        Category(context, codec, fold, initial, sliding20m, AccessStrategy.RollingSnapshots snapshot)
+        Category(context, codec, fold, initial, sliding20m, AccessStrategy.AdjacentSnapshots snapshot)
         |> Equinox.Decider.resolve log
         |> Cart.create
 

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -168,7 +168,20 @@ module ContactPreferences =
         |> Equinox.Decider.resolve log
         |> ContactPreferences.create
 
-type Tests(testOutputHelper) =
+let addAndThenRemoveItems optimistic exceptTheLastOne context cartId skuId (service: Cart.Service) count =
+        service.ExecuteManyAsync(cartId, optimistic, seq {
+            for i in 1..count do
+                yield Cart.SyncItem (context, skuId, Some i, None)
+                if not exceptTheLastOne || i <> count then
+                    yield Cart.SyncItem (context, skuId, Some 0, None) })
+let addAndThenRemoveItemsManyTimes context cartId skuId service count =
+    addAndThenRemoveItems false false context cartId skuId service count
+let addAndThenRemoveItemsManyTimesExceptTheLastOne context cartId skuId service count =
+    addAndThenRemoveItems false true context cartId skuId service count
+let addAndThenRemoveItemsOptimisticManyTimesExceptTheLastOne context cartId skuId service count =
+    addAndThenRemoveItems true true context cartId skuId service count
+
+type GeneralTests(testOutputHelper) =
     #if STORE_MESSAGEDB
     let sdk =
         Sdk.CreateTracerProviderBuilder()
@@ -182,19 +195,6 @@ type Tests(testOutputHelper) =
     #endif
 
     let output = TestContext(testOutputHelper)
-
-    let addAndThenRemoveItems optimistic exceptTheLastOne context cartId skuId (service: Cart.Service) count =
-        service.ExecuteManyAsync(cartId, optimistic, seq {
-            for i in 1..count do
-                yield Cart.SyncItem (context, skuId, Some i, None)
-                if not exceptTheLastOne || i <> count then
-                    yield Cart.SyncItem (context, skuId, Some 0, None) })
-    let addAndThenRemoveItemsManyTimes context cartId skuId service count =
-        addAndThenRemoveItems false false context cartId skuId service count
-    let addAndThenRemoveItemsManyTimesExceptTheLastOne context cartId skuId service count =
-        addAndThenRemoveItems false true context cartId skuId service count
-    let addAndThenRemoveItemsOptimisticManyTimesExceptTheLastOne context cartId skuId service count =
-        addAndThenRemoveItems true true context cartId skuId service count
 
 #if STORE_EVENTSTOREDB // gRPC does not expose slice metrics
     let sliceForward = []
@@ -321,111 +321,18 @@ type Tests(testOutputHelper) =
         test <@ [1; 1] = [for c in [capture1; capture2] -> c.ChooseCalls hadConflict |> List.length] @>
     }
 
-#if STORE_MESSAGEDB // MessageDB doesn't report Batches for "Read Last Event" scenarios
-    let singleBatchBackwards = [EsAct.ReadLast]
-    let batchBackwardsAndAppend = [EsAct.ReadLast; EsAct.Append]
-    let readSnapshotted = [EsAct.ReadLast; EsAct.SliceForward; EsAct.BatchForward]
-#else
 #if STORE_EVENTSTOREDB // gRPC does not expose slice metrics
     let sliceBackward = []
 #else
     let sliceBackward = [EsAct.SliceBackward]
 #endif
+#if STORE_MESSAGEDB // MessageDB doesn't report Batches for "Read Last Event" scenarios
+    let singleBatchBackwards = [EsAct.ReadLast]
+    let batchBackwardsAndAppend = [EsAct.ReadLast; EsAct.Append]
+#else
     let singleBatchBackwards = sliceBackward @ [EsAct.BatchBackward]
     let batchBackwardsAndAppend = singleBatchBackwards @ [EsAct.Append]
 #endif
-
-    #if !STORE_MESSAGEDB
-    [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
-    let ``Can roundtrip against Store, correctly compacting to avoid redundant reads`` (ctx, skuId) = Async.RunSynchronously <| async {
-        #if NET
-        use _ = source.StartActivity("Can roundtrip against Store, correctly compacting to avoid redundant reads")
-        #endif
-        let log, capture = output.CreateLoggerWithCapture()
-        let! client = connectToLocalStore log
-        let batchSize = 10
-        let context = createContext client batchSize
-        let service = Cart.createServiceWithCompaction log context
-
-        // Trigger 10 events, then reload
-        let cartId = % Guid.NewGuid()
-        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 5
-        let! _ = service.Read cartId
-
-        // ... should see a single read as we are inside the batch threshold
-        test <@ batchBackwardsAndAppend @ singleBatchBackwards = capture.ExternalCalls @>
-
-        // Add two more, which should push it over the threshold and hence trigger inclusion of a snapshot event (but not incurr extra roundtrips)
-        capture.Clear()
-        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 1
-        test <@ batchBackwardsAndAppend = capture.ExternalCalls @>
-
-        // While we now have 13 events, we should be able to read them with a single call
-        capture.Clear()
-        let! _ = service.Read cartId
-        test <@ singleBatchBackwards = capture.ExternalCalls @>
-
-        // Add 8 more; total of 21 should not trigger snapshotting as Event Number 12 (the 13th one) is a shapshot
-        capture.Clear()
-        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 4
-        test <@ batchBackwardsAndAppend = capture.ExternalCalls @>
-
-        // While we now have 21 events, we should be able to read them with a single call
-        capture.Clear()
-        let! _ = service.Read cartId
-        // ... and trigger a second snapshotting (inducing a single additional read + write)
-        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 1
-        // and reload the 24 events with a single read
-        let! _ = service.Read cartId
-        test <@ singleBatchBackwards @ batchBackwardsAndAppend @ singleBatchBackwards = capture.ExternalCalls @>
-    }
-    #else
-    [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
-    let ``Can roundtrip against Store, correctly snapshotting to avoid redundant reads`` (ctx, skuId) = Async.RunSynchronously <| async {
-        #if NET
-        use _ = source.StartActivity("Can roundtrip against Store, correctly snapshotting to avoid redundant reads")
-        #endif
-        let log, capture = output.CreateLoggerWithCapture()
-        let! client = connectToLocalStore log
-        let batchSize = 10
-        let context = createContext client batchSize
-        let service = Cart.createServiceWithAdjacentSnapshotting  log context
-
-        // Trigger 8 events, then reload
-        let cartId = % Guid.NewGuid()
-        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 4
-        let! _ = service.Read cartId
-
-        test <@ readSnapshotted @ [EsAct.Append] @ readSnapshotted = capture.ExternalCalls @>
-
-        // Add two more, which should push it over the threshold and hence trigger an append of a snapshot event
-        capture.Clear()
-        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 1
-        test <@ readSnapshotted @ [EsAct.Append; EsAct.Append] = capture.ExternalCalls @>
-
-        // We now have 10 events and should be able to read them with a single call
-        capture.Clear()
-        let! _ = service.Read cartId
-        test <@ readSnapshotted = capture.ExternalCalls @>
-
-        // Add 8 more; total of 18 should not trigger snapshotting as we snapshotted at Event Number 10
-        capture.Clear()
-        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 4
-        test <@ readSnapshotted @ [EsAct.Append] = capture.ExternalCalls @>
-
-        // While we now have 18 events, we should be able to read them with a single call
-        capture.Clear()
-        let! _ = service.Read cartId
-        test <@ readSnapshotted = capture.ExternalCalls @>
-
-        // add two more events, triggering a snapshot, then read it in a single snapshotted read
-        capture.Clear()
-        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 1
-        // and reload the 20 events with a single read
-        let! _ = service.Read cartId
-        test <@ readSnapshotted @ [EsAct.Append; EsAct.Append] @ readSnapshotted = capture.ExternalCalls @>
-    }
-    #endif
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
     let ``Can correctly read and update against Store, with LatestKnownEvent Access Strategy`` id value = Async.RunSynchronously <| async {
@@ -517,53 +424,94 @@ type Tests(testOutputHelper) =
         test <@ [EsAct.AppendConflict; yield! sliceForward; EsAct.BatchForward] = capture.ExternalCalls @>
     }
 
-#if STORE_MESSAGEDB
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
-    let ``Can combine snapshotting with caching against Store`` (ctx, skuId) = Async.RunSynchronously <| async {
+    let ``Version is 0-based`` () = Async.RunSynchronously <| async {
+        #if NET
+        use _ = source.StartActivity("Version is 0-based")
+        #endif
+        let log, _ = output.CreateLoggerWithCapture()
+        let! connection = connectToLocalStore log
+
+        let batchSize = 3
+        let context = createContext connection batchSize
+        let id = Guid.NewGuid()
+        let toStreamId (x : Guid) = x.ToString "N"
+        let decider = SimplestThing.resolve log context SimplestThing.Category (Equinox.StreamId.gen toStreamId id)
+
+        let! before, after = decider.TransactEx(
+            (fun state -> state.Version, [SimplestThing.StuffHappened]),
+            mapResult = (fun result ctx-> result, ctx.Version))
+        test <@ [before; after] = [0L; 1L] @>
+    }
+
+#if STORE_MESSAGEDB
+    interface IDisposable with
+      member _.Dispose() = sdk.Shutdown() |> ignore
+#endif
+
+
+#if !STORE_MESSAGEDB
+type RollingSnapshotTests(testOutputHelper) =
+    let output = TestContext(testOutputHelper)
+#if STORE_EVENTSTOREDB // gRPC does not expose slice metrics
+    let sliceForward = []
+#else
+    let sliceForward = [EsAct.SliceForward]
+#endif
+    let singleBatchForward = sliceForward @ [EsAct.BatchForward]
+
+#if STORE_EVENTSTOREDB // gRPC does not expose slice metrics
+    let sliceBackward = []
+#else
+    let sliceBackward = [EsAct.SliceBackward]
+#endif
+    let singleBatchBackwards = sliceBackward @ [EsAct.BatchBackward]
+    let batchBackwardsAndAppend = singleBatchBackwards @ [EsAct.Append]
+
+    [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
+    let ``Can roundtrip against Store, correctly compacting to avoid redundant reads`` (ctx, skuId) = Async.RunSynchronously <| async {
+        #if NET
+        use _ = source.StartActivity("Can roundtrip against Store, correctly compacting to avoid redundant reads")
+        #endif
         let log, capture = output.CreateLoggerWithCapture()
         let! client = connectToLocalStore log
         let batchSize = 10
         let context = createContext client batchSize
-        let service1 = Cart.createServiceWithAdjacentSnapshotting log context
-        let cache = Equinox.Cache("cart", sizeMb = 50)
-        let context = createContext client batchSize
-        let service2 = Cart.createServiceWithSnapshottingAndCaching log context cache
+        let service = Cart.createServiceWithCompaction log context
 
-        // Trigger 8 events, then reload
+        // Trigger 10 events, then reload
         let cartId = % Guid.NewGuid()
-        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service1 4
-        let! _ = service2.Read cartId
+        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 5
+        let! _ = service.Read cartId
 
-        // ... should see a single append as we are inside the batch threshold
-        test <@ readSnapshotted @ [EsAct.Append] @ readSnapshotted = capture.ExternalCalls @>
+        // ... should see a single read as we are inside the batch threshold
+        test <@ batchBackwardsAndAppend @ singleBatchBackwards = capture.ExternalCalls @>
 
-        // Add two more, which should push it over the threshold and hence trigger generation of a snapshot event
+        // Add two more, which should push it over the threshold and hence trigger inclusion of a snapshot event (but not incurr extra roundtrips)
         capture.Clear()
-        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service1 1
-        test <@ readSnapshotted @ [EsAct.Append; EsAct.Append] = capture.ExternalCalls @>
+        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 1
+        test <@ batchBackwardsAndAppend = capture.ExternalCalls @>
 
-        // We now have 10 events, we should be able to read them with a single snapshotted read
+        // While we now have 13 events, we should be able to read them with a single call
         capture.Clear()
-        let! _ = service1.Read cartId
-        test <@ readSnapshotted = capture.ExternalCalls @>
+        let! _ = service.Read cartId
+        test <@ singleBatchBackwards = capture.ExternalCalls @>
 
-        // Add 8 more; total of 18 should not trigger snapshotting as the snapshot is at version 10
+        // Add 8 more; total of 21 should not trigger snapshotting as Event Number 12 (the 13th one) is a shapshot
         capture.Clear()
-        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service1 4
-        test <@ readSnapshotted @ [EsAct.Append] = capture.ExternalCalls @>
+        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 4
+        test <@ batchBackwardsAndAppend = capture.ExternalCalls @>
 
-        // While we now have 18 events, we should be able to read them with a single snapshotted read
+        // While we now have 21 events, we should be able to read them with a single call
         capture.Clear()
-        let! _ = service1.Read cartId
-        test <@ readSnapshotted = capture.ExternalCalls @>
-        // ... trigger a second snapshotting
-        capture.Clear()
-        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service1 1
-        // and we _could_ reload the 20 events with a single read. However we are using the cache, which last saw it with 10 events, which necessitates two reads
-        let! _ = service2.Read cartId
-        test <@ readSnapshotted @ [EsAct.Append; EsAct.Append] @ sliceForward @ singleBatchForward = capture.ExternalCalls @>
+        let! _ = service.Read cartId
+        // ... and trigger a second snapshotting (inducing a single additional read + write)
+        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 1
+        // and reload the 24 events with a single read
+        let! _ = service.Read cartId
+        test <@ singleBatchBackwards @ batchBackwardsAndAppend @ singleBatchBackwards = capture.ExternalCalls @>
     }
-#else
+
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
     let ``Can combine compaction with caching against Store`` (ctx, skuId) = Async.RunSynchronously <| async {
         let log, capture = output.CreateLoggerWithCapture()
@@ -609,27 +557,118 @@ type Tests(testOutputHelper) =
         test <@ singleBatchBackwards @ batchBackwardsAndAppend @ suboptimalExtraSlice @ singleBatchForward = capture.ExternalCalls @>
     }
 #endif
-    [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
-    let ``Version is 0-based`` () = Async.RunSynchronously <| async {
-        #if NET
-        use _ = source.StartActivity("Version is 0-based")
-        #endif
-        let log, _ = output.CreateLoggerWithCapture()
-        let! connection = connectToLocalStore log
 
-        let batchSize = 3
-        let context = createContext connection batchSize
-        let id = Guid.NewGuid()
-        let toStreamId (x : Guid) = x.ToString "N"
-        let decider = SimplestThing.resolve log context SimplestThing.Category (Equinox.StreamId.gen toStreamId id)
-
-        let! before, after = decider.TransactEx(
-            (fun state -> state.Version, [SimplestThing.StuffHappened]),
-            mapResult = (fun result ctx-> result, ctx.Version))
-        test <@ [before; after] = [0L; 1L] @>
-    }
 
 #if STORE_MESSAGEDB
+type AdjacentSnapshotTests(testOutputHelper) =
+    let sdk =
+        Sdk.CreateTracerProviderBuilder()
+           .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(serviceName = "mdbi"))
+           .AddSource("Equinox")
+           .AddSource("Equinox.MessageDb")
+           .AddSource("StoreIntegration")
+           .AddSource("Npqsl")
+           .AddOtlpExporter(fun opts -> opts.Endpoint <- Uri("http://localhost:4317"))
+           .Build()
+
+    let output = TestContext(testOutputHelper)
+
+    let sliceForward = [EsAct.SliceForward]
+    let singleBatchForward = [EsAct.SliceForward; EsAct.BatchForward]
+    let readSnapshotted = [EsAct.ReadLast; EsAct.SliceForward; EsAct.BatchForward]
+
+    [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
+    let ``Can roundtrip against Store, correctly snapshotting to avoid redundant reads`` (ctx, skuId) = Async.RunSynchronously <| async {
+        #if NET
+        use _ = source.StartActivity("Can roundtrip against Store, correctly snapshotting to avoid redundant reads")
+        #endif
+        let log, capture = output.CreateLoggerWithCapture()
+        let! client = connectToLocalStore log
+        let batchSize = 10
+        let context = createContext client batchSize
+        let service = Cart.createServiceWithAdjacentSnapshotting  log context
+
+        // Trigger 8 events, then reload
+        let cartId = % Guid.NewGuid()
+        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 4
+        let! _ = service.Read cartId
+
+        test <@ readSnapshotted @ [EsAct.Append] @ readSnapshotted = capture.ExternalCalls @>
+
+        // Add two more, which should push it over the threshold and hence trigger an append of a snapshot event
+        capture.Clear()
+        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 1
+        test <@ readSnapshotted @ [EsAct.Append; EsAct.Append] = capture.ExternalCalls @>
+
+        // We now have 10 events and should be able to read them with a single call
+        capture.Clear()
+        let! _ = service.Read cartId
+        test <@ readSnapshotted = capture.ExternalCalls @>
+
+        // Add 8 more; total of 18 should not trigger snapshotting as we snapshotted at Event Number 10
+        capture.Clear()
+        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 4
+        test <@ readSnapshotted @ [EsAct.Append] = capture.ExternalCalls @>
+
+        // While we now have 18 events, we should be able to read them with a single call
+        capture.Clear()
+        let! _ = service.Read cartId
+        test <@ readSnapshotted = capture.ExternalCalls @>
+
+        // add two more events, triggering a snapshot, then read it in a single snapshotted read
+        capture.Clear()
+        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service 1
+        // and reload the 20 events with a single read
+        let! _ = service.Read cartId
+        test <@ readSnapshotted @ [EsAct.Append; EsAct.Append] @ readSnapshotted = capture.ExternalCalls @>
+    }
+
+    [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
+    let ``Can combine snapshotting with caching against Store`` (ctx, skuId) = Async.RunSynchronously <| async {
+        let log, capture = output.CreateLoggerWithCapture()
+        let! client = connectToLocalStore log
+        let batchSize = 10
+        let context = createContext client batchSize
+        let service1 = Cart.createServiceWithAdjacentSnapshotting log context
+        let cache = Equinox.Cache("cart", sizeMb = 50)
+        let context = createContext client batchSize
+        let service2 = Cart.createServiceWithSnapshottingAndCaching log context cache
+
+        // Trigger 8 events, then reload
+        let cartId = % Guid.NewGuid()
+        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service1 4
+        let! _ = service2.Read cartId
+
+        // ... should see a single append as we are inside the batch threshold
+        test <@ readSnapshotted @ [EsAct.Append] @ readSnapshotted = capture.ExternalCalls @>
+
+        // Add two more, which should push it over the threshold and hence trigger generation of a snapshot event
+        capture.Clear()
+        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service1 1
+        test <@ readSnapshotted @ [EsAct.Append; EsAct.Append] = capture.ExternalCalls @>
+
+        // We now have 10 events, we should be able to read them with a single snapshotted read
+        capture.Clear()
+        let! _ = service1.Read cartId
+        test <@ readSnapshotted = capture.ExternalCalls @>
+
+        // Add 8 more; total of 18 should not trigger snapshotting as the snapshot is at version 10
+        capture.Clear()
+        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service1 4
+        test <@ readSnapshotted @ [EsAct.Append] = capture.ExternalCalls @>
+
+        // While we now have 18 events, we should be able to read them with a single snapshotted read
+        capture.Clear()
+        let! _ = service1.Read cartId
+        test <@ readSnapshotted = capture.ExternalCalls @>
+        // ... trigger a second snapshotting
+        capture.Clear()
+        do! addAndThenRemoveItemsManyTimes ctx cartId skuId service1 1
+        // and we _could_ reload the 20 events with a single read. However we are using the cache, which last saw it with 10 events, which necessitates two reads
+        let! _ = service2.Read cartId
+        test <@ readSnapshotted @ [EsAct.Append; EsAct.Append] @ sliceForward @ singleBatchForward = capture.ExternalCalls @>
+    }
+
     interface IDisposable with
       member _.Dispose() = sdk.Shutdown() |> ignore
 #endif

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -315,16 +315,6 @@ type Tests(testOutputHelper) =
     let singleBatchBackwards = [EsAct.ReadLast]
     let batchBackwardsAndAppend = [EsAct.ReadLast; EsAct.Append]
     let readSnapshotted = [EsAct.ReadLast; EsAct.SliceForward; EsAct.BatchForward]
-    (*
-   [0] = {SerilogHelpers.EsAct} ReadLast
-[1] = {SerilogHelpers.EsAct} SliceForward
-[2] = {SerilogHelpers.EsAct} BatchForward
-[3] = {SerilogHelpers.EsAct} Append
-[4] = {SerilogHelpers.EsAct} Append
-[5] = {SerilogHelpers.EsAct} ReadLast
-[6] = {SerilogHelpers.EsAct} SliceForward
-[7] = {SerilogHelpers.EsAct} BatchForward
-    *)
 #else
 #if STORE_EVENTSTOREDB // gRPC does not expose slice metrics
     let sliceBackward = []


### PR DESCRIPTION
As discussed, this is likely not worth the trouble.

I'm sharing it here anyway, I'm not sure whether this should ultimately be offered up as functionality of the messagedb store or not 🤔. I see the MessageDb store as a starting point that teams could eventually grow out of if their scale demands. It provides a decent set of trade-offs for medium throughput systems, and as such adding snapshots should in most cases be unnecessary.