### PR TITLE
Esdb, Sss, Mdb: Implement ITimelineEvent.Size

### DIFF
--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -172,8 +172,8 @@ module Batch =
         let events =
             Seq.zip x.c x.e
             |> Seq.mapi (fun i (c, e) ->
-                let d, m = InternalBody.ofStreamAndEncoding (e.d, e.D), InternalBody.ofStreamAndEncoding (e.m, e.M)
-                { i = baseIndex + i; t = e.t; d = d; m = m; correlationId = e.x; causationId = e.y; c = c })
+                let data, meta = InternalBody.ofStreamAndEncoding (e.d, e.D), InternalBody.ofStreamAndEncoding (e.m, e.M)
+                { i = baseIndex + i; t = e.t; d = data; m = meta; correlationId = e.x; causationId = e.y; c = c })
         { p = x.p; b = x.b; i = x.i; etag = Option.toObj x.etag; n = x.n; e = Seq.toArray events; u = x.u |> Array.map ofUnfoldSchema }
     let enumEvents (minIndex, maxIndex) (x : Batch) : Event seq =
         let indexMin, indexMax = defaultArg minIndex 0L, defaultArg maxIndex Int64.MaxValue

--- a/src/Equinox.EventStoreDb/EventStoreDb.fs
+++ b/src/Equinox.EventStoreDb/EventStoreDb.fs
@@ -227,9 +227,9 @@ module ClientCodec =
         // TOCONSIDER wire e.Metadata["$correlationId"] and ["$causationId"] into correlationId and causationId
         // https://eventstore.org/docs/server/metadata-and-reserved-names/index.html#event-metadata
         let n, eu, ts = x.EventNumber, x.EventId, DateTimeOffset x.Created
-        let c, d, m = x.EventType, x.Data, x.Metadata
-        let size = c.Length + d.Length + m.Length
-        FsCodec.Core.TimelineEvent.Create(n.ToInt64(), c, d, m, eu.ToGuid(), correlationId = null, causationId = null, timestamp = ts, size = size)
+        let et, data, meta = x.EventType, x.Data, x.Metadata
+        let size = et.Length + data.Length + meta.Length
+        FsCodec.Core.TimelineEvent.Create(n.ToInt64(), et, data, meta, eu.ToGuid(), correlationId = null, causationId = null, timestamp = ts, size = size)
     let isSystemEvent (x : EventRecord) = x.EventStreamId.StartsWith '$'
     let isJson (x : EventRecord) = x.ContentType = "application/json"
 

--- a/src/Equinox.EventStoreDb/EventStoreDb.fs
+++ b/src/Equinox.EventStoreDb/EventStoreDb.fs
@@ -227,7 +227,9 @@ module ClientCodec =
         // TOCONSIDER wire e.Metadata["$correlationId"] and ["$causationId"] into correlationId and causationId
         // https://eventstore.org/docs/server/metadata-and-reserved-names/index.html#event-metadata
         let n, eu, ts = x.EventNumber, x.EventId, DateTimeOffset x.Created
-        FsCodec.Core.TimelineEvent.Create(n.ToInt64(), x.EventType, x.Data, x.Metadata, eu.ToGuid(), correlationId = null, causationId = null, timestamp = ts)
+        let c, d, m = x.EventType, x.Data, x.Metadata
+        let size = c.Length + d.Length + m.Length
+        FsCodec.Core.TimelineEvent.Create(n.ToInt64(), c, d, m, eu.ToGuid(), correlationId = null, causationId = null, timestamp = ts, size = size)
     let isSystemEvent (x : EventRecord) = x.EventStreamId.StartsWith '$'
     let isJson (x : EventRecord) = x.ContentType = "application/json"
 

--- a/src/Equinox.MessageDb/MessageDbClient.fs
+++ b/src/Equinox.MessageDb/MessageDbClient.fs
@@ -65,13 +65,13 @@ type MessageDbReader internal (connectionString : string, leaderConnectionString
 
     let parseRow (reader : DbDataReader) : ITimelineEvent<Format> =
         let inline readNullableString idx = if reader.IsDBNull(idx) then None else Some (reader.GetString idx)
-        let c, d, m = reader.GetString(1), reader |> Json.fromReader 2, reader |> Json.fromReader 3
+        let et, data, meta = reader.GetString(1), reader |> Json.fromReader 2, reader |> Json.fromReader 3
         FsCodec.Core.TimelineEvent.Create(
             index = reader.GetInt64(0),
-            eventType = c, data = d, meta = m, eventId = reader.GetGuid(4),
+            eventType = et, data = data, meta = meta, eventId = reader.GetGuid(4),
             ?correlationId = readNullableString 5, ?causationId = readNullableString 6,
             timestamp = DateTimeOffset(DateTime.SpecifyKind(reader.GetDateTime(7), DateTimeKind.Utc)),
-            size = c.Length + d.Length + m.Length)
+            size = et.Length + data.Length + meta.Length)
 
     member _.ReadLastEvent(streamName : string, requiresLeader, ct) = task {
         use! conn = connect requiresLeader ct

--- a/src/Equinox.SqlStreamStore/SqlStreamStore.fs
+++ b/src/Equinox.SqlStreamStore/SqlStreamStore.fs
@@ -278,8 +278,9 @@ module UnionEncoderAdapters =
         let (Bytes data) = e.GetJsonData() |> Async.AwaitTaskCorrect |> Async.RunSynchronously
         let (Bytes meta) = e.JsonMetadata
         let ts = e.CreatedUtc |> DateTimeOffset
-        let size = data.Length + meta.Length + e.Type.Length
-        // TOCONSIDER wire x.CorrelationId, x.CausationId into x.Meta.["$correlationId"] and .["$causationId"]
+        let inline len (xs : byte array) = if xs = null then 0 else xs.Length
+        let size = len data + len meta + e.Type.Length
+        // TOCONSIDER wire x.CorrelationId, x.CausationId into x.Meta["$correlationId"] and ["$causationId"]
         // https://eventstore.org/docs/server/metadata-and-reserved-names/index.html#event-metadata
         FsCodec.Core.TimelineEvent.Create(int64 e.StreamVersion, e.Type, data, meta, e.MessageId, null, null, ts, size = size)
     let eventDataOfEncodedEvent (x : FsCodec.IEventData<EventBody>) =
@@ -287,7 +288,7 @@ module UnionEncoderAdapters =
         // TODO: Follow up on inconsistency with ES
         let mapData (x : EventBody) = if x.IsEmpty then "{}" else System.Text.Encoding.UTF8.GetString(x.Span)
         let mapMeta (x : EventBody) = if x.IsEmpty then null else System.Text.Encoding.UTF8.GetString(x.Span)
-        // TOCONSIDER wire x.CorrelationId, x.CausationId into x.Meta.["$correlationId"] and .["$causationId"]
+        // TOCONSIDER wire x.CorrelationId, x.CausationId into x.Meta["$correlationId"] and ["$causationId"]
         // https://eventstore.org/docs/server/metadata-and-reserved-names/index.html#event-metadata
         NewStreamMessage(x.EventId, x.EventType, mapData x.Data, mapMeta x.Meta)
 

--- a/src/Equinox.SqlStreamStore/SqlStreamStore.fs
+++ b/src/Equinox.SqlStreamStore/SqlStreamStore.fs
@@ -277,9 +277,11 @@ module UnionEncoderAdapters =
     let encodedEventOfResolvedEvent (e : StreamMessage) : FsCodec.ITimelineEvent<EventBody> =
         let (Bytes data) = e.GetJsonData() |> Async.AwaitTaskCorrect |> Async.RunSynchronously
         let (Bytes meta) = e.JsonMetadata
+        let ts = e.CreatedUtc |> DateTimeOffset
+        let size = data.Length + meta.Length + e.Type.Length
         // TOCONSIDER wire x.CorrelationId, x.CausationId into x.Meta.["$correlationId"] and .["$causationId"]
         // https://eventstore.org/docs/server/metadata-and-reserved-names/index.html#event-metadata
-        FsCodec.Core.TimelineEvent.Create(int64 e.StreamVersion, e.Type, data, meta, e.MessageId, null, null, let ts = e.CreatedUtc in DateTimeOffset ts)
+        FsCodec.Core.TimelineEvent.Create(int64 e.StreamVersion, e.Type, data, meta, e.MessageId, null, null, ts, size = size)
     let eventDataOfEncodedEvent (x : FsCodec.IEventData<EventBody>) =
         // SQLStreamStore rejects IsNullOrEmpty data value.
         // TODO: Follow up on inconsistency with ES


### PR DESCRIPTION
Adds a baseline event size computation for the specified stores
Required for correct StreamsSink state logging when feeding from `EventStoreDbSource` https://github.com/jet/propulsion/pull/185