### PR TITLE
DynamoDb: Fix integration test expectations

### DIFF
--- a/tests/Equinox.CosmosStore.Integration/CosmosFixtures.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosFixtures.fs
@@ -15,12 +15,13 @@ let discoverConnection () =
     match tryRead "EQUINOX_DYNAMO_SERVICE_URL" with // NOT USING EQUINOX_DYNAMO_SERVICE_URL env var as we don't want to go provisioning 2 tables in a random DB
     | None -> "dynamodb-local", "http://localhost:8000"
     | Some connectionString -> "EQUINOX_DYNAMO_CONNECTION", connectionString
+let isSimulatorServiceUrl url = Uri(url).IsLoopback
 
 let createClient (log : Serilog.ILogger) name serviceUrl =
     // See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html#docker for details of how to deploy a simulator instance
     let clientConfig = AmazonDynamoDBConfig(ServiceURL = serviceUrl)
     log.Information("DynamoStore {name} {endpoint}", name, serviceUrl)
-    if serviceUrl.Contains "localhost" then
+    if isSimulatorServiceUrl serviceUrl then
         // Credentials are not validated if connecting to local instance so anything will do (this avoids it looking for profiles to be configured)
         let credentials = Amazon.Runtime.BasicAWSCredentials("A", "A")
         new AmazonDynamoDBClient(credentials, clientConfig) :> IAmazonDynamoDB

--- a/tests/Equinox.CosmosStore.Integration/CosmosFixtures.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosFixtures.fs
@@ -12,18 +12,21 @@ let private tableName = tryRead "EQUINOX_DYNAMO_TABLE" |> Option.defaultValue "e
 let private archiveTableName = tryRead "EQUINOX_DYNAMO_TABLE_ARCHIVE" |> Option.defaultValue "equinox-test-archive"
 
 let discoverConnection () =
-    match tryRead "EQUINOX_DYNAMO_CONNECTION" with
-    | None -> "dynamodb-local", "http://localhost:8000" // OR: change to "https://dynamodb.eu-west-1.amazonaws.com" to hit prod instance
+    match tryRead "EQUINOX_DYNAMO_SERVICE_URL" with // NOT USING EQUINOX_DYNAMO_SERVICE_URL env var as we don't want to go provisioning 2 tables in a random DB
+    | None -> "dynamodb-local", "http://localhost:8000"
     | Some connectionString -> "EQUINOX_DYNAMO_CONNECTION", connectionString
 
 let createClient (log : Serilog.ILogger) name serviceUrl =
     // See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html#docker for details of how to deploy a simulator instance
     let clientConfig = AmazonDynamoDBConfig(ServiceURL = serviceUrl)
     log.Information("DynamoStore {name} {endpoint}", name, serviceUrl)
-    // Credentials are not validated if connecting to local instance so anything will do (this avoids it looking for profiles to be configured)
-    // OR: don't pass credentials to ctor to use keychain configured access
-    let credentials = Amazon.Runtime.BasicAWSCredentials("A", "A")
-    new AmazonDynamoDBClient(credentials, clientConfig) :> IAmazonDynamoDB
+    if serviceUrl.Contains "localhost" then
+        // Credentials are not validated if connecting to local instance so anything will do (this avoids it looking for profiles to be configured)
+        let credentials = Amazon.Runtime.BasicAWSCredentials("A", "A")
+        new AmazonDynamoDBClient(credentials, clientConfig) :> IAmazonDynamoDB
+    else
+        // omitting credentials to ctor in order to trigger use of keychain configured access
+        new AmazonDynamoDBClient(clientConfig) :> IAmazonDynamoDB
 
 let connectPrimary log =
     let name, serviceUrl = discoverConnection ()
@@ -40,7 +43,7 @@ let connectWithFallback log =
     let client = createClient log name serviceUrl
     DynamoStoreClient(client, tableName, archiveTableName = archiveTableName)
 
-// Prepares the two required tables that the test lea on via connectPrimary/Archive/WithFallback
+// Prepares the two required tables that the tests use via connectPrimary/Archive/WithFallback
 type DynamoTablesFixture() =
 
     interface Xunit.IAsyncLifetime with

--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -91,8 +91,7 @@ type Tests(testOutputHelper) =
     // when you hit the max count as you read the final item in a stream. Leaving it ugly in the hope we get to delete it.
     let expectFinalExtraPage () =
 #if STORE_DYNAMO
-       let _, url = discoverConnection ()
-       url.Contains "localhost"
+        discoverConnection () |> snd |> isSimulatorServiceUrl
 #else
         false
 #endif

--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -263,8 +263,8 @@ type Tests(testOutputHelper) =
                 | Choice2Of2 e -> e.Message.StartsWith "Origin event not found; no Archive Container supplied"
                                   || e.Message.StartsWith "Origin event not found; no Archive Table supplied"
                 | x -> failwithf "Unexpected %A" x @>
-        let expectedResponses = if expectFinalExtraPage () then 2 else 1
-        test <@ [yield! Seq.replicate expectedResponses EqxAct.ResponseForward; EqxAct.QueryForward] = capture.ExternalCalls @>
+        let finalEmptyPage = if expectFinalExtraPage () then 1 else 0
+        test <@ [yield! Seq.replicate (1 + finalEmptyPage) EqxAct.ResponseForward; EqxAct.QueryForward] = capture.ExternalCalls @>
         verifyRequestChargesMax 3 // 2.99
 
         // But not forgotten

--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -97,8 +97,14 @@ type Tests(testOutputHelper) =
 
         let service = Cart.createServiceWithoutOptimization log context
         let expectedResponses n =
+            #if STORE_DYNAMO // For Cosmos, we supply a full query and it notices it is at the end - for Dynamo, another query is required
+            let finalEmptyPage = 1
+            #else
+            let finalEmptyPage = 0
+            #endif
+
             let tipItem = 1
-            let expectedItems = tipItem + (if eventsInTip then n / 2 else n)
+            let expectedItems = tipItem + (if eventsInTip then n / 2 else n) + finalEmptyPage
             max 1 (int (ceil (float expectedItems / float queryMaxItems)))
 
         let cartId = % Guid.NewGuid()
@@ -252,7 +258,11 @@ type Tests(testOutputHelper) =
                 | Choice2Of2 e -> e.Message.StartsWith "Origin event not found; no Archive Container supplied"
                                   || e.Message.StartsWith "Origin event not found; no Archive Table supplied"
                 | x -> failwithf "Unexpected %A" x @>
+        #if STORE_DYNAMO // Extra null query
+        test <@ [EqxAct.ResponseForward; EqxAct.ResponseForward; EqxAct.QueryForward] = capture.ExternalCalls @>
+        #else
         test <@ [EqxAct.ResponseForward; EqxAct.QueryForward] = capture.ExternalCalls @>
+        #endif
         verifyRequestChargesMax 3 // 2.99
 
         // But not forgotten

--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -97,14 +97,8 @@ type Tests(testOutputHelper) =
 
         let service = Cart.createServiceWithoutOptimization log context
         let expectedResponses n =
-            #if STORE_DYNAMO // For Cosmos, we supply a full query and it notices it is at the end - for Dynamo, another query is required
-            let finalEmptyPage = 1
-            #else
-            let finalEmptyPage = 0
-            #endif
-
             let tipItem = 1
-            let expectedItems = tipItem + (if eventsInTip then n / 2 else n) + finalEmptyPage
+            let expectedItems = tipItem + (if eventsInTip then n / 2 else n)
             max 1 (int (ceil (float expectedItems / float queryMaxItems)))
 
         let cartId = % Guid.NewGuid()
@@ -258,11 +252,7 @@ type Tests(testOutputHelper) =
                 | Choice2Of2 e -> e.Message.StartsWith "Origin event not found; no Archive Container supplied"
                                   || e.Message.StartsWith "Origin event not found; no Archive Table supplied"
                 | x -> failwithf "Unexpected %A" x @>
-        #if STORE_DYNAMO // Extra null query
-        test <@ [EqxAct.ResponseForward; EqxAct.ResponseForward; EqxAct.QueryForward] = capture.ExternalCalls @>
-        #else
         test <@ [EqxAct.ResponseForward; EqxAct.QueryForward] = capture.ExternalCalls @>
-        #endif
         verifyRequestChargesMax 3 // 2.99
 
         // But not forgotten


### PR DESCRIPTION
The repo contains a docker compose file that provisions a dynamodb-local instance
For the last batch of edits, I tested against a DynamoDB cloud instance

I erroneously updated the test expectations to match what I observed without considering that:
- I had tested against a cloud instance (the expectation is that the tests should just work from trunk).
- _dynamodb-local continues to have this behavioral difference_ (if you query with a maxItems that coincides with the number of items in the partition, you still get yielded a continuation token, which triggers an extra roundtrip)

This change makes the expectations of the integration tests suite conditional on the target instance URL, which is hacky. Hopefully this simulator difference goes away eventually...

resolves #366 (🙏 @nordfjord who did all the research to determine the problem, and when it was introduced)