### PR TITLE
MemoryStore: Revert Committed event signature

### DIFF
--- a/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
+++ b/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
@@ -69,7 +69,7 @@ type ChangeFeed(testOutputHelper) =
             let xs = events.ToArray()
             events.Clear()
             List.ofArray xs
-        use _ = store.Committed.Subscribe(fun struct (cn, sid, xs) -> events.Add(Equinox.Core.StreamName.render cn sid, List.ofArray xs))
+        use _ = store.Committed.Subscribe(fun struct (sn, xs) -> events.Add(FsCodec.StreamName.toString sn, List.ofArray xs))
         let service = createFavoritesServiceMemory store log
         let expectedStream = Favorites.streamId clientId |> Equinox.Core.StreamId.renderStreamName Favorites.Category
 


### PR DESCRIPTION
Reverts the Committed event signature change, changing it from `string * string * Event[]' back to `FsCodecStreamName * Event[]`

The changed signature did not mesh well with the needs of test suites that use `Propulsion.Sinks` and/or `Propulsion.MemoryStore`

Also (temporarily) adds a hacked way to disable the locking. This will remain undocumented and will be removed in due course.