### PR TITLE
MessageDb: Remove Connector

### DIFF
--- a/samples/Infrastructure/Storage.fs
+++ b/samples/Infrastructure/Storage.fs
@@ -360,7 +360,7 @@ module MessageDb =
          member _.BatchSize =        p.GetResult(BatchSize, 500)
     let connect (log : ILogger) (connectionString: string) =
         log.Information("MessageDB Connection {connectionString}", connectionString)
-        MessageDbConnector(connectionString).Establish()
+        MessageDbConnection(connectionString)
     let config (log : ILogger) cache (p : ParseResults<Parameters>) =
         let a = Arguments(p)
         let connection = connect log a.ConnectionString

--- a/samples/Infrastructure/Storage.fs
+++ b/samples/Infrastructure/Storage.fs
@@ -360,7 +360,7 @@ module MessageDb =
          member _.BatchSize =        p.GetResult(BatchSize, 500)
     let connect (log : ILogger) (connectionString: string) =
         log.Information("MessageDB Connection {connectionString}", connectionString)
-        MessageDbConnection(connectionString)
+        MessageDbClient(connectionString)
     let config (log : ILogger) cache (p : ParseResults<Parameters>) =
         let a = Arguments(p)
         let connection = connect log a.ConnectionString

--- a/src/Equinox.MessageDb/MessageDbClient.fs
+++ b/src/Equinox.MessageDb/MessageDbClient.fs
@@ -43,7 +43,7 @@ module private Npgsql =
         do! conn.OpenAsync(ct)
         return conn }
 
-type MessageDbWriter(connectionString : string) =
+type internal MessageDbWriter(connectionString : string) =
 
     let prepareAppend (streamName : string) (expectedVersion : ExpectedVersion) (e : IEventData<Format>) =
         let cmd = NpgsqlBatchCommand(CommandText = "select * from write_message(@Id::text, @StreamName, @EventType, @Data, @Meta, @ExpectedVersion)")
@@ -73,7 +73,7 @@ type MessageDbWriter(connectionString : string) =
         with :? PostgresException as ex when ex.Message.Contains("Wrong expected version") ->
             return MdbSyncResult.ConflictUnknown }
 
-type MessageDbReader internal (connectionString : string, leaderConnectionString : string) =
+type internal MessageDbReader (connectionString : string, leaderConnectionString : string) =
 
     let connect requiresLeader = Npgsql.connect (if requiresLeader then leaderConnectionString else connectionString)
 

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -56,7 +56,7 @@ open OpenTelemetry.Resources
 
 let connectToLocalStore _ = async {
   let connectionString = "Host=localhost; Username=message_store; Password=; Database=message_store; Port=5433; Maximum Pool Size=10"
-  return MessageDbConnection(connectionString)
+  return MessageDbClient(connectionString)
 }
 type Context = MessageDbContext
 type Category<'event, 'state, 'context> = MessageDbCategory<'event, 'state, 'context>

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -56,8 +56,7 @@ open OpenTelemetry.Resources
 
 let connectToLocalStore _ = async {
   let connectionString = "Host=localhost; Username=message_store; Password=; Database=message_store; Port=5433; Maximum Pool Size=10"
-  let connector = MessageDbConnector(connectionString)
-  return connector.Establish()
+  return MessageDbConnection(connectionString)
 }
 type Context = MessageDbContext
 type Category<'event, 'state, 'context> = MessageDbCategory<'event, 'state, 'context>


### PR DESCRIPTION
Aligns MessageDb with DynamoStore and CosmosStore in using `Client` to refer to the layer that talks to the underlying store (but does not hold active connections as such)
- Having a Client similarly implies "make one of these and reuse them"
- However having an Establish or Connect method suggests that there is a long lived connection element and/or something interesting going on (for EventStore, Establish was originally a one-off Async method that did something)
