### PR TITLE
StreamId C# interop

### DIFF
--- a/samples/Store/Domain/InventoryItem.fs
+++ b/samples/Store/Domain/InventoryItem.fs
@@ -1,4 +1,4 @@
-/// This is not part of the Store; it's ported from https://gyyhub.com/gregoryyoung/m-r/tree/master/SimpleCQRS for fun
+/// This is not part of the Store; it's ported from https://github.com/gregoryyoung/m-r/tree/master/SimpleCQRS for fun
 module Domain.InventoryItem
 
 open System

--- a/samples/Tutorial/Upload.fs
+++ b/samples/Tutorial/Upload.fs
@@ -46,7 +46,7 @@ let decide (value : UploadId) (state : Fold.State) : Choice<UploadId,UploadId> *
     | None -> Choice1Of2 value, [Events.IdAssigned { value = value}]
     | Some value -> Choice2Of2 value, []
 
-type Service internal (resolve : struct (CompanyId * PurchaseOrderId) -> Equinox.Decider<Events.Event, Fold.State>) =
+type Service internal (resolve : CompanyId * PurchaseOrderId -> Equinox.Decider<Events.Event, Fold.State>) =
 
     member _.Sync(companyId, purchaseOrderId, value) : Async<Choice<UploadId,UploadId>> =
         let decider = resolve (companyId, purchaseOrderId)

--- a/src/Equinox.Core/Category.fs
+++ b/src/Equinox.Core/Category.fs
@@ -52,16 +52,16 @@ type Category<'event, 'state, 'context>
                 return! inner.TrySync(log, categoryName, streamId, streamName, context, init, token, originState, events, ct) } }
 
 type private Stream =
-    static member Resolve(cat : Category<'event, 'state, 'context>, log, context) : System.Func<string, StreamId, Core.IStream<'event, 'state>> =
-        System.Func<string, StreamId, _>(fun categoryName streamId -> cat.Stream(log, context, categoryName, StreamId.toString streamId))
+    static member Resolve(cat : Category<'event, 'state, 'context>, log, context) : System.Func<string, Core.StreamId, Core.IStream<'event, 'state>> =
+        System.Func<string, Core.StreamId, _>(fun categoryName streamId -> cat.Stream(log, context, categoryName, Core.StreamId.toString streamId))
 
 [<System.Runtime.CompilerServices.Extension>]
 type DeciderCore =
     [<System.Runtime.CompilerServices.Extension>]
-    static member Resolve(cat : Category<'event, 'state, 'context>, log, context) : System.Func<string, StreamId, DeciderCore<'event, 'state>> =
-         System.Func<_, _, _>(fun c s -> Stream.Resolve(cat, log, context).Invoke(c,s) |> DeciderCore)
+    static member Resolve(cat : Category<'event, 'state, 'context>, log, context) : System.Func<string, Core.StreamId, DeciderCore<'event, 'state>> =
+         System.Func<_, _, _>(fun c s -> Stream.Resolve(cat, log, context).Invoke(c, s) |> DeciderCore)
     [<System.Runtime.CompilerServices.Extension>]
-    static member Resolve(cat : Category<'event, 'state, unit>, log) : System.Func<string, StreamId, DeciderCore<'event, 'state>> =
+    static member Resolve(cat : Category<'event, 'state, unit>, log) : System.Func<string, Core.StreamId, DeciderCore<'event, 'state>> =
         DeciderCore.Resolve(cat, log, ())
 
 module Decider =

--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -249,7 +249,7 @@ type Tests(testOutputHelper) =
         // Needs to share the same context (with inner CosmosClient) for the session token to be threaded through
         // If we run on an independent context, we won't see (and hence prune) the full set of events
         let ctx = Core.EventsContext(context, log)
-        let streamName = ContactPreferences.streamId id |> Equinox.StreamId.renderStreamName ContactPreferences.Category
+        let streamName = ContactPreferences.streamId id |> Equinox.Core.StreamId.renderStreamName ContactPreferences.Category
 
         // Prune all the events
         let! deleted, deferred, trimmedPos = Core.Events.pruneUntil ctx streamName 14L

--- a/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
+++ b/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
@@ -71,7 +71,7 @@ type ChangeFeed(testOutputHelper) =
             List.ofArray xs
         use _ = store.Committed.Subscribe(fun struct (cn, sid, xs) -> events.Add(Equinox.Core.StreamName.render cn sid, List.ofArray xs))
         let service = createFavoritesServiceMemory store log
-        let expectedStream = Favorites.streamId clientId |> Equinox.StreamId.renderStreamName Favorites.Category
+        let expectedStream = Favorites.streamId clientId |> Equinox.Core.StreamId.renderStreamName Favorites.Category
 
         do! service.Favorite(clientId, [sku])
         let written = takeCaptured ()


### PR DESCRIPTION
Provides an idiomatic C# equivalent for the FSharpFunc `StreamId.gen` (and shifts the type alias to Core now rather than having to do it at some other time)