### PR TITLE
Handle nested ProvisionedThroughputExceeded

### DIFF
--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -1388,15 +1388,15 @@ type DynamoStoreCategory<'event, 'state, 'context>(resolveInner, empty) =
 
 module Exceptions =
 
-    let rec private anyInnerHas predicate (x : AggregateException) =
+    let rec private anyInnerIs predicate (x : AggregateException) =
         match x.InnerException with
-        | :? AggregateException as iae -> anyInnerHas predicate iae
+        | :? AggregateException as iae -> anyInnerIs predicate iae
         | ie -> predicate ie
-
-    let [<return: Struct>] (|ProvisionedThroughputExceeded|_|) : exn -> unit voption = function
-        | :? Amazon.DynamoDBv2.Model.ProvisionedThroughputExceededException -> ValueSome ()
-        | :? AggregateException as e when e |> anyInnerHas (fun x -> x :? Amazon.DynamoDBv2.Model.ProvisionedThroughputExceededException) -> ValueSome ()
-        | _ -> ValueNone
+    let private exceptionOrAnyInnerIs predicate : exn -> bool = function
+        | :? AggregateException as e -> e |> anyInnerIs predicate
+        | e -> predicate e
+    let isThrottlingExn (x : exn) = x :? Amazon.DynamoDBv2.Model.ProvisionedThroughputExceededException
+    let [<return: Struct>] (|ProvisionedThroughputExceeded|_|) e = if exceptionOrAnyInnerIs isThrottlingExn e then ValueSome () else ValueNone
 
 namespace Equinox.DynamoStore.Core
 

--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -452,7 +452,7 @@ type Container(tableName, createContext : (RequestMetrics -> unit) -> TableConte
         let pk = Batch.tableKeyForStreamTip stream
         let! item = context.UpdateItemAsync(pk, updateExpr, ?precondition = precondition) |> Async.startImmediateAsTask ct
         return item |> Batch.ofSchema, rm.Consumed }
-    member _.QueryBatches(stream, consistentRead, minN, maxI, backwards, batchSize, ct) : IAsyncEnumerable<int * StopwatchInterval * Batch array * RequestConsumption> =
+    member _.QueryBatches(stream, consistentRead, minN, maxI, backwards, batchSize, ct) : IAsyncEnumerable<int * StopwatchInterval * Batch array * RequestConsumption> = taskSeq {
         let compile = (createContext ignore).Template.PrecomputeConditionalExpr
         let kc = match maxI with
                  | Some maxI -> compile <@ fun (b : Batch.Schema) -> b.p = stream && b.i < maxI @>
@@ -460,20 +460,21 @@ type Container(tableName, createContext : (RequestMetrics -> unit) -> TableConte
         let fc = match minN with
                  | Some minN -> compile <@ fun (b : Batch.Schema) -> b.n > minN @> |> Some
                  | None -> None
-        let rec aux (i, le) = taskSeq {
+        let mutable index, lastEvaluated, more = 0, None, true
+        while more do
             // TOCONSIDER could avoid projecting `p`
             let rm = Metrics()
             let context = createContext rm.Add
-            let! t, res = context.QueryPaginatedAsync(kc, ?filterCondition = fc, limit = batchSize, ?exclusiveStartKey = le,
+            let! t, res = context.QueryPaginatedAsync(kc, ?filterCondition = fc, limit = batchSize, ?exclusiveStartKey = lastEvaluated,
                                                       scanIndexForward = not backwards, consistentRead = consistentRead)
                           |> Stopwatch.timeAsync ct
-            yield i, t, Array.map Batch.ofSchema res.Records, rm.Consumed
-            match res.LastEvaluatedKey with
-            | None -> ()
-            | le -> yield! aux (i + 1, le) }
-        aux (0, None)
-    member internal _.QueryIAndNOrderByNAscending(stream, maxItems, ct) : IAsyncEnumerable<int * StopwatchInterval * BatchIndices array * RequestConsumption> =
-        let rec aux (index, lastEvaluated) = taskSeq {
+            yield index, t, Array.map Batch.ofSchema res.Records, rm.Consumed
+            lastEvaluated <- res.LastEvaluatedKey
+            more <- Option.isSome lastEvaluated
+            index <- index + 1 }
+    member internal _.QueryIAndNOrderByNAscending(stream, maxItems, ct) : IAsyncEnumerable<int * StopwatchInterval * BatchIndices array * RequestConsumption> = taskSeq {
+        let mutable index, lastEvaluated, more = 0, None, true
+        while more do
             let rm = Metrics()
             let context = createContext rm.Add
             let keyCond = <@ fun (b : Batch.Schema) -> b.p = stream @>
@@ -481,10 +482,9 @@ type Container(tableName, createContext : (RequestMetrics -> unit) -> TableConte
             let! t, res = context.QueryProjectedPaginatedAsync(keyCond, proj, ?exclusiveStartKey = lastEvaluated, scanIndexForward = true, limit = maxItems)
                           |> Stopwatch.timeAsync ct
             yield index, t, [| for i, c, n in res -> { isTip = Batch.isTip i; index = n - int64 c.Length; n = n } |], rm.Consumed
-            match res.LastEvaluatedKey with
-            | None -> ()
-            | le -> yield! aux (index + 1, le) }
-        aux (0, None)
+            lastEvaluated <- res.LastEvaluatedKey
+            more <- Option.isSome lastEvaluated
+            index <- index + 1 }
     member x.DeleteItem(stream : string, i, ct) : Task<RequestConsumption> = task {
         let rm = Metrics()
         let context = createContext rm.Add


### PR DESCRIPTION
As a side effect of #361, `ProvisionedThroughputExceededExceptions` get nested:-

```
17:32:13 I Unhandled  {duration=00:00:00.3333882, events=9, stream="Loan-BC-I-00706146"}
System.AggregateException: One or more errors occurred. (One or more errors occurred. (The level of configured provisioned throughput for the table was exceeded. Consider increasing your provisioning level with the UpdateTable API.))
 ---> System.AggregateException: One or more errors occurred. (The level of configured provisioned throughput for the table was exceeded. Consider increasing your provisioning level with the UpdateTable API.)
 ---> Amazon.DynamoDBv2.Model.ProvisionedThroughputExceededException: The level of configured provisioned throughput for the table was exceeded. Consider increasing your provisioning level with the UpdateTable API.
 ---> Amazon.Runtime.Internal.HttpErrorResponseException: Exception of type 'Amazon.Runtime.Internal.HttpErrorResponseException' was thrown.
   at Amazon.Runtime.HttpWebRequestMessage.GetResponseAsync(CancellationToken cancellationToken)
```

This updates the active pattern to handle the way in manifests now (doubly nested inside an `AggregateException`)
