### PR TITLE
Cosmos: Add Docker emulator config

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1804,8 +1804,9 @@ type EventData with
     static member FromT eventType value =
         EventData.FromUtf8Bytes(eventType, Json.toBytes value)
 
-// Load connection sring from your Key Vault (example here is the CosmosDB
+// Load connection string from your Key Vault (example here is the CosmosDB
 // simulator's well known key)
+// see https://github.com/jet/equinox-provisioning-cosmosdb
 let connectionString : string =
     "AccountEndpoint=https://localhost:8081;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==;"
 

--- a/Equinox.sln
+++ b/Equinox.sln
@@ -24,6 +24,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".project", ".project", "{7E
 		SECURITY.md = SECURITY.md
 		global.json = global.json
 		nuget.config = nuget.config
+		docker-compose-cosmos.sh = docker-compose-cosmos.sh
+		docker-compose-mssql.sh = docker-compose-mssql.sh
 	EndProjectSection
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Domain", "samples\Store\Domain\Domain.fsproj", "{37B4A45F-039E-4515-8A84-D242DDE12D22}"

--- a/README.md
+++ b/README.md
@@ -651,7 +651,10 @@ There's a `docker-compose.yml` file in the root, so installing `docker-compose` 
 
 For more complete instructions, follow https://developers.eventstore.com/server/v21.10/installation.html#use-docker-compose
 
-### Provisioning CosmosDB (when not using -sc)
+<a name="provisioning-cosmosdb"></a>
+### Provisioning CosmosDB (when not using build.ps1 -sc to skip verification)
+
+#### Using Azure Cosmos DB Service
 
     dotnet run --project tools/Equinox.Tool -- init -ru 400 `
         cosmos -s $env:EQUINOX_COSMOS_CONNECTION -d $env:EQUINOX_COSMOS_DATABASE -c $env:EQUINOX_COSMOS_CONTAINER
@@ -660,19 +663,26 @@ For more complete instructions, follow https://developers.eventstore.com/server/
     dotnet run --project tools/Equinox.Tool -- init -ru 400 `
         cosmos -s $env:EQUINOX_COSMOS_CONNECTION -d $env:EQUINOX_COSMOS_DATABASE -c $env:EQUINOX_COSMOS_CONTAINER_ARCHIVE
 
+#### Using Cosmos Emulator on an Intel Mac 
+
+NOTE There's [no Apple Silicon emulator available as yet](https://github.com/Azure/azure-cosmos-db-emulator-docker/issues/54#issuecomment-1399067365).
+
+NOTE Have not tested with the Windows Emulator, but it should work with analogous steps.
+
+    docker compose up equinox-cosmos -d
+    bash docker-compose-cosmos.sh
+
 ### Provisioning SqlStreamStore
 
 There's a `docker-compose.yml` file in the root, so installing `docker-compose` and then running `docker-compose up` rigs local `equinox-mssql`, `equinox-mysql` and `equinox-postgres` servers and databases at known ports. _NOTE The `Equinox.SqlStreamStore.*.Integration` suites currently assume this is in place and will otherwise fail_.
 
+<a name="provisioning-mssql"></a>
 ### Provisioning `mcr.microsoft.com/mssql/server:2019-latest` for `SqlStreamStore.MsSql`
 
 Until https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719 is resolved (see [#315](https://github.com/jet/equinox/pull/315), after the `docker compose up` one needs to manually:
 
-```zsh
-docker exec -it equinox-mssql /opt/mssql-tools/bin/sqlcmd \
-    -S localhost -U sa -P mssql1Ipw \
-    -Q "CREATE database EQUINOX_TEST_DB"
-```
+    docker compose up equinox-mssql
+    bash docker-compose-mssql.sh
 
 (PRs welcome to automate the hack, but ideally the image will allow parameterizing it as handled by the Postgres and MySql images when common sense prevails re [`mssql-docker#2`](https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719))
 

--- a/docker-compose-cosmos.sh
+++ b/docker-compose-cosmos.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e # exit on any non-zero exit code
+
+tmpf=$(mktemp)
+curl -k https://localhost:8081/_explorer/emulator.pem > $tmpf
+sudo security add-trusted-cert -d -r trustRoot -k ~/Library/Keychains/login.keychain $tmpf
+
+dotnet run --project tools/Equinox.Tool -- init cosmos
+dotnet run --project tools/Equinox.Tool -- init cosmos -c equinox-test-archive

--- a/docker-compose-mssql.sh
+++ b/docker-compose-mssql.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker exec -it equinox-mssql /opt/mssql-tools/bin/sqlcmd \
+    -S localhost -U sa -P "mssql1Ipw" \
+    -Q "CREATE database EQUINOX_TEST_DB"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: '3.7'
 
 services:
 
-  # NOTE requires initialization (trust cert, create 2 databases) via: bash docker-compose-cosmos.sh 
+  # NOTE requires initialization (trust emulator's self-signed cert, create 2 databases)
+  #      after `docker compose up equinox-cosmos`, run `bash docker-compose-cosmos.sh`
   equinox-cosmos:
     container_name: equinox-cosmos
     image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator
@@ -27,7 +28,7 @@ services:
       - "5432:5432"
 
   # NOTE MANUAL STEP until MS get with the program https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719
-  # after `docker compose up`, run `bash docker-compose-mssql.sh`
+  #      after `docker compose up`, run `bash docker-compose-mssql.sh`
   equinox-mssql:
     container_name: equinox-mssql
     image: mcr.microsoft.com/mssql/server:2019-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,19 @@
 version: '3.7'
 
 services:
+
+  # NOTE requires initialization (trust cert, create 2 databases) via: bash docker-compose-cosmos.sh 
+  equinox-cosmos:
+    container_name: equinox-cosmos
+    image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator
+    restart: unless-stopped
+    environment:
+      - AZURE_COSMOS_EMULATOR_PARTITION_COUNT=3
+      - AZURE_COSMOS_EMULATOR_IP_ADDRESS_OVERRIDE=127.0.0.1
+    ports:
+      - "8081:8081" # so docker-cosmos-init.sh can get the cert and/or humans can use https://localhost:8081/_explorer/index.html
+      - "10250-10256:10250-10256" # tests connect using Direct mode
+
   equinox-postgres:
     container_name: equinox-postgres
     image: postgres
@@ -13,6 +26,8 @@ services:
     ports:
       - "5432:5432"
 
+  # NOTE MANUAL STEP until MS get with the program https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719
+  # after `docker compose up`, run `bash docker-compose-mssql.sh`
   equinox-mssql:
     container_name: equinox-mssql
     image: mcr.microsoft.com/mssql/server:2019-latest
@@ -22,11 +37,6 @@ services:
     environment:
       - SA_PASSWORD=mssql1Ipw
       - ACCEPT_EULA=Y
-
-#  MANUAL STEP re https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719; after docker compose up, run:
-#  docker exec -it equinox-mssql /opt/mssql-tools/bin/sqlcmd \
-#    -S localhost -U sa -P "!Passw0rd" \
-#    -Q "CREATE database EQUINOX_TEST_DB"
 
   equinox-mysql:
     container_name: equinox-mysql
@@ -92,8 +102,6 @@ services:
   node2.eventstore:
       <<: *template
       container_name: node2.eventstore
-      env_file:
-        - docker-compose.env
       environment:
         - EVENTSTORE_INT_IP=172.30.240.12
         - EVENTSTORE_ADVERTISE_HTTP_PORT_TO_CLIENT_AS=2112

--- a/samples/Infrastructure/Storage.fs
+++ b/samples/Infrastructure/Storage.fs
@@ -41,6 +41,7 @@ let private defaultWithEnvVar varName argName = function
 // 1) replace connection below with a connection string or Uri+Key for an initialized Equinox instance with a database and collection named "equinox-test"
 // 2) Set the 3x environment variables and create a local Equinox using tools/Equinox.Tool/bin/Release/net6.0/eqx.exe `
 //     init -ru 1000 cosmos -s $env:EQUINOX_COSMOS_CONNECTION -d $env:EQUINOX_COSMOS_DATABASE -c $env:EQUINOX_COSMOS_CONTAINER
+// see https://github.com/jet/equinox#provisioning-cosmosdb
 module Cosmos =
 
     open Equinox.CosmosStore
@@ -260,6 +261,7 @@ module EventStore =
         let cacheStrategy = cache |> Option.map (fun c -> CachingStrategy.SlidingWindow (c, TimeSpan.FromMinutes 20.))
         StorageConfig.Es (EventStoreContext(connection, batchSize = a.BatchSize), cacheStrategy, unfolds)
 
+// see https://github.com/jet/equinox#provisioning-mssql
 module Sql =
 
     open Equinox.SqlStreamStore

--- a/tests/Equinox.CosmosStore.Integration/CosmosCoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosCoreIntegration.fs
@@ -240,7 +240,7 @@ type Tests(testOutputHelper) =
         let! expected = add6EventsIn2BatchesEx ctx streamName 4
 
         let! seq = Events.getAll ctx streamName 0L 1
-        let! res = seq |> TaskSeq.takeWhileInclusive (fun _ -> false) |> TaskSeq.collectSeq id |> TaskSeq.toArrayAsync |> Async.AwaitTaskCorrect
+        let! res = seq |> TaskSeq.collectSeq id |> TaskSeq.takeWhileInclusive (fun _ -> false) |> TaskSeq.toArrayAsync |> Async.AwaitTaskCorrect
         let expected = expected |> Array.take 1
 
         verifyCorrectEvents 0L expected res

--- a/tests/Equinox.CosmosStore.Integration/CosmosFixtures.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosFixtures.fs
@@ -80,6 +80,7 @@ let private databaseId = tryRead "EQUINOX_COSMOS_DATABASE" |> Option.defaultValu
 let private containerId = tryRead "EQUINOX_COSMOS_CONTAINER" |> Option.defaultValue "equinox-test"
 let private archiveContainerId = tryRead "EQUINOX_COSMOS_CONTAINER_ARCHIVE" |> Option.defaultValue "equinox-test-archive"
 
+// see https://github.com/jet/equinox-provisioning-cosmosdb for details of what's expected in terms of provisioned containers etc
 let discoverConnection () =
     match tryRead "EQUINOX_COSMOS_CONNECTION" with
     | None -> "localDocDbSim", Discovery.AccountUriAndKey(Uri "https://localhost:8081", "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==")

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -25,15 +25,10 @@ open Equinox.SqlStreamStore
 open Equinox.SqlStreamStore.MsSql
 
 let connectToLocalStore (_ : ILogger) =
-    Connector(sprintf "Server=localhost,1433;User=sa;Password=mssql1Ipw;Database=EQUINOX_TEST_DB",autoCreate=true).Establish()
+    Connector("Server=localhost,1433;User=sa;Password=mssql1Ipw;Database=EQUINOX_TEST_DB", autoCreate = true).Establish()
 
 (* WORKAROUND FOR https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719
-AFTER `docker compose up`, run:
-
-docker exec -it equinox-mssql /opt/mssql-tools/bin/sqlcmd \
-    -S localhost -U sa -P mssql1Ipw \
-    -Q "CREATE database EQUINOX_TEST_DB"
-*)
+AFTER `docker compose up`, run `bash docker-compose-mssql.sh` *)
 
 type Context = SqlStreamStoreContext
 type Category<'event, 'state, 'context> = SqlStreamStoreCategory<'event, 'state, 'context>


### PR DESCRIPTION
Adds `docker compose` config for the CosmosDB emulator [for a Mac]
- [ ] 2 failing tests (re Lazy semantics) awaiting updated `FSharp.Control.TaskSeq` that reinstates `try/finally` when a sequence is not fully drained