### PR TITLE
Docs, formatting  tweaks

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -273,7 +273,7 @@ Stored Procedure         | JavaScript code stored in a Container that (repeatedl
 
 Term                     | Description
 -------------------------|------------
-Table                    | Defined storage in DynamoDB, defining a schema and (optionally), a Streams configuration. (There's no notion of a Database)
+Table                    | Defined storage area in DynamoDB, defining a schema and (optionally), a Streams configuration. (There's no notion of a Database)
 Streams                  | Buffer used to record information about all changes with a 24h retention window
 Transactions             | Feature allowing up to 100 atomic updates across multiple tables and logical partitions. Doubles the RU cost of a write 
 
@@ -294,6 +294,7 @@ Term       | Description
 -----------|------------
 Cache      | `System.Net.MemoryCache` or equivalent holding _State_ and/or `etag` information for a Stream with a view to reducing roundtrips, latency and/or Request Charges
 Unfolds    | Snapshot information, stored in an appropriate storage location (not as a Stream's actual Events), _but represented as Events_, to minimize Queries and the attendant Request Charges when there is a Cache miss
+Version    | When a decision function is invoked, it's presented with a State derived from the Stream's Events and/or Unfolds up to a given position. If the newest event has Index `9` (or it was loaded from an Unfold with `i=9`) the Version is `10`
 
 # Programming Model
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -275,7 +275,9 @@ Term                     | Description
 -------------------------|------------
 Table                    | Defined storage area in DynamoDB, defining a schema and (optionally), a Streams configuration. (There's no notion of a Database)
 Streams                  | Buffer used to record information about all changes with a 24h retention window
-Transactions             | Feature allowing up to 100 atomic updates across multiple tables and logical partitions. Doubles the RU cost of a write 
+Transactions             | Feature allowing up to 100 atomic updates across multiple tables and logical partitions. Doubles the RU cost of a write
+DynamoStore Index        | Custom implementation (in Propulsion) that indexes the DynamoDB Streams output to enable traversing all the events in the store akin to how the CosmosDB ChangeFeed enables that
+Export                   | A Table can be exported in full to an S3 bucket as a set of json files containing all items
 
 ## EventStore
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -714,7 +714,7 @@ follow!
 #### Decider Members
 
 ```fsharp
-type Equinox.Decider(stream : IStream<'event, 'state>, log, maxAttempts) =
+type Equinox.Decider(...) =
 StoreIntegration
     // Run interpret function with present state, retrying with Optimistic Concurrency
     member _.Transact(interpret : State -> Event list) : Async<unit>
@@ -2446,16 +2446,12 @@ The pruner cyclically (i.e., when it reaches the end, it loops back to the start
 This is a very loose laundry list of items that have occurred to us to do,
 given infinite time. No conclusions of likelihood of starting, finishing, or
 even committing to adding a feature should be inferred, but most represent
-things that would be likely to be accepted into the codebase (please [read and]
-raise Issues first though ;) ).
+things that would be likely to be accepted into the codebase.
 
 - Extend samples and templates; see
   [#57](https://github.com/jet/equinox/issues/57)
 
 ## Wouldn't it be nice - `Equinox.EventStoreDb`
-
-EventStore, and it's Store adapter is the most proven and is pretty feature
-rich relative to the need of consumers to date. Some things remain though:
 
 - Provide a low level walking events in F# API akin to
   `Equinox.CosmosStore.Core.Events`; this would allow consumers to jump from direct
@@ -2492,4 +2488,5 @@ rich relative to the need of consumers to date. Some things remain though:
   that's no longer in use gets removed)
   [#108](https://github.com/jet/equinox/issues/108)
 - low level performance improvements in loading logic (reducing allocations etc)
-- `Propulsion.CosmosStore`: provide a Serverless mode that can be used with Azure Functions to execute batch of projections based on a set of documents from the change feed
+- `Propulsion.CosmosStore`: provide a Serverless mode that can be used with Azure
+  Functions to execute batch of projections based on a set of documents from the change feed

--- a/README.md
+++ b/README.md
@@ -983,7 +983,7 @@ With the Equinox `type Decider`, the typical `decide` signature used with the `T
 
       context -> inputsAndOrCommand -> 'State -> Event list
 
-> NOTE: There are more advanced forms that allow the `decide` function to be `Async` and/or to also return a `'result`, which will be yielded to the caller driving the Decision as the return value of the `Transact` function.
+> NOTE: There are more advanced forms that allow the `decide` function to be `Async`, inspect the State's `Version` and/or to also return a `'result`, which will be yielded to the caller driving the Decision as the return value of the `Transact` function.
 
 #### So what kind of a thing is a Decider then?
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ _If you're looking to learn more about and/or discuss Event Sourcing and it's my
       - `Equinox.Cosmos.Core.Events.appendAtEnd`/`NonIdempotentAppend` has not been ported (there's no obvious clean and efficient way to do a conditional insert/update/split as the CosmosDB stored proc can, and this is a low usage feature)
       - The implementation uses [the excellent `FSharp.AWS.DynamoDB` library](https://github.com/fsprojects/FSharp.AWS.DynamoDB)) (which wraps the standard AWS `AWSSDK.DynamoDBv2` SDK Package), and leans on [significant preparatory research](https://github.com/pierregoudjo/dynamodb_conditional_writes) :pray: [@pierregoudjo](https://github.com/pierregoudjo)
       - `CosmosStore` dictates (as of V4) that event bodies be supplied as `System.Text.Json.JsonElement`s (in order that events can be included in the Document/ Items as JSON directly. This is also to underscore the fact that the only reasonable format to use is valid JSON; binary data would need to be base64 encoded. `DynamoStore` accepts and yields event bodies as arbitrary `ReadOnlyMemory<byte>` BLOBs (the AWS SDK round-trips such blobs as a `MemoryStream` and does not impose any restrictions on the blobs in terms of required format).
-      - `CosmosStore` defaults to compressing (with `System.IO.Compression.DeflateStream`) event bodies for Unfolds; `DynamoStore` round-trips an `encoding : int` value, which enables the `IEventCodec` to manage that concern. Regardless, minimizing Request Charges is imperative when request size directly maps to financial charges, 429s, reduced throughput and a lowered scaling ceiling.
+      - `CosmosStore` defaults to compressing (with `System.IO.Compression.DeflateStream`) event bodies for Unfolds; `DynamoStore` round-trips an `encoding: int` value, which enables the `IEventCodec` to manage that concern. Regardless, minimizing Request Charges is imperative when request size directly maps to financial charges, 429s, reduced throughput and a lowered scaling ceiling.
     - Azure CosmosDB's ChangeFeed API intrinsically supports replays of all the events in a Store, whereas the DynamoDB Streams facility only retains 24h of actions. As a result, there are ancillary components that provide equivalent functionality composed of:
       - `Propulsion.DynamoStore.Lambda`: an AWS Lambda that is configured via a DynamoDB Streams Trigger to Index the Events (represented as Equinox Streams, typically in a separated `<tableName>-index` Table) as they are appended 
       - `Propulsion.DynamoStore.DynamoStoreSource`: consumes the Index Streams akin to how `Propulsion.CosmosStore.CosmosStoreSource` consumes the CosmosDB Change Feed 
@@ -578,6 +578,11 @@ DynamoDB is supported in the samples and the `eqx` tool equivalent to the Cosmos
     eqx run -t saveforlater -f 50 -d 5 -CU web
     eqx dump "SavedForLater-ab25cc9f24464d39939000aeb37ea11a" dynamo # show stored JSON (Guid shown in eqx run output) 
     ```
+
+3. Useful articles
+
+- [Troubleshooting throttling issues in Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TroubleshootingThrottling.html)
+- [Troubleshooting latency issues in Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TroubleshootingLatency.html)
 
 ### BENCHMARKS
 

--- a/diagrams/CosmosCode.puml
+++ b/diagrams/CosmosCode.puml
@@ -93,7 +93,7 @@ Aggregate --> IStream: state'
 IStream -> Aggregate: snapshot state'
 Aggregate --> IStream: { snapshot = Snapshotted (encoded(state')) }
 IStream -> Aggregate: codec.Encode snapshot
-Aggregate --> IStream: { eventType = "Snapshotted"; body : JsonElement }
+Aggregate --> IStream: { eventType = "Snapshotted"; body: JsonElement }
 IStream -> CosmosDB: ExecuteStoredProcedure("Sync", "Favorites-clientId", token,\n        events, unfolds = [{ c: eventType, d: body }])
 alt Normal, conflict-free case
 CosmosDB -[#green]-> IStream: {result = 200; etag = etag'; version = version' }

--- a/samples/Infrastructure/Services.fs
+++ b/samples/Infrastructure/Services.fs
@@ -8,10 +8,10 @@ open System
 
 type Store(store) =
     member _.Category
-        (   codec : FsCodec.IEventCodec<'event, ReadOnlyMemory<byte>, unit>,
+        (   codec: FsCodec.IEventCodec<'event, ReadOnlyMemory<byte>, unit>,
             fold: 'state -> 'event seq -> 'state,
-            initial : 'state,
-            snapshot : ('event -> bool) * ('state -> 'event)) : Category<'event, 'state, unit> =
+            initial: 'state,
+            snapshot: ('event -> bool) * ('state -> 'event)): Category<'event, 'state, unit> =
         match store with
         | Storage.StorageConfig.Memory store ->
             Equinox.MemoryStore.MemoryStoreCategory(store, codec, fold, initial)

--- a/samples/Store/Domain.Tests/CartTests.fs
+++ b/samples/Store/Domain.Tests/CartTests.fs
@@ -13,8 +13,8 @@ let mkChangeWaived skuId value  = Events.ItemPropertiesChanged { empty<Events.It
 
 /// Represents the high level primitives that can be expressed in a SyncItem Command
 type Command =
-    | AddItem of Context * SkuId * quantity : int * waiveStatus : bool option
-    | PatchItem of Context * SkuId * quantity : int option * waiveStatus : bool option
+    | AddItem of Context * SkuId * quantity: int * waiveStatus: bool option
+    | PatchItem of Context * SkuId * quantity: int option * waiveStatus: bool option
     | RemoveItem of Context * SkuId
 
 let interpret = function
@@ -104,7 +104,7 @@ let isValid = function
 
 // For the origin state, we only do basic filtering, which can provide good fuzz testing even if our implementation
 // might not happen to ever trigger such a state (as opposed to neutering an entire scenario as we do with isValue)
-let (|ValidOriginState|) : Fold.State -> Fold.State =
+let (|ValidOriginState|): Fold.State -> Fold.State =
     let updateItems f = function { items = i } -> { items = f i }
     updateItems (List.choose (function { quantity = q } as x when q > 0 -> Some x | _ -> None))
 

--- a/samples/Store/Domain.Tests/FavoritesTests.fs
+++ b/samples/Store/Domain.Tests/FavoritesTests.fs
@@ -11,10 +11,10 @@ let mkFavorite skuId    = Favorited { date = DateTimeOffset.UtcNow; skuId = skuI
 let mkUnfavorite skuId  = Unfavorited { skuId = skuId }
 
 type Command =
-    | Favorite      of date : DateTimeOffset * skuIds : SkuId list
-    | Unfavorite    of skuId : SkuId
+    | Favorite      of date: DateTimeOffset * skuIds: SkuId list
+    | Unfavorite    of skuId: SkuId
 
-let interpret (command : Command) =
+let interpret (command: Command) =
     match command with
     | Favorite (date, skus) ->  decideFavorite date skus
     | Unfavorite sku ->         decideUnfavorite sku
@@ -29,7 +29,7 @@ let verifyCorrectEventGenerationWhenAppropriate command (originState: State) =
     let state' = fold state events
 
     let hadSkuId, hasSkuId =
-        let stateHasSku (s : State) (skuId : SkuId) = s |> Array.exists (function { skuId = sSkuId } -> sSkuId = skuId)
+        let stateHasSku (s: State) (skuId: SkuId) = s |> Array.exists (function { skuId = sSkuId } -> sSkuId = skuId)
         stateHasSku state, stateHasSku state'
     match command, events with
     | Unfavorite skuId, [ Unfavorited e] ->

--- a/samples/Store/Domain.Tests/Infrastructure.fs
+++ b/samples/Store/Domain.Tests/Infrastructure.fs
@@ -30,7 +30,7 @@ module IdTypes =
     [<Fact>]
     let ``CartId has structural equality and Guid rendering semantics`` () =
         let x = Guid.NewGuid() in let xs, xn = x.ToString(), x.ToString "N"
-        let (x1 : CartId, x2 : CartId) = %x, %x
+        let (x1: CartId, x2: CartId) = %x, %x
         test <@ x1 = x2
                 && xn = CartId.toString x2
                 && string x1 = xs @>
@@ -38,7 +38,7 @@ module IdTypes =
     [<Fact>]
     let ``ClientId has structural equality and Guid rendering semantics`` () =
         let x = Guid.NewGuid() in let xs, xn = x.ToString(), x.ToString "N"
-        let (x1 : ClientId, x2 : ClientId) = %x, %x
+        let (x1: ClientId, x2: ClientId) = %x, %x
         test <@ x1 = x2
                 && xn = ClientId.toString x2
                 && string x1 = xs @>
@@ -46,7 +46,7 @@ module IdTypes =
     [<Fact>]
     let ``RequestId has structural equality and canonical rendering semantics`` () =
         let x = Guid.NewGuid() in let xn = Guid.toStringN x
-        let (x1 : RequestId, x2 : RequestId) = RequestId.parse %x, RequestId.parse %x
+        let (x1: RequestId, x2: RequestId) = RequestId.parse %x, RequestId.parse %x
         test <@ x1 = x2
                 && string x1 = xn @>
 
@@ -54,6 +54,6 @@ module IdTypes =
     let ``SkuId has structural equality and canonical rendering semantics`` () =
         let x = Guid.NewGuid()
         let xn = Guid.toStringN x
-        let (x1 : SkuId, x2 : SkuId) = SkuId x, SkuId x
+        let (x1: SkuId, x2: SkuId) = SkuId x, SkuId x
         test <@ x1 = x2
                 && string x1 = xn @>

--- a/samples/Store/Domain.Tests/Infrastructure.fs
+++ b/samples/Store/Domain.Tests/Infrastructure.fs
@@ -14,13 +14,13 @@ type FsCheckGenerators =
 type DomainPropertyAttribute() =
     inherit FsCheck.Xunit.PropertyAttribute(QuietOnSuccess = true, Arbitrary=[| typeof<FsCheckGenerators> |])
 
-let rnd = new Random()
+let rnd = Random()
 // https://www.rosettacode.org/wiki/Knuth_shuffle#F.23
-let knuthShuffle (array : 'a []) =
+let knuthShuffle (array: 'a[]) =
     let swap i j =
-        let item = array.[i]
-        array.[i] <- array.[j]
-        array.[j] <- item
+        let item = array[i]
+        array[i] <- array[j]
+        array[j] <- item
     let ln = array.Length
     for i in 0.. (ln - 2) do        // For all indices except the last
         swap i (rnd.Next(i, ln))    // swap th item at the index with a random one following it (or itself)

--- a/samples/Store/Domain/ContactPreferences.fs
+++ b/samples/Store/Domain/ContactPreferences.fs
@@ -9,8 +9,8 @@ let streamId = Equinox.StreamId.gen ClientId.toString // TODO hash >> base64
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
 
-    type Preferences = { manyPromotions : bool; littlePromotions : bool; productReview : bool; quickSurveys : bool }
-    type Value = { email : string; preferences : Preferences }
+    type Preferences = { manyPromotions: bool; littlePromotions: bool; productReview: bool; quickSurveys: bool }
+    type Value = { email: string; preferences: Preferences }
 
     type Event =
         | [<System.Runtime.Serialization.DataMember(Name = "contactPreferencesChanged")>]Updated of Value
@@ -22,10 +22,10 @@ module Fold =
 
     type State = Events.Preferences
 
-    let initial : State = { manyPromotions = false; littlePromotions = false; productReview = false; quickSurveys = false }
+    let initial: State = { manyPromotions = false; littlePromotions = false; productReview = false; quickSurveys = false }
     let private evolve _ignoreState = function
         | Events.Updated { preferences = value } -> value
-    let fold (state: State) (events: seq<Events.Event>) : State =
+    let fold (state: State) (events: seq<Events.Event>): State =
         Seq.tryLast events |> Option.fold evolve state
     let isOrigin _ = true
     /// When using AccessStrategy.Custom, we use the (single) event become an unfold, but the logic remains identical
@@ -35,15 +35,15 @@ module Fold =
 type Command =
     | Update of Events.Value
 
-let interpret command (state : Fold.State) =
+let interpret command (state: Fold.State) =
     match command with
     | Update ({ preferences = preferences } as value) ->
         if state = preferences then [] else
         [ Events.Updated value ]
 
-type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.State>) =
+type Service internal (resolve: ClientId -> Equinox.Decider<Events.Event, Fold.State>) =
 
-    let update email value : Async<unit> =
+    let update email value: Async<unit> =
         let decider = resolve email
         let command = let (ClientId email) = email in Update { email = email; preferences = value }
         decider.Transact(interpret command)

--- a/samples/Store/Domain/Infrastructure.fs
+++ b/samples/Store/Domain/Infrastructure.fs
@@ -7,7 +7,7 @@ open System
 
 /// Endows any type that inherits this class with standard .NET comparison semantics using a supplied token identifier
 [<AbstractClass>]
-type Comparable<'TComp, 'Token when 'TComp :> Comparable<'TComp, 'Token> and 'Token : comparison>(token : 'Token) =
+type Comparable<'TComp, 'Token when 'TComp :> Comparable<'TComp, 'Token> and 'Token : comparison>(token: 'Token) =
     member private _.Token = token
     override x.Equals y = match y with :? Comparable<'TComp, 'Token> as y -> x.Token = y.Token | _ -> false
     override _.GetHashCode() = hash token
@@ -20,21 +20,21 @@ type Comparable<'TComp, 'Token when 'TComp :> Comparable<'TComp, 'Token> and 'To
 /// Endows any type that inherits this class with standard .NET comparison semantics using a supplied token identifier
 /// + treats the token as the canonical rendition for `ToString()` purposes
 [<AbstractClass>]
-type StringId<'TComp when 'TComp :> Comparable<'TComp, string>>(token : string) =
+type StringId<'TComp when 'TComp :> Comparable<'TComp, string>>(token: string) =
     inherit Comparable<'TComp,string>(token)
     override _.ToString() = token
 
 module Guid =
-    let inline toStringN (x : Guid) = x.ToString "N"
+    let inline toStringN (x: Guid) = x.ToString "N"
 
 /// SkuId strongly typed id
 /// - Ensures canonical rendering without dashes via ToString + Newtonsoft.Json
 /// - Guards against XSS by only permitting initialization based on Guid.Parse
 /// - Implements comparison/equality solely to enable tests to leverage structural equality
 [<Sealed; AutoSerializable(false); JsonConverter(typeof<SkuIdJsonConverter>); System.Text.Json.Serialization.JsonConverter(typeof<SkuIdJsonConverterStj>)>]
-type SkuId private (id : string) =
+type SkuId private (id: string) =
     inherit StringId<SkuId>(id)
-    new(value : Guid) = SkuId(value.ToString "N")
+    new(value: Guid) = SkuId(value.ToString "N")
     /// Required to support empty
     [<Obsolete>] new() = SkuId(Guid.NewGuid())
 /// Represent as a Guid.ToString("N") output externally
@@ -58,22 +58,22 @@ module RequestId =
     /// - For web inputs, should guard against XSS by only permitting initialization based on RequestId.parse
     /// - For json deserialization where the saved representation is not trusted to be in canonical Guid form,
     ///     it is recommended to bind to a Guid and then upconvert to string<requestId>
-    let parse (value : Guid<requestId>) : string<requestId> = % Guid.toStringN %value
+    let parse (value: Guid<requestId>): string<requestId> = % Guid.toStringN %value
 
 /// CartId strongly typed id; represented internally as a Guid; not used for storage so rendering is not significant
 type CartId = Guid<cartId>
 and [<Measure>] cartId
-module CartId = let toString (value : CartId) : string = Guid.toStringN %value
+module CartId = let toString (value: CartId): string = Guid.toStringN %value
 
 /// ClientId strongly typed id; represented internally as a Guid; not used for storage so rendering is not significant
 type ClientId = Guid<clientId>
 and [<Measure>] clientId
-module ClientId = let toString (value : ClientId) : string = Guid.toStringN %value
+module ClientId = let toString (value: ClientId): string = Guid.toStringN %value
 
 /// InventoryItemId strongly typed id
 type InventoryItemId = Guid<inventoryItemId>
 and [<Measure>] inventoryItemId
-module InventoryItemId = let toString (value : InventoryItemId) : string = Guid.toStringN %value
+module InventoryItemId = let toString (value: InventoryItemId): string = Guid.toStringN %value
 
 module EventCodec =
 

--- a/samples/Store/Domain/InventoryItem.fs
+++ b/samples/Store/Domain/InventoryItem.fs
@@ -18,15 +18,15 @@ module Events =
         interface TypeShape.UnionContract.IUnionContract
 
 module Fold =
-    type State = { active : bool; name: string; quantity: int }
-    let initial : State = { active = true; name = null; quantity = 0 }
+    type State = { active: bool; name: string; quantity: int }
+    let initial: State = { active = true; name = null; quantity = 0 }
     let private evolve state = function
         | Events.Created name
         | Events.Renamed name -> { state with name = name }
         | Events.Deactivated -> { state with active = false }
         | Events.Removed count -> { state with quantity = state.quantity - count}
         | Events.CheckedIn count -> { state with quantity = state.quantity + count}
-    let fold (state: State) (events: seq<Events.Event>) : State =
+    let fold (state: State) (events: seq<Events.Event>): State =
         Seq.fold evolve state events
 
 type Command =
@@ -37,7 +37,7 @@ type Command =
     | Deactivate
 
 // TODO make commands/event representations idempotent
-let interpret command (state : Fold.State) =
+let interpret command (state: Fold.State) =
     match command with
     | Create name ->
         if String.IsNullOrEmpty name then invalidArg "name" ""
@@ -57,7 +57,7 @@ let interpret command (state : Fold.State) =
         if not state.active then invalidOp "Already deactivated"
         [ Events.Deactivated ]
 
-type Service internal (resolve : InventoryItemId -> Equinox.Decider<Events.Event, Fold.State>) =
+type Service internal (resolve: InventoryItemId -> Equinox.Decider<Events.Event, Fold.State>) =
 
     member _.Execute(itemId, command) =
         let decider = resolve itemId

--- a/samples/Store/Domain/Retries.fs
+++ b/samples/Store/Domain/Retries.fs
@@ -19,10 +19,10 @@ module Backoff =
     else x
 
   /// Stops immediately.
-  let never : Backoff = konst None
+  let never: Backoff = konst None
 
   /// Always returns a fixed interval.
-  let linear i : Backoff = konst (Some i)
+  let linear i: Backoff = konst (Some i)
 
   /// Modifies the interval.
   let bind (f:int -> int option) (b:Backoff) =
@@ -32,7 +32,7 @@ module Backoff =
       | None -> None
 
   /// Modifies the interval.
-  let map (f:int -> int) (b:Backoff) : Backoff =
+  let map (f:int -> int) (b:Backoff): Backoff =
     fun i ->
       match b i with
       | Some x -> f x |> checkOverflow |> Some
@@ -42,7 +42,7 @@ module Backoff =
   let bound mx = map (min mx)
 
   /// Creates a back-off strategy which increases the interval exponentially.
-  let exp (initialIntervalMs:int) (multiplier:float) : Backoff =
+  let exp (initialIntervalMs:int) (multiplier:float): Backoff =
     fun i -> (float initialIntervalMs) * (pown multiplier i) |> int |> checkOverflow |> Some
 
   /// Randomizes the output produced by a back-off strategy:
@@ -53,7 +53,7 @@ module Backoff =
     map (fun x -> (float x) * (rand.NextDouble() * (maxRand - minRand) + minRand) |> int)
 
   /// Uses a fibonacci sequence to genereate timeout intervals starting from the specified initial interval.
-  let fib (initialIntervalMs:int) : Backoff =
+  let fib (initialIntervalMs:int): Backoff =
     let rec fib n =
       if n < 2 then initialIntervalMs
       else fib (n - 1) + fib (n - 2)
@@ -61,13 +61,13 @@ module Backoff =
 
   /// Creates a stateful back-off strategy which keeps track of the number of attempts,
   /// and a reset function which resets attempts to zero.
-  let keepCount (b:Backoff) : (unit -> int option) * (unit -> unit) =
+  let keepCount (b:Backoff): (unit -> int option) * (unit -> unit) =
     let i = ref -1
     (fun () -> System.Threading.Interlocked.Increment i |> b),
     (fun () -> i := -1)
 
   /// Bounds a backoff strategy to a specified maximum number of attempts.
-  let maxAttempts (max:int) (b:Backoff) : Backoff =
+  let maxAttempts (max:int) (b:Backoff): Backoff =
     fun n -> if n > max then None else b n
 
 

--- a/samples/Store/Domain/SavedForLater.fs
+++ b/samples/Store/Domain/SavedForLater.fs
@@ -9,13 +9,13 @@ let streamId = Equinox.StreamId.gen ClientId.toString
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
 
-    type Item =             { skuId : SkuId; dateSaved : DateTimeOffset }
+    type Item =             { skuId: SkuId; dateSaved: DateTimeOffset }
 
-    type Added =            { skus : SkuId []; dateSaved : DateTimeOffset }
-    type Removed =          { skus : SkuId [] }
-    type Merged =           { items : Item [] }
+    type Added =            { skus: SkuId []; dateSaved: DateTimeOffset }
+    type Removed =          { skus: SkuId [] }
+    type Merged =           { items: Item [] }
     module Compaction =
-        type Compacted =    { items : Item [] }
+        type Compacted =    { items: Item [] }
         // NB need to revise this tag if you break the unfold schema
         let [<Literal>] EventType = "compacted"
 
@@ -34,26 +34,26 @@ module Events =
 
 module Fold =
     open Events
-    let isSupersededAt effectiveDate (item : Item) = item.dateSaved < effectiveDate
-    type private InternalState(externalState : seq<Item>) =
+    let isSupersededAt effectiveDate (item: Item) = item.dateSaved < effectiveDate
+    type private InternalState(externalState: seq<Item>) =
         let index = Dictionary<_,_>()
         do for i in externalState do index[i.skuId] <- i
 
-        member _.Replace (skus : seq<Item>) =
+        member _.Replace (skus: seq<Item>) =
             index.Clear() ; for s in skus do index[s.skuId] <- s
-        member _.Append(skus : seq<Item>) =
+        member _.Append(skus: seq<Item>) =
             for sku in skus do
                 let ok,found = index.TryGetValue sku.skuId
                 if not ok || found |> isSupersededAt sku.dateSaved then
                     index[sku.skuId] <- sku
-        member _.Remove (skus : seq<SkuId>) =
+        member _.Remove (skus: seq<SkuId>) =
             for sku in skus do index.Remove sku |> ignore
         member _.ToExternalState () =
             index.Values |> Seq.sortBy (fun s -> -s.dateSaved.Ticks, s.skuId) |> Seq.toArray
 
     type State = Item []
     let initial = Array.empty<Item>
-    let fold (state : State) (events : seq<Event>) : State =
+    let fold (state: State) (events: seq<Event>): State =
         let index = InternalState state
         for event in events do
             match event with
@@ -70,11 +70,11 @@ module Fold =
     let compact state = Compacted { items = state }
 
 type Command =
-    | Merge of merges : Events.Item []
-    | Remove of skuIds : SkuId []
-    | Add of dateSaved : DateTimeOffset * skuIds : SkuId []
+    | Merge of merges: Events.Item []
+    | Remove of skuIds: SkuId []
+    | Add of dateSaved: DateTimeOffset * skuIds: SkuId []
 
-type private Index(state : Events.Item seq) =
+type private Index(state: Events.Item seq) =
     let index = Dictionary<_,_>()
     do for i in state do do index[i.skuId] <- i
 
@@ -82,11 +82,11 @@ type private Index(state : Events.Item seq) =
         match index.TryGetValue sku with
         | true,item when item.dateSaved >= effectiveDate -> false
         | _ -> true
-    member this.DoesNotAlreadyContainItem(item : Events.Item) =
+    member this.DoesNotAlreadyContainItem(item: Events.Item) =
         this.DoesNotAlreadyContainSameOrMoreRecent item.dateSaved item.skuId
 
 // yields true if the command was executed, false if it would have breached the invariants
-let decide (maxSavedItems : int) (cmd : Command) (state : Fold.State) : bool * Events.Event list =
+let decide (maxSavedItems: int) (cmd: Command) (state: Fold.State): bool * Events.Event list =
     let validateAgainstInvariants events =
         if Fold.proposedEventsWouldExceedLimit maxSavedItems events state then false, []
         else true, events
@@ -106,21 +106,21 @@ let decide (maxSavedItems : int) (cmd : Command) (state : Fold.State) : bool * E
         if Array.isEmpty net then true, []
         else validateAgainstInvariants [ Events.Added { skus = net ; dateSaved = dateSaved } ]
 
-type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.State>, maxSavedItems) =
+type Service internal (resolve: ClientId -> Equinox.Decider<Events.Event, Fold.State>, maxSavedItems) =
 
     do if maxSavedItems < 0 then invalidArg "maxSavedItems" "must be non-negative value."
 
-    let execute clientId command : Async<bool> =
+    let execute clientId command: Async<bool> =
         let decider = resolve clientId
         decider.Transact(decide maxSavedItems command)
 
-    let read clientId : Async<Events.Item[]> =
+    let read clientId: Async<Events.Item[]> =
         let decider = resolve clientId
         decider.Query id
 
-    let remove clientId (resolveCommand : (SkuId->bool) -> Async<Command>) : Async<unit> =
+    let remove clientId (resolveCommand: (SkuId->bool) -> Async<Command>): Async<unit> =
         let decider = resolve clientId
-        decider.TransactAsync(fun (state : Fold.State) -> async {
+        decider.TransactAsync(fun (state: Fold.State) -> async {
             let contents = seq { for item in state -> item.skuId } |> set
             let! cmd = resolveCommand contents.Contains
             let _, events = decide maxSavedItems cmd state
@@ -128,18 +128,18 @@ type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.
 
     member _.MaxSavedItems = maxSavedItems
 
-    member _.List clientId : Async<Events.Item []> = read clientId
+    member _.List clientId: Async<Events.Item []> = read clientId
 
-    member _.Save(clientId, skus : seq<SkuId>) : Async<bool> =
+    member _.Save(clientId, skus: seq<SkuId>): Async<bool> =
         execute clientId <| Add (DateTimeOffset.Now, Seq.toArray skus)
 
-    member _.Remove(clientId, resolve : (SkuId -> bool) -> Async<SkuId[]>) : Async<unit> =
+    member _.Remove(clientId, resolve: (SkuId -> bool) -> Async<SkuId[]>): Async<unit> =
         let resolve hasSku = async {
             let! skus = resolve hasSku
             return Remove skus }
         remove clientId resolve
 
-    member _.Merge(clientId, targetId) : Async<bool> = async {
+    member _.Merge(clientId, targetId): Async<bool> = async {
         let! state = read clientId
         return! execute targetId (Merge state) }
 

--- a/samples/Store/Integration/AutoDataAttribute.fs
+++ b/samples/Store/Integration/AutoDataAttribute.fs
@@ -5,7 +5,7 @@ open System
 type AutoDataAttribute() =
     inherit FsCheck.Xunit.PropertyAttribute(Arbitrary = [|typeof<FsCheckGenerators>|], MaxTest = 1, QuietOnSuccess = true)
 
-    member val SkipIfRequestedViaEnvironmentVariable : string = null with get, set
+    member val SkipIfRequestedViaEnvironmentVariable: string = null with get, set
 
     member x.SkipRequested =
         match Option.ofObj x.SkipIfRequestedViaEnvironmentVariable |> Option.map Environment.GetEnvironmentVariable |> Option.bind Option.ofObj with

--- a/samples/Store/Integration/TestOutput.fs
+++ b/samples/Store/Integration/TestOutput.fs
@@ -22,14 +22,14 @@ type LogCaptureBuffer() =
     member _.Clear () = captured.Clear()
     member _.ChooseCalls chooser = captured |> Seq.choose chooser |> List.ofSeq
 
-type TestOutput(testOutput : Xunit.Abstractions.ITestOutputHelper) =
+type TestOutput(testOutput: Xunit.Abstractions.ITestOutputHelper) =
 
-    let write (m : string) =
+    let write (m: string) =
         m.TrimEnd '\n' |> testOutput.WriteLine
         m |> System.Diagnostics.Trace.WriteLine
     let testOutputAndTrace = TestOutputRendererSink(write)
 
-    member _.CreateLogger(?sink : Serilog.Core.ILogEventSink) =
+    member _.CreateLogger(?sink: Serilog.Core.ILogEventSink) =
         LoggerConfiguration()
             .WriteTo.Sink(testOutputAndTrace)
             .WriteTo.Seq("http://localhost:5341")

--- a/src/Equinox.Core/AsyncBatchingGate.fs
+++ b/src/Equinox.Core/AsyncBatchingGate.fs
@@ -4,7 +4,7 @@ namespace Equinox.Core
 /// - requests arriving together can be coalesced into the batch during the linger period via TryAdd
 /// - callers that have had items admitted can concurrently await the shared fate of the dispatch via AwaitResult
 /// - callers whose TryAdd has been denied can await the completion of the in-flight batch via AwaitCompletion
-type internal AsyncBatch<'Req, 'Res>(dispatch : 'Req[] -> Async<'Res>, lingerMs : int) =
+type internal AsyncBatch<'Req, 'Res>(dispatch: 'Req[] -> Async<'Res>, lingerMs: int) =
     // Yes, naive impl in the absence of a cleaner way to have callers sharing the AwaitCompletion coordinate the adding
     let queue = new System.Collections.Concurrent.BlockingCollection<'Req>()
     let task = lazy if lingerMs = 0 then task { queue.CompleteAdding(); return! dispatch (queue.ToArray()) }
@@ -30,11 +30,11 @@ type internal AsyncBatch<'Req, 'Res>(dispatch : 'Req[] -> Async<'Res>, lingerMs 
     /// Wait for dispatch to conclude (for any reason: ok/exn/cancel; we only care about the channel being clear)
     member _.AwaitCompletion() =
         Async.FromContinuations(fun (cont, _, _) ->
-            task.Value.ContinueWith(fun (_ : System.Threading.Tasks.Task<'Res>) -> cont ())
+            task.Value.ContinueWith(fun (_: System.Threading.Tasks.Task<'Res>) -> cont ())
             |> ignore)
 
 /// Manages concurrent work such that requests arriving while a batch is in flight converge to wait for the next window
-type AsyncBatchingGate<'Req, 'Res>(dispatch : 'Req[] -> Async<'Res>, ?linger : System.TimeSpan) =
+type AsyncBatchingGate<'Req, 'Res>(dispatch: 'Req[] -> Async<'Res>, ?linger: System.TimeSpan) =
     let linger = match linger with None -> 1 | Some x -> int x.TotalMilliseconds
     let mutable cell = AsyncBatch(dispatch, linger)
 

--- a/src/Equinox.Core/AsyncCacheCell.fs
+++ b/src/Equinox.Core/AsyncCacheCell.fs
@@ -4,7 +4,7 @@ open System.Threading
 open System.Threading.Tasks
 
 /// Asynchronous Lazy<'T> used to gate a workflow to ensure at most once execution of a computation.
-type AsyncLazy<'T>(workflow : unit -> Task<'T>) =
+type AsyncLazy<'T>(workflow: unit -> Task<'T>) =
 
     /// NOTE due to `Lazy<T>` semantics, failed attempts will cache any exception; AsyncCacheCell compensates for this by rolling over to a new instance
     let workflow = lazy workflow ()
@@ -21,13 +21,13 @@ type AsyncLazy<'T>(workflow : unit -> Task<'T>) =
         | _ -> true
 
     /// Used to rule out values where the computation yielded an exception or the result has now expired
-    member _.TryAwaitValid(isExpired) : Task<'T voption> =
+    member _.TryAwaitValid(isExpired): Task<'T voption> =
         let t = workflow.Value
 
         // Determines if the last attempt completed, but failed; For TMI see https://stackoverflow.com/a/33946166/11635
         if t.IsFaulted then Task.FromResult ValueNone
         else task {
-            let! (res : 'T) = t
+            let! (res: 'T) = t
             match isExpired with
             | ValueSome isExpired when isExpired res -> return ValueNone
             | _ -> return ValueSome res }
@@ -38,7 +38,7 @@ type AsyncLazy<'T>(workflow : unit -> Task<'T>) =
 /// Generic async lazy caching implementation that admits expiration/recomputation/retry on exception semantics.
 /// If `workflow` fails, all readers entering while the load/refresh is in progress will share the failure
 /// The first caller through the gate triggers a recomputation attempt if the previous attempt ended in failure
-type AsyncCacheCell<'T>(workflow : CancellationToken -> Task<'T>, ?isExpired : 'T -> bool) =
+type AsyncCacheCell<'T>(workflow: CancellationToken -> Task<'T>, ?isExpired: 'T -> bool) =
 
     let isExpired = match isExpired with Some x -> ValueSome x | None -> ValueNone
     // we can't pre-initialize as we need the invocation to be tied to a CancellationToken

--- a/src/Equinox.Core/Cache.fs
+++ b/src/Equinox.Core/Cache.fs
@@ -11,20 +11,20 @@ type [<NoEquality; NoComparison>] CacheItemOptions =
 type CacheEntry<'state>(initialToken: StreamToken, initialState: 'state) =
     let mutable currentToken = initialToken
     let mutable currentState = initialState
-    member x.UpdateIfNewer(supersedes : struct (StreamToken * StreamToken) -> bool, other : CacheEntry<'state>) =
+    member x.UpdateIfNewer(supersedes: struct (StreamToken * StreamToken) -> bool, other: CacheEntry<'state>) =
         lock x <| fun () ->
             let struct (otherToken, otherState) = other.Value
             if supersedes (currentToken, otherToken) then
                 currentToken <- otherToken
                 currentState <- otherState
 
-    member x.Value : struct (StreamToken * 'state) =
+    member x.Value: struct (StreamToken * 'state) =
         lock x <| fun () ->
             currentToken, currentState
 
 type ICache =
-    abstract member UpdateIfNewer : key: string * options: CacheItemOptions * (struct (StreamToken * StreamToken) -> bool) * entry: CacheEntry<'state> -> Task<unit>
-    abstract member TryGet : key: string -> Task<struct (StreamToken * 'state) voption>
+    abstract member UpdateIfNewer: key: string * options: CacheItemOptions * (struct (StreamToken * StreamToken) -> bool) * entry: CacheEntry<'state> -> Task<unit>
+    abstract member TryGet: key: string -> Task<struct (StreamToken * 'state) voption>
 
 namespace Equinox
 
@@ -32,7 +32,7 @@ open Equinox.Core
 open System.Runtime.Caching
 open System.Threading.Tasks
 
-type Cache(name, sizeMb : int) =
+type Cache(name, sizeMb: int) =
 
     let cache =
         let config = System.Collections.Specialized.NameValueCollection(1)

--- a/src/Equinox.Core/Category.fs
+++ b/src/Equinox.Core/Category.fs
@@ -7,19 +7,19 @@ open System.Threading.Tasks
 /// Store-agnostic interface representing interactions an Application can have with a set of streams with a given pair of Event and State types
 type ICategory<'event, 'state, 'context> =
     /// Obtain the state from the target stream
-    abstract Load : log: ILogger * categoryName: string * streamId: string * streamName: string
-                    * allowStale: bool * requireLeader: bool
-                    * ct: CancellationToken -> Task<struct (StreamToken * 'state)>
+    abstract Load: log: ILogger * categoryName: string * streamId: string * streamName: string
+                   * allowStale: bool * requireLeader: bool
+                   * ct: CancellationToken -> Task<struct (StreamToken * 'state)>
 
     /// Given the supplied `token`, attempt to sync to the proposed updated `state'` by appending the supplied `events` to the underlying stream, yielding:
     /// - Written: signifies synchronization has succeeded, implying the included StreamState should now be assumed to be the state of the stream
     /// - Conflict: signifies the sync failed, and the proposed decision hence needs to be reconsidered in light of the supplied conflicting Stream State
     /// NB the central precondition upon which the sync is predicated is that the stream has not diverged from the `originState` represented by `token`
     ///    where the precondition is not met, the SyncResult.Conflict bears a [lazy] async result (in a specific manner optimal for the store)
-    abstract TrySync : log: ILogger * categoryName: string * streamId: string * streamName: string * 'context
-                       * maybeInit: (CancellationToken -> Task<unit>) voption
-                       * originToken: StreamToken * originState: 'state * events: 'event[]
-                       * CancellationToken -> Task<SyncResult<'state>>
+    abstract TrySync: log: ILogger * categoryName: string * streamId: string * streamName: string * 'context
+                      * maybeInit: (CancellationToken -> Task<unit>) voption
+                      * originToken: StreamToken * originState: 'state * events: 'event[]
+                      * CancellationToken -> Task<SyncResult<'state>>
 
 // Low level stream impl, used by Store-specific Category types that layer policies such as Caching in
 namespace Equinox
@@ -32,11 +32,11 @@ open System.Threading.Tasks
 /// Store-agnostic baseline functionality for a Category of 'event representations that fold to a given 'state
 [<NoComparison; NoEquality>]
 type Category<'event, 'state, 'context>
-    (   resolveInner : string -> string-> struct (Core.ICategory<'event, 'state, 'context> * string * (CancellationToken -> Task<unit>) voption),
-        empty : struct (Core.StreamToken * 'state)) =
+    (   resolveInner: string -> string-> struct (Core.ICategory<'event, 'state, 'context> * string * (CancellationToken -> Task<unit>) voption),
+        empty: struct (Core.StreamToken * 'state)) =
     /// Provides access to the low level store operations used for Loading and/or Syncing updates via the Decider
     /// (Normal usage is via the adjacent `module Decider` / `DeciderExtensions.Resolve` helpers)
-    member _.Stream(log : Serilog.ILogger, context : 'context, categoryName, streamId) =
+    member _.Stream(log: Serilog.ILogger, context: 'context, categoryName, streamId) =
         let struct (inner, streamName, init) = resolveInner categoryName streamId
         { new Core.IStream<'event, 'state> with
             member _.LoadEmpty() =
@@ -52,20 +52,20 @@ type Category<'event, 'state, 'context>
                 return! inner.TrySync(log, categoryName, streamId, streamName, context, init, token, originState, events, ct) } }
 
 type private Stream =
-    static member Resolve(cat : Category<'event, 'state, 'context>, log, context) : System.Func<string, Core.StreamId, Core.IStream<'event, 'state>> =
+    static member Resolve(cat: Category<'event, 'state, 'context>, log, context): System.Func<string, Core.StreamId, Core.IStream<'event, 'state>> =
         System.Func<string, Core.StreamId, _>(fun categoryName streamId -> cat.Stream(log, context, categoryName, Core.StreamId.toString streamId))
 
 [<System.Runtime.CompilerServices.Extension>]
 type DeciderCore =
     [<System.Runtime.CompilerServices.Extension>]
-    static member Resolve(cat : Category<'event, 'state, 'context>, log, context) : System.Func<string, Core.StreamId, DeciderCore<'event, 'state>> =
+    static member Resolve(cat: Category<'event, 'state, 'context>, log, context): System.Func<string, Core.StreamId, DeciderCore<'event, 'state>> =
          System.Func<_, _, _>(fun c s -> Stream.Resolve(cat, log, context).Invoke(c, s) |> DeciderCore)
     [<System.Runtime.CompilerServices.Extension>]
-    static member Resolve(cat : Category<'event, 'state, unit>, log) : System.Func<string, Core.StreamId, DeciderCore<'event, 'state>> =
+    static member Resolve(cat: Category<'event, 'state, unit>, log): System.Func<string, Core.StreamId, DeciderCore<'event, 'state>> =
         DeciderCore.Resolve(cat, log, ())
 
 module Decider =
-    let resolveWithContext log (cat : Category<'event, 'state, 'context>) categoryName context streamId =
+    let resolveWithContext log (cat: Category<'event, 'state, 'context>) categoryName context streamId =
         DeciderCore.Resolve(cat, log, context).Invoke(categoryName, streamId) |> Decider
-    let resolve log (cat : Category<'event, 'state, unit>) categoryName streamId =
+    let resolve log (cat: Category<'event, 'state, unit>) categoryName streamId =
         resolveWithContext log cat categoryName () streamId

--- a/src/Equinox.Core/Category.fs
+++ b/src/Equinox.Core/Category.fs
@@ -18,7 +18,7 @@ type ICategory<'event, 'state, 'context> =
     ///    where the precondition is not met, the SyncResult.Conflict bears a [lazy] async result (in a specific manner optimal for the store)
     abstract TrySync : log: ILogger * categoryName: string * streamId: string * streamName: string * 'context
                        * maybeInit: (CancellationToken -> Task<unit>) voption
-                       * originToken: StreamToken * originState: 'state * events: 'event array
+                       * originToken: StreamToken * originState: 'state * events: 'event[]
                        * CancellationToken -> Task<SyncResult<'state>>
 
 // Low level stream impl, used by Store-specific Category types that layer policies such as Caching in
@@ -41,7 +41,7 @@ type Category<'event, 'state, 'context>
         { new Core.IStream<'event, 'state> with
             member _.LoadEmpty() =
                 empty
-            member x.Load(allowStale, requireLeader, ct) = task {
+            member _.Load(allowStale, requireLeader, ct) = task {
                 use act = source.StartActivity("Load", ActivityKind.Client)
                 if act <> null then act.AddStream(categoryName, streamId, streamName).AddLeader(requireLeader).AddStale(allowStale) |> ignore
                 return! inner.Load(log, categoryName, streamId, streamName, allowStale, requireLeader, ct) }

--- a/src/Equinox.Core/Infrastructure.fs
+++ b/src/Equinox.Core/Infrastructure.fs
@@ -20,9 +20,9 @@ type Async with
     /// </summary>
     /// <param name="task">Task to be awaited.</param>
     [<DebuggerStepThrough>]
-    static member AwaitTaskCorrect(task : Task<'T>) : Async<'T> =
+    static member AwaitTaskCorrect(task: Task<'T>): Async<'T> =
         Async.FromContinuations(fun (sc, ec, _cc) ->
-            task.ContinueWith(fun (t : Task<'T>) ->
+            task.ContinueWith(fun (t: Task<'T>) ->
                 if t.IsFaulted then
                     let e = t.Exception
                     if e.InnerExceptions.Count = 1 then ec e.InnerExceptions[0]
@@ -38,9 +38,9 @@ type Async with
     /// </summary>
     /// <param name="task">Task to be awaited.</param>
     [<DebuggerStepThrough>]
-    static member AwaitTaskCorrect(task : Task) : Async<unit> =
+    static member AwaitTaskCorrect(task: Task): Async<unit> =
         Async.FromContinuations(fun (sc, ec, _cc) ->
-            task.ContinueWith(fun (task : Task) ->
+            task.ContinueWith(fun (task: Task) ->
                 if task.IsFaulted then
                     let e = task.Exception
                     if e.InnerExceptions.Count = 1 then ec e.InnerExceptions[0]
@@ -63,4 +63,4 @@ module Seq =
 module Array =
 
     let inline chooseV f xs = [| for item in xs do match f item with ValueSome v -> yield v | ValueNone -> () |]
-    let inline tryFirstV (xs : _ array) = if xs.Length = 0 then ValueNone else ValueSome xs[0]
+    let inline tryFirstV (xs: _[]) = if xs.Length = 0 then ValueNone else ValueSome xs[0]

--- a/src/Equinox.Core/Internal.fs
+++ b/src/Equinox.Core/Internal.fs
@@ -4,11 +4,11 @@ module internal Equinox.Core.Internal
 module Log =
 
     // Sidestep Log.ForContext converting to a string; see https://github.com/serilog/serilog/issues/1124
-    let withScalarProperty (key: string) (value : 'T) (log : Serilog.ILogger) =
-        let enrich (e : Serilog.Events.LogEvent) =
+    let withScalarProperty (key: string) (value: 'T) (log: Serilog.ILogger) =
+        let enrich (e: Serilog.Events.LogEvent) =
             e.AddPropertyIfAbsent(Serilog.Events.LogEventProperty(key, Serilog.Events.ScalarValue(value)))
         log.ForContext({ new Serilog.Core.ILogEventEnricher with member _.Enrich(evt,_) = enrich evt })
-    let [<return: Struct>] (|ScalarValue|_|) : Serilog.Events.LogEventPropertyValue -> obj voption = function
+    let [<return: Struct>] (|ScalarValue|_|): Serilog.Events.LogEventPropertyValue -> obj voption = function
         | :? Serilog.Events.ScalarValue as x -> ValueSome x.Value
         | _ -> ValueNone
 

--- a/src/Equinox.Core/Retry.fs
+++ b/src/Equinox.Core/Retry.fs
@@ -1,16 +1,16 @@
 namespace Equinox.Core
 
 /// Exception yielded by after `count` attempts to complete an operation have taken place
-type OperationRetriesExceededException(count : int, innerException : exn) =
+type OperationRetriesExceededException(count: int, innerException: exn) =
    inherit exn(sprintf "Retries failed; aborting after %i attempts." count, innerException)
 
 /// Helper for defining backoffs within the definition of a retry policy for a store.
 module Retry =
     /// Wraps an async computation in a retry loop, passing the (1-based) count into the computation and,
     ///   (until `attempts` exhausted) on an exception matching the `filter`, waiting for the timespan chosen by `backoff` before retrying
-    let withBackoff (maxAttempts : int) (backoff : int -> System.TimeSpan option) (f : int -> Async<'a>) : Async<'a> =
+    let withBackoff (maxAttempts: int) (backoff: int -> System.TimeSpan option) (f: int -> Async<'a>): Async<'a> =
         if maxAttempts < 1 then raise (invalidArg "maxAttempts" "Should be >= 1")
-        
+
         let rec go attempt = async {
             try
                 let! res = f attempt
@@ -22,5 +22,5 @@ module Retry =
                     | Some timespan -> do! Async.Sleep (int timespan.TotalMilliseconds)
                     | None -> ()
                     return! go (attempt + 1) }
-        
+
         go 1

--- a/src/Equinox.Core/StopwatchInterval.fs
+++ b/src/Equinox.Core/StopwatchInterval.fs
@@ -10,12 +10,12 @@ type Stopwatch =
 
     /// Converts a tick count (derived from two Stopwatch.GetTimeStamp() Tick Counters) into a number of seconds
     [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
-    static member TicksToSeconds(ticks : int64) : double =
+    static member TicksToSeconds(ticks: int64): double =
         let ticksPerSecond = double Stopwatch.Frequency
         double ticks / ticksPerSecond
 
 /// Represents a time measurement of a computation that includes the Stopwatch Timestamp metadata
-and [<Struct; NoEquality; NoComparison>] StopwatchInterval(startTicks : int64, endTicks : int64) =
+and [<Struct; NoEquality; NoComparison>] StopwatchInterval(startTicks: int64, endTicks: int64) =
     // do if startTicks < 0L || startTicks > endTicks then invalidArg "ticks" "tick arguments do not form a valid interval."
     member _.StartTicks = startTicks
     member _.EndTicks = endTicks
@@ -26,7 +26,7 @@ and [<Struct; NoEquality; NoComparison>] StopwatchInterval(startTicks : int64, e
 module Stopwatch =
 
     [<DebuggerStepThrough>]
-    let time (ct : CancellationToken) (f : CancellationToken -> Task<'T>) : Task<struct (StopwatchInterval * 'T)> = task {
+    let time (ct: CancellationToken) (f: CancellationToken -> Task<'T>): Task<struct (StopwatchInterval * 'T)> = task {
         let startTicks = Stopwatch.GetTimestamp()
         let! result = f ct
         let endTicks = Stopwatch.GetTimestamp()

--- a/src/Equinox.CosmosStore.Prometheus/CosmosStorePrometheus.fs
+++ b/src/Equinox.CosmosStore.Prometheus/CosmosStorePrometheus.fs
@@ -9,9 +9,9 @@ module private Histograms =
 
     let labelNames tagNames = Array.append tagNames [| "rut"; "facet"; "op"; "db"; "con"; "cat" |]
     let labelValues tagValues (rut, facet, op, db, con, cat) = Array.append tagValues [| rut; facet; op; db; con; cat |]
-    let private mkHistogram (cfg : Prometheus.HistogramConfiguration) name desc =
+    let private mkHistogram (cfg: Prometheus.HistogramConfiguration) name desc =
         let h = Prometheus.Metrics.CreateHistogram(name, desc, cfg)
-        fun tagValues (rut, facet : string, op : string) (db, con, cat : string) s ->
+        fun tagValues (rut, facet: string, op: string) (db, con, cat: string) s ->
             h.WithLabels(labelValues tagValues (rut, facet, op, db, con, cat)).Observe(s)
     // Given we also have summary metrics with equivalent labels, we focus the bucketing on LAN latencies
     let private sHistogram tagNames =
@@ -26,7 +26,7 @@ module private Histograms =
         let baseName, baseDesc = Impl.baseName stat, Impl.baseDesc desc
         let observeS = sHistogram tagNames (baseName + "_seconds") (baseDesc + " latency")
         let observeRu = ruHistogram tagNames (baseName + "_ru") (baseDesc + " charge")
-        fun (rut, facet, op) (db, con, cat, s : System.TimeSpan, ru) ->
+        fun (rut, facet, op) (db, con, cat, s: System.TimeSpan, ru) ->
             observeS tagValues (rut, facet, op) (db, con, cat) s.TotalSeconds
             observeRu tagValues (rut, facet, op) (db, con, cat) ru
 
@@ -34,9 +34,9 @@ module private Summaries =
 
     let labelNames tagNames = Array.append tagNames [| "facet"; "db"; "con" |]
     let labelValues tagValues (facet, db, con) = Array.append tagValues [| facet; db; con |]
-    let private mkSummary (cfg : Prometheus.SummaryConfiguration) name desc  =
+    let private mkSummary (cfg: Prometheus.SummaryConfiguration) name desc  =
         let s = Prometheus.Metrics.CreateSummary(name, desc, cfg)
-        fun tagValues (facet : string) (db, con) o -> s.WithLabels(labelValues tagValues (facet, db, con)).Observe(o)
+        fun tagValues (facet: string) (db, con) o -> s.WithLabels(labelValues tagValues (facet, db, con)).Observe(o)
     let config tagNames =
         let inline qep q e = Prometheus.QuantileEpsilonPair(q, e)
         let objectives = [| qep 0.50 0.05; qep 0.95 0.01; qep 0.99 0.01 |]
@@ -45,7 +45,7 @@ module private Summaries =
         let baseName, baseDesc = Impl.baseName stat, Impl.baseDesc desc
         let observeS = mkSummary (config tagNames) (baseName + "_seconds") (baseDesc + " latency") tagValues
         let observeRu = mkSummary (config tagNames) (baseName + "_ru") (baseDesc + " charge") tagValues
-        fun facet (db, con, s : System.TimeSpan, ru) ->
+        fun facet (db, con, s: System.TimeSpan, ru) ->
             observeS facet (db, con) s.TotalSeconds
             observeRu facet (db, con) ru
 
@@ -53,9 +53,9 @@ module private Counters =
 
     let labelNames tagNames = Array.append tagNames [| "facet"; "op"; "outcome"; "db"; "con"; "cat" |]
     let labelValues tagValues (facet, op, outcome, db, con, cat) = Array.append tagValues [| facet; op; outcome; db; con; cat |]
-    let private mkCounter (cfg : Prometheus.CounterConfiguration) name desc =
+    let private mkCounter (cfg: Prometheus.CounterConfiguration) name desc =
         let h = Prometheus.Metrics.CreateCounter(name, desc, cfg)
-        fun tagValues (facet : string, op : string, outcome : string) (db, con, cat) c ->
+        fun tagValues (facet: string, op: string, outcome: string) (db, con, cat) c ->
             h.WithLabels(labelValues tagValues (facet, op, outcome, db, con, cat)).Inc(c)
     let config tagNames = Prometheus.CounterConfiguration(LabelNames = labelNames tagNames)
     let total (tagNames, tagValues) stat desc =
@@ -91,7 +91,7 @@ type LogSink(customTags: seq<string * string>) =
         observeLatencyAndCharge (rut, facet, op) (db, con, cat, s, ru)
         payloadCounters (facet, op, outcome) (db, con, cat, float count, if bytes = -1 then None else Some (float bytes))
 
-    let (|CatSRu|) ({ interval = i; ru = ru } : Measurement as m) =
+    let (|CatSRu|) ({ interval = i; ru = ru }: Measurement as m) =
         struct (m.database, m.container, m.Category, i.Elapsed, ru)
     let observeRes (_rut, facet, _op as stat) (CatSRu (db, con, cat, s, ru)) =
         roundtripHistogram stat (db, con, cat, s, ru)

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -78,7 +78,7 @@ type Batch = // TODO for STJ v5: All fields required unless explicitly optional
 /// Compaction/Snapshot/Projection Event based on the state at a given point in time `i`
 [<NoEquality; NoComparison>]
 type Unfold =
-    {   /// Base: Stream Position (Version) of State from which this Unfold Event was generated
+    {   /// Base: Stream Position (Version) of State from which this Unfold Event was generated. An unfold from State Version 1 is i=1 and includes event i=1
         i: int64
 
         /// Generation datetime

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -29,10 +29,10 @@ type Event = // TODO for STJ v5: All fields required unless explicitly optional
         m: EventBody // TODO for STJ v5: Optional, not serialized if missing
 
         /// Optional correlationId
-        correlationId : string // TODO for STJ v5: Optional, not serialized if missing
+        correlationId: string // TODO for STJ v5: Optional, not serialized if missing
 
         /// Optional causationId
-        causationId : string // TODO for STJ v5: Optional, not serialized if missing
+        causationId: string // TODO for STJ v5: Optional, not serialized if missing
     }
 
     interface IEventData<EventBody> with
@@ -128,20 +128,20 @@ type Tip = // TODO for STJ v5: All fields required unless explicitly optional
 
 /// Position and Etag to which an operation is relative
 [<NoComparison>]
-type Position = { index : int64; etag : string option }
+type Position = { index: int64; etag: string option }
 
 module internal Position =
     /// NB very inefficient compared to FromDocument or using one already returned to you
-    let fromI (i : int64) = { index = i; etag = None }
+    let fromI (i: int64) = { index = i; etag = None }
     /// If we have strong reason to suspect a stream is empty, we won't have an etag (and Writer Stored Procedure special cases this)
     let fromKnownEmpty = fromI 0L
     /// Just Do It mode
     let fromAppendAtEnd = fromI -1L // sic - needs to yield -1
-    let fromEtag (value : string) = { fromI -2L with etag = Some value }
+    let fromEtag (value: string) = { fromI -2L with etag = Some value }
     /// Create Position from Tip record context (facilitating 1 RU reads)
-    let fromTip (x : Tip) = { index = x.n; etag = match x._etag with null -> None | x -> Some x }
+    let fromTip (x: Tip) = { index = x.n; etag = match x._etag with null -> None | x -> Some x }
     /// If we encounter the tip (id=-1) item/document, we're interested in its etag so we can re-sync for 1 RU
-    let tryFromBatch (x : Batch) =
+    let tryFromBatch (x: Batch) =
         if x.id <> Tip.WellKnownDocumentId then None
         else Some { index = x.n; etag = match x._etag with null -> None | x -> Some x }
 
@@ -149,7 +149,7 @@ module internal Position =
 type Direction = Forward | Backward override this.ToString() = match this with Forward -> "Forward" | Backward -> "Backward"
 
 type internal Enum() =
-    static member Events(i : int64, e : Event[], ?minIndex, ?maxIndex) : ITimelineEvent<EventBody> seq = seq {
+    static member Events(i: int64, e: Event[], ?minIndex, ?maxIndex): ITimelineEvent<EventBody> seq = seq {
         let indexMin, indexMax = defaultArg minIndex 0L, defaultArg maxIndex Int64.MaxValue
         for offset in 0..e.Length-1 do
             let index = i + int64 offset
@@ -157,19 +157,19 @@ type internal Enum() =
             if index >= indexMin && index < indexMax then
                 let x = e[offset]
                 yield FsCodec.Core.TimelineEvent.Create(index, x.c, x.d, x.m, Guid.Empty, x.correlationId, x.causationId, x.t) }
-    static member internal Events(t : Tip, ?minIndex, ?maxIndex) : ITimelineEvent<EventBody> seq =
+    static member internal Events(t: Tip, ?minIndex, ?maxIndex): ITimelineEvent<EventBody> seq =
         Enum.Events(t.i, t.e, ?minIndex = minIndex, ?maxIndex = maxIndex)
-    static member internal Events(b : Batch, ?minIndex, ?maxIndex) =
+    static member internal Events(b: Batch, ?minIndex, ?maxIndex) =
         Enum.Events(b.i, b.e, ?minIndex = minIndex, ?maxIndex = maxIndex)
-    static member Unfolds(xs : Unfold[]) : ITimelineEvent<EventBody> seq = seq {
+    static member Unfolds(xs: Unfold[]): ITimelineEvent<EventBody> seq = seq {
         for x in xs -> FsCodec.Core.TimelineEvent.Create(x.i, x.c, x.d, x.m, Guid.Empty, null, null, x.t, isUnfold = true) }
-    static member EventsAndUnfolds(x : Tip, ?minIndex, ?maxIndex) : ITimelineEvent<EventBody> seq =
+    static member EventsAndUnfolds(x: Tip, ?minIndex, ?maxIndex): ITimelineEvent<EventBody> seq =
         Enum.Events(x, ?minIndex = minIndex, ?maxIndex = maxIndex)
         |> Seq.append (Enum.Unfolds x.u)
         // where Index is equal, unfolds get delivered after the events so the fold semantics can be 'idempotent'
         |> Seq.sortBy (fun x -> x.Index, x.IsUnfold)
 
-type IRetryPolicy = abstract member Execute : (int -> CancellationToken -> Task<'T>) -> Task<'T>
+type IRetryPolicy = abstract member Execute: (int -> CancellationToken -> Task<'T>) -> Task<'T>
 
 module Log =
 
@@ -178,8 +178,8 @@ module Log =
 
     [<NoEquality; NoComparison>]
     type Measurement =
-       {   database : string; container : string; stream : string
-           interval : StopwatchInterval; bytes : int; count : int; ru : float }
+       {   database: string; container: string; stream: string
+           interval: StopwatchInterval; bytes: int; count: int; ru: float }
        member x.Category = StreamName.category (FSharp.UMX.UMX.tag x.stream)
     [<RequireQualifiedAccess; NoEquality; NoComparison>]
     type Metric =
@@ -191,7 +191,7 @@ module Log =
         | TipNotModified of Measurement
 
         /// Summarizes a set of Responses for a given Read request
-        | Query of Direction * responses : int * Measurement
+        | Query of Direction * responses: int * Measurement
         /// Individual read request in a Batch
         /// Charges are rolled up into Query Metric (so do not double count)
         | QueryResponse of Direction * Measurement
@@ -203,7 +203,7 @@ module Log =
         /// Summarizes outcome of request to trim batches from head of a stream and events in Tip
         /// Count in Measurement is number of batches (documents) deleted
         /// Bytes in Measurement is number of events deleted
-        | Prune of responsesHandled : int * Measurement
+        | Prune of responsesHandled: int * Measurement
         /// Handled response from listing of batches in a stream
         /// Charges are rolled up into the Prune Metric (so do not double count)
         | PruneResponse of Measurement
@@ -211,24 +211,24 @@ module Log =
         | Delete of Measurement
         /// Trimmed the Tip
         | Trim of Measurement
-    let [<return: Struct>] (|MetricEvent|_|) (logEvent : Serilog.Events.LogEvent) : Metric voption =
+    let [<return: Struct>] (|MetricEvent|_|) (logEvent: Serilog.Events.LogEvent): Metric voption =
         let mutable p = Unchecked.defaultof<_>
         logEvent.Properties.TryGetValue(PropertyTag, &p) |> ignore
         match p with Log.ScalarValue (:? Metric as e) -> ValueSome e | _ -> ValueNone
 
     /// Attach a property to the captured event record to hold the metric information
-    let internal event (value : Metric) = Internal.Log.withScalarProperty PropertyTag value
-    let internal prop name value (log : ILogger) = log.ForContext(name, value)
-    let internal propData name (events : #IEventData<EventBody> seq) (log : ILogger) =
-        let render (body : EventBody) = body.GetRawText()
+    let internal event (value: Metric) = Internal.Log.withScalarProperty PropertyTag value
+    let internal prop name value (log: ILogger) = log.ForContext(name, value)
+    let internal propData name (events: #IEventData<EventBody> seq) (log: ILogger) =
+        let render (body: EventBody) = body.GetRawText()
         let items = seq { for e in events do yield sprintf "{\"%s\": %s}" e.EventType (render e.Data) }
         log.ForContext(name, sprintf "[%s]" (String.concat ",\n\r" items))
     let internal propEvents = propData "events"
     let internal propDataUnfolds = Enum.Unfolds >> propData "unfolds"
-    let internal propStartPos (value : Position) log = prop "startPos" value.index log
-    let internal propStartEtag (value : Position) log = prop "startEtag" value.etag log
+    let internal propStartPos (value: Position) log = prop "startPos" value.index log
+    let internal propStartEtag (value: Position) log = prop "startEtag" value.etag log
 
-    let withLoggedRetries<'t> (retryPolicy : IRetryPolicy option) (contextLabel : string) (f : ILogger -> CancellationToken -> Task<'t>) log ct : Task<'t> =
+    let withLoggedRetries<'t> (retryPolicy: IRetryPolicy option) (contextLabel: string) (f: ILogger -> CancellationToken -> Task<'t>) log ct: Task<'t> =
         match retryPolicy with
         | None -> f log ct
         | Some retryPolicy ->
@@ -237,7 +237,7 @@ module Log =
                 f log
             retryPolicy.Execute withLoggingContextWrapping
 
-    let internal (|BlobLen|) (x : EventBody) = if x.ValueKind = JsonValueKind.Null then 0 else x.GetRawText().Length
+    let internal (|BlobLen|) (x: EventBody) = if x.ValueKind = JsonValueKind.Null then 0 else x.GetRawText().Length
     let internal eventLen (x: #IEventData<_>) = let BlobLen bytes, BlobLen metaBytes = x.Data, x.Meta in bytes + metaBytes + 80
     let internal batchLen = Seq.sumBy eventLen
     [<RequireQualifiedAccess>]
@@ -266,13 +266,13 @@ module Log =
         module Stats =
 
             type internal Counter =
-                 { mutable rux100 : int64; mutable count : int64; mutable ms : int64 }
+                 { mutable rux100: int64; mutable count: int64; mutable ms: int64 }
                  static member Create() = { rux100 = 0L; count = 0L; ms = 0L }
                  member x.Ingest(ru, ms) =
                      Interlocked.Increment(&x.count) |> ignore
                      Interlocked.Add(&x.rux100, int64 (ru*100.)) |> ignore
                      Interlocked.Add(&x.ms, ms) |> ignore
-            let inline private (|RcMs|) ({ interval = i; ru = ru } : Measurement) =
+            let inline private (|RcMs|) ({ interval = i; ru = ru }: Measurement) =
                 ru, int64 i.ElapsedMilliseconds
             type LogSink() =
                 static let epoch = System.Diagnostics.Stopwatch.StartNew()
@@ -313,7 +313,7 @@ module Log =
 
         /// Relies on feeding of metrics from Log through to Stats.LogSink
         /// Use Stats.LogSink.Restart() to reset the start point (and stats) where relevant
-        let dump (log : ILogger) =
+        let dump (log: ILogger) =
             let stats =
               [ "Read", Stats.LogSink.Read
                 "Write", Stats.LogSink.Write
@@ -339,7 +339,7 @@ module Log =
             // Yes, there's a minor race here between the use of the values and the reset
             let duration = Stats.LogSink.Restart()
             if rows > 1 then logActivity "TOTAL" totalCount (totalRRu + totalWRu) totalMs
-            let measures : (string * (TimeSpan -> float)) list = [ "s", fun x -> x.TotalSeconds(*; "m", fun x -> x.TotalMinutes; "h", fun x -> x.TotalHours*) ]
+            let measures: (string * (TimeSpan -> float)) list = [ "s", fun x -> x.TotalSeconds(*; "m", fun x -> x.TotalMinutes; "h", fun x -> x.TotalHours*) ]
             let logPeriodicRate name count rru wru = log.Information("{rru:n1}R/{wru:n1}W CU @ {count:n0} rp{unit}", rru, wru, count, name)
             for uom, f in measures do let d = f duration in if d <> 0. then logPeriodicRate uom (float totalCount/d |> int64) (totalRRu/d) (totalWRu/d)
 
@@ -348,10 +348,10 @@ module private MicrosoftAzureCosmosWrappers =
 
     type ReadResult<'T> = Found of 'T | NotFound | NotModified
     type Container with
-        member private container.DeserializeResponseBody<'T>(rm : ResponseMessage) : 'T =
+        member private container.DeserializeResponseBody<'T>(rm: ResponseMessage): 'T =
             rm.EnsureSuccessStatusCode().Content
             |> container.Database.Client.ClientOptions.Serializer.FromStream<'T>
-        member container.TryReadItem(partitionKey : PartitionKey, id : string, ct, ?options : ItemRequestOptions): Task<float * ReadResult<'T>> = task {
+        member container.TryReadItem(partitionKey: PartitionKey, id: string, ct, ?options: ItemRequestOptions): Task<float * ReadResult<'T>> = task {
             use! rm = container.ReadItemStreamAsync(id, partitionKey, requestOptions = Option.toObj options, cancellationToken = ct)
             return rm.Headers.RequestCharge, rm.StatusCode |> function
                 | System.Net.HttpStatusCode.NotFound -> NotFound
@@ -360,7 +360,7 @@ module private MicrosoftAzureCosmosWrappers =
 
 // NB don't nest in a private module, or serialization will fail miserably ;)
 [<CLIMutable; NoEquality; NoComparison>]
-type SyncResponse = { etag : string; n : int64; conflicts : Unfold[]; e : Event[] }
+type SyncResponse = { etag: string; n: int64; conflicts: Unfold[]; e: Event[] }
 
 module internal SyncStoredProc =
     let [<Literal>] name = "EquinoxEventsInTip4"  // NB need to rename/number for any breaking change
@@ -452,10 +452,10 @@ module internal Sync =
     [<RequireQualifiedAccess; NoEquality; NoComparison>]
     type Result =
         | Written of Position
-        | Conflict of Position * events : ITimelineEvent<EventBody>[]
+        | Conflict of Position * events: ITimelineEvent<EventBody>[]
         | ConflictUnknown of Position
 
-    let private run (container : Container, stream : string) (maxEventsInTip, maxStringifyLen) (exp, req : Tip, ct)
+    let private run (container: Container, stream: string) (maxEventsInTip, maxStringifyLen) (exp, req: Tip, ct)
         : Task<float*Result> = task {
         let ep =
             match exp with
@@ -463,7 +463,7 @@ module internal Sync =
             | SyncExp.Etag et -> Position.fromEtag et
             | SyncExp.Any -> Position.fromAppendAtEnd
         let args = [| box req; box ep.index; box (Option.toObj ep.etag); box maxEventsInTip; box maxStringifyLen |]
-        let! (res : Scripts.StoredProcedureExecuteResponse<SyncResponse>) =
+        let! (res: Scripts.StoredProcedureExecuteResponse<SyncResponse>) =
             container.Scripts.ExecuteStoredProcedureAsync<SyncResponse>(SyncStoredProc.name, PartitionKey stream, args, cancellationToken = ct)
         let newPos = { index = res.Resource.n; etag = Option.ofObj res.Resource.etag }
         match res.Resource.conflicts with
@@ -475,12 +475,12 @@ module internal Sync =
             let events = (Enum.Events(ep.index, res.Resource.e), Enum.Unfolds unfolds) ||> Seq.append |> Array.ofSeq
             return res.RequestCharge, Result.Conflict (newPos, events) }
 
-    let private logged (container, stream) (maxEventsInTip, maxStringifyLen) (exp : SyncExp, req : Tip) (log : ILogger) ct : Task<Result> = task {
+    let private logged (container, stream) (maxEventsInTip, maxStringifyLen) (exp: SyncExp, req: Tip) (log: ILogger) ct: Task<Result> = task {
         let! t, (ru, result) = (fun ct -> run (container, stream) (maxEventsInTip, maxStringifyLen) (exp, req, ct)) |> Stopwatch.time ct
         let verbose = log.IsEnabled Serilog.Events.LogEventLevel.Debug
         let count, bytes = req.e.Length, if verbose then Enum.Events req |> Log.batchLen else 0
         let log =
-            let inline mkMetric ru : Log.Measurement =
+            let inline mkMetric ru: Log.Measurement =
                 { database = container.Database.Id; container = container.Id; stream = stream; interval = t; bytes = bytes; count = count; ru = ru }
             let inline propConflict log = log |> Log.prop "conflict" true |> Log.prop "eventTypes" (Seq.truncate 5 (seq { for x in req.e -> x.c }))
             if verbose then log |> Log.propEvents (Enum.Events req) |> Log.propDataUnfolds req.u else log
@@ -500,30 +500,30 @@ module internal Sync =
             "Sync", stream, count, req.u.Length, t.ElapsedMilliseconds, ru, bytes, exp)
         return result }
 
-    let batch (log : ILogger) (retryPolicy, maxEventsInTip, maxStringifyLen) containerStream expBatch ct : Task<Result> =
+    let batch (log: ILogger) (retryPolicy, maxEventsInTip, maxStringifyLen) containerStream expBatch ct: Task<Result> =
         let call = logged containerStream (maxEventsInTip, maxStringifyLen) expBatch
         Log.withLoggedRetries retryPolicy "writeAttempt" call log ct
 
-    let private mkEvent (e : IEventData<_>) =
+    let private mkEvent (e: IEventData<_>) =
         {   t = e.Timestamp
             c = e.EventType; d = JsonElement.undefinedToNull e.Data; m = JsonElement.undefinedToNull e.Meta
             correlationId = e.CorrelationId; causationId = e.CausationId }
-    let mkBatch (stream : string) (events : IEventData<_>[]) unfolds : Tip =
+    let mkBatch (stream: string) (events: IEventData<_>[]) unfolds: Tip =
         {   p = stream; id = Tip.WellKnownDocumentId; n = -1L(*Server-managed*); i = -1L(*Server-managed*); _etag = null
             e = Array.map mkEvent events; u = Array.ofSeq unfolds }
-    let mkUnfold compressor baseIndex (x : IEventData<_>) : Unfold =
+    let mkUnfold compressor baseIndex (x: IEventData<_>): Unfold =
         {   i = baseIndex; t = x.Timestamp
             c = x.EventType; d = compressor x.Data; m = compressor x.Meta }
 
 module Initialization =
 
     // Note: the Cosmos SDK does not (currently) support changing the Throughput mode of an existing Database or Container.
-    type [<RequireQualifiedAccess>] Throughput = Manual of rus : int | Autoscale of maxRus : int
+    type [<RequireQualifiedAccess>] Throughput = Manual of rus: int | Autoscale of maxRus: int
     type [<RequireQualifiedAccess>] Provisioning = Container of Throughput | Database of Throughput | Serverless
     let private (|ThroughputProperties|) = function
         | Throughput.Manual rus -> ThroughputProperties.CreateManualThroughput(rus)
         | Throughput.Autoscale maxRus -> ThroughputProperties.CreateAutoscaleThroughput(maxRus)
-    let private createOrProvisionDatabase (client : CosmosClient) dName mode = async {
+    let private createOrProvisionDatabase (client: CosmosClient) dName mode = async {
         let! ct = Async.CancellationToken
         let createDatabaseIfNotExists maybeTp = async {
             let! r = client.CreateDatabaseIfNotExistsAsync(dName, throughputProperties = Option.toObj maybeTp, cancellationToken = ct) |> Async.AwaitTaskCorrect
@@ -534,7 +534,7 @@ module Initialization =
             let! d = createDatabaseIfNotExists (Some tp)
             let! _ = d.ReplaceThroughputAsync(tp, cancellationToken = ct) |> Async.AwaitTaskCorrect
             return d }
-    let private createOrProvisionContainer (d : Database) (cName, pkPath, customizeContainer) mode = async {
+    let private createOrProvisionContainer (d: Database) (cName, pkPath, customizeContainer) mode = async {
         let cp = ContainerProperties(id = cName, partitionKeyPath = pkPath)
         customizeContainer cp
         let! ct = Async.CancellationToken
@@ -548,11 +548,11 @@ module Initialization =
             let! _ = c.ReplaceThroughputAsync(throughput, cancellationToken = ct) |> Async.AwaitTaskCorrect
             return c }
 
-    let private createStoredProcIfNotExists (c : Container) (name, body) ct : Task<float> = task {
+    let private createStoredProcIfNotExists (c: Container) (name, body) ct: Task<float> = task {
         try let! r = c.Scripts.CreateStoredProcedureAsync(Scripts.StoredProcedureProperties(id = name, body = body), cancellationToken = ct)
             return r.RequestCharge
         with :? CosmosException as ce when ce.StatusCode = System.Net.HttpStatusCode.Conflict -> return ce.RequestCharge }
-    let private applyBatchAndTipContainerProperties (cp : ContainerProperties) =
+    let private applyBatchAndTipContainerProperties (cp: ContainerProperties) =
         cp.IndexingPolicy.IndexingMode <- IndexingMode.Consistent
         cp.IndexingPolicy.Automatic <- true
         // Can either do a blacklist or a whitelist
@@ -560,28 +560,28 @@ module Initialization =
         cp.IndexingPolicy.ExcludedPaths.Add(ExcludedPath(Path="/*"))
         // NB its critical to index the nominated PartitionKey field defined above or there will be runtime errors
         for k in Batch.IndexedFields do cp.IndexingPolicy.IncludedPaths.Add(IncludedPath(Path = sprintf "/%s/?" k))
-    let createSyncStoredProcIfNotExists (log : ILogger option) container ct = task {
+    let createSyncStoredProcIfNotExists (log: ILogger option) container ct = task {
         let! t, ru = createStoredProcIfNotExists container (SyncStoredProc.name, SyncStoredProc.body) |> Stopwatch.time ct
         match log with
         | None -> ()
         | Some log -> log.Information("Created stored procedure {procName} in {ms:f1}ms {ru}RU", SyncStoredProc.name, t.ElapsedMilliseconds, ru) }
-    let init log (client : CosmosClient) (dName, cName) mode skipStoredProc ct = task {
+    let init log (client: CosmosClient) (dName, cName) mode skipStoredProc ct = task {
         let! d = createOrProvisionDatabase client dName mode
         let! c = createOrProvisionContainer d (cName, sprintf "/%s" Batch.PartitionKeyField, applyBatchAndTipContainerProperties) mode // as per Cosmos team, Partition Key must be "/id"
         if not skipStoredProc then
             do! createSyncStoredProcIfNotExists (Some log) c ct }
 
-    let private applyAuxContainerProperties (cp : ContainerProperties) =
+    let private applyAuxContainerProperties (cp: ContainerProperties) =
         // TL;DR no indexing of any kind; see https://github.com/Azure/azure-documentdb-changefeedprocessor-dotnet/issues/142
         cp.IndexingPolicy.Automatic <- false
         cp.IndexingPolicy.IndexingMode <- IndexingMode.None
 
-    let initAux (client : CosmosClient) (dName, cName) mode = async {
+    let initAux (client: CosmosClient) (dName, cName) mode = async {
         let! d = createOrProvisionDatabase client dName mode
         return! createOrProvisionContainer d (cName, "/id", applyAuxContainerProperties) mode } // as per Cosmos team, Partition Key must be "/id"
 
     /// Holds Container state, coordinating initialization activities
-    type internal ContainerInitializerGuard(container : Container, fallback : Container option, ?initContainer : Container -> CancellationToken -> Task<unit>) =
+    type internal ContainerInitializerGuard(container: Container, fallback: Container option, ?initContainer: Container -> CancellationToken -> Task<unit>) =
         let initGuard = initContainer |> Option.map (fun init -> AsyncCacheCell<unit>(init container))
 
         member _.Container = container
@@ -590,14 +590,14 @@ module Initialization =
 
 module internal Tip =
 
-    let private get (container : Container, stream : string) (maybePos : Position option) ct =
+    let private get (container: Container, stream: string) (maybePos: Position option) ct =
         let ro = match maybePos with Some { etag = Some etag } -> ItemRequestOptions(IfNoneMatchEtag = etag) |> Some | _ -> None
         container.TryReadItem<Tip>(PartitionKey stream, Tip.WellKnownDocumentId, ct, ?options = ro)
-    let private loggedGet (get : Container * string -> Position option -> CancellationToken -> Task<_>) (container, stream) (maybePos : Position option) (log : ILogger) ct = task {
+    let private loggedGet (get: Container * string -> Position option -> CancellationToken -> Task<_>) (container, stream) (maybePos: Position option) (log: ILogger) ct = task {
         let log = log |> Log.prop "stream" stream
-        let! t, (ru, res : ReadResult<Tip>) = get (container, stream) maybePos |> Stopwatch.time ct
+        let! t, (ru, res: ReadResult<Tip>) = get (container, stream) maybePos |> Stopwatch.time ct
         let verbose = log.IsEnabled Events.LogEventLevel.Debug
-        let log bytes count (f : Log.Measurement -> _) = log |> Log.event (f { database = container.Database.Id; container = container.Id; stream = stream; interval = t; bytes = bytes; count = count; ru = ru })
+        let log bytes count (f: Log.Measurement -> _) = log |> Log.event (f { database = container.Database.Id; container = container.Id; stream = stream; interval = t; bytes = bytes; count = count; ru = ru })
         match res with
         | ReadResult.NotModified ->
             (log 0 0 Log.Metric.TipNotModified).Information("EqxCosmos {action:l} {stream} {res} {ms:f1}ms {ru}RU", "Tip", stream, 304, t.ElapsedMilliseconds, ru)
@@ -612,9 +612,9 @@ module internal Tip =
             let log = log |> Log.prop "_etag" tip._etag |> Log.prop "n" tip.n
             log.Information("EqxCosmos {action:l} {stream} {res} {ms:f1}ms {ru}RU", "Tip", stream, 200, t.ElapsedMilliseconds, ru)
         return ru, res }
-    type [<RequireQualifiedAccess; NoComparison; NoEquality>] Result = NotModified | NotFound | Found of Position * i : int64 * ITimelineEvent<EventBody>[]
+    type [<RequireQualifiedAccess; NoComparison; NoEquality>] Result = NotModified | NotFound | Found of Position * i: int64 * ITimelineEvent<EventBody>[]
     /// `pos` being Some implies that the caller holds a cached value and hence is ready to deal with Result.NotModified
-    let tryLoad (log : ILogger) retryPolicy containerStream (maybePos : Position option, maxIndex) ct : Task<Result> = task {
+    let tryLoad (log: ILogger) retryPolicy containerStream (maybePos: Position option, maxIndex) ct: Task<Result> = task {
         let! _rc, res = Log.withLoggedRetries retryPolicy "readAttempt" (loggedGet get containerStream maybePos) log ct
         match res with
         | ReadResult.NotModified -> return Result.NotModified
@@ -625,19 +625,19 @@ module internal Tip =
 
 module internal Query =
 
-    let feedIteratorMapTi (map : int -> StopwatchInterval -> FeedResponse<'t> -> 'u) (query : FeedIterator<'t>) ct : IAsyncEnumerable<'u> = taskSeq {
+    let feedIteratorMapTi (map: int -> StopwatchInterval -> FeedResponse<'t> -> 'u) (query: FeedIterator<'t>) ct: IAsyncEnumerable<'u> = taskSeq {
         // earlier versions, such as 3.9.0, do not implement IDisposable; see linked issue for detail on when SDK team added it
         use _ = query // see https://github.com/jet/equinox/issues/225 - in the Cosmos V4 SDK, all this is managed IAsyncEnumerable
         let mutable i = 0
         while query.HasMoreResults do
-            let! t, (res : FeedResponse<'t>) = (fun ct -> query.ReadNextAsync(ct)) |> Stopwatch.time ct
+            let! t, (res: FeedResponse<'t>) = (fun ct -> query.ReadNextAsync(ct)) |> Stopwatch.time ct
             yield map i t res }
-    let private mkQuery (log : ILogger) (container : Container, stream : string) includeTip (maxItems : int) (direction : Direction, minIndex, maxIndex) : FeedIterator<Batch> =
+    let private mkQuery (log: ILogger) (container: Container, stream: string) includeTip (maxItems: int) (direction: Direction, minIndex, maxIndex): FeedIterator<Batch> =
         let order = if direction = Direction.Forward then "ASC" else "DESC"
         let query =
             let args = [
-                 match minIndex with None -> () | Some x -> yield "c.n > @minPos", fun (q : QueryDefinition) -> q.WithParameter("@minPos", x)
-                 match maxIndex with None -> () | Some x -> yield "c.i < @maxPos", fun (q : QueryDefinition) -> q.WithParameter("@maxPos", x) ]
+                 match minIndex with None -> () | Some x -> yield "c.n > @minPos", fun (q: QueryDefinition) -> q.WithParameter("@minPos", x)
+                 match maxIndex with None -> () | Some x -> yield "c.i < @maxPos", fun (q: QueryDefinition) -> q.WithParameter("@maxPos", x) ]
             let whereClause =
                 let notTip = sprintf "c.id!=\"%s\"" Tip.WellKnownDocumentId
                 let conditions = Seq.map fst args
@@ -651,21 +651,21 @@ module internal Query =
 
     // Unrolls the Batches in a response
     // NOTE when reading backwards, the events are emitted in reverse Index order to suit the takeWhile consumption
-    let private mapPage direction (container : Container, streamName : string) (minIndex, maxIndex) (maxRequests : int option)
-            (log : ILogger) i t (res : FeedResponse<Batch>)
+    let private mapPage direction (container: Container, streamName: string) (minIndex, maxIndex) (maxRequests: int option)
+            (log: ILogger) i t (res: FeedResponse<Batch>)
         : ITimelineEvent<EventBody>[] * Position option * float =
         let log = log |> Log.prop "batchIndex" i
         match maxRequests with
         | Some mr when i >= mr -> log.Information "batch Limit exceeded"; invalidOp "batch Limit exceeded"
         | _ -> ()
         let batches, ru = Array.ofSeq res, res.RequestCharge
-        let unwrapBatch (b : Batch) =
+        let unwrapBatch (b: Batch) =
             Enum.Events(b, ?minIndex = minIndex, ?maxIndex = maxIndex)
             |> if direction = Direction.Backward then Seq.rev else id
         let events = batches |> Seq.collect unwrapBatch |> Array.ofSeq
         let verbose = log.IsEnabled Events.LogEventLevel.Debug
         let count, bytes = events.Length, if verbose then events |> Log.batchLen else 0
-        let reqMetric : Log.Measurement = { database = container.Database.Id; container = container.Id; stream = streamName; interval = t; bytes = bytes; count = count; ru = ru }
+        let reqMetric: Log.Measurement = { database = container.Database.Id; container = container.Id; stream = streamName; interval = t; bytes = bytes; count = count; ru = ru }
         let log = let evt = Log.Metric.QueryResponse (direction, reqMetric) in log |> Log.event evt
         let log = if verbose then log |> Log.propEvents events else log
         let index = if count = 0 then Nullable () else Nullable <| Seq.min (seq { for x in batches -> x.i })
@@ -677,17 +677,17 @@ module internal Query =
         let maybePosition = batches |> Array.tryPick Position.tryFromBatch
         events, maybePosition, ru
 
-    let private logQuery direction (container : Container, streamName) interval (responsesCount, events : ITimelineEvent<EventBody>[]) n (ru : float) (log : ILogger) =
+    let private logQuery direction (container: Container, streamName) interval (responsesCount, events: ITimelineEvent<EventBody>[]) n (ru: float) (log: ILogger) =
         let verbose = log.IsEnabled Events.LogEventLevel.Debug
         let count, bytes = events.Length, if verbose then events |> Log.batchLen else 0
-        let reqMetric : Log.Measurement = { database = container.Database.Id; container = container.Id; stream = streamName; interval = interval; bytes = bytes; count = count; ru = ru }
+        let reqMetric: Log.Measurement = { database = container.Database.Id; container = container.Id; stream = streamName; interval = interval; bytes = bytes; count = count; ru = ru }
         let evt = Log.Metric.Query (direction, responsesCount, reqMetric)
         let action = match direction with Direction.Forward -> "QueryF" | Direction.Backward -> "QueryB"
         (log |> Log.prop "bytes" bytes |> Log.event evt).Information(
             "EqxCosmos {action:l} {stream} v{n} {count}/{responses} {ms:f1}ms {ru}RU",
             action, streamName, n, count, responsesCount, interval.ElapsedMilliseconds, ru)
 
-    let private calculateUsedVersusDroppedPayload stopIndex (xs : ITimelineEvent<EventBody>[]) : int * int =
+    let private calculateUsedVersusDroppedPayload stopIndex (xs: ITimelineEvent<EventBody>[]): int * int =
         let mutable used, dropped = 0, 0
         let mutable found = false
         for x in xs do
@@ -698,9 +698,9 @@ module internal Query =
         used, dropped
 
     [<RequireQualifiedAccess; NoComparison; NoEquality>]
-    type ScanResult<'event> = { found : bool; minIndex : int64; next : int64; maybeTipPos : Position option; events : 'event[] }
+    type ScanResult<'event> = { found: bool; minIndex: int64; next: int64; maybeTipPos: Position option; events: 'event[] }
 
-    let scanTip (tryDecode : #IEventData<EventBody> -> 'event voption, isOrigin : 'event -> bool) (pos : Position, i : int64, xs : #ITimelineEvent<EventBody>[]) : ScanResult<'event> =
+    let scanTip (tryDecode: #IEventData<EventBody> -> 'event voption, isOrigin: 'event -> bool) (pos: Position, i: int64, xs: #ITimelineEvent<EventBody>[]): ScanResult<'event> =
         let items = ResizeArray()
         let isOrigin' e =
             match tryDecode e with
@@ -712,13 +712,13 @@ module internal Query =
         { found = f; maybeTipPos = Some pos; minIndex = i; next = pos.index + 1L; events = e }
 
     // Yields events in ascending Index order
-    let scan<'event> (log : ILogger) (container, stream) includeTip (maxItems : int) maxRequests direction
-        (tryDecode : ITimelineEvent<EventBody> -> 'event voption, isOrigin : 'event -> bool)
+    let scan<'event> (log: ILogger) (container, stream) includeTip (maxItems: int) maxRequests direction
+        (tryDecode: ITimelineEvent<EventBody> -> 'event voption, isOrigin: 'event -> bool)
         (minIndex, maxIndex, ct)
         : Task<ScanResult<'event> option> = task {
         let mutable found = false
         let mutable responseCount = 0
-        let mergeBatches (log : ILogger) (batchesBackward : IAsyncEnumerable<ITimelineEvent<EventBody>[] * Position option * float>) = task {
+        let mergeBatches (log: ILogger) (batchesBackward: IAsyncEnumerable<ITimelineEvent<EventBody>[] * Position option * float>) = task {
             let mutable lastResponse, maybeTipPos, ru = None, None, 0.
             let! events =
                 batchesBackward
@@ -742,7 +742,7 @@ module internal Query =
             return events, maybeTipPos, ru }
         let log = log |> Log.prop "batchSize" maxItems |> Log.prop "stream" stream
         let readLog = log |> Log.prop "direction" direction
-        let batches ct : IAsyncEnumerable<ITimelineEvent<EventBody>[] * Position option * float> =
+        let batches ct: IAsyncEnumerable<ITimelineEvent<EventBody>[] * Position option * float> =
             let query = mkQuery readLog (container, stream) includeTip maxItems (direction, minIndex, maxIndex)
             feedIteratorMapTi (mapPage direction (container, stream) (minIndex, maxIndex) maxRequests readLog) query ct
         let! t, (events, maybeTipPos, ru) = (fun ct -> batches ct |> mergeBatches log) |> Stopwatch.time ct
@@ -756,13 +756,13 @@ module internal Query =
             | None, None -> 0L
         log |> logQuery direction (container, stream) t (responseCount, raws) version ru
         match minMax, maybeTipPos with
-        | Some (i, m), _ -> return Some ({ found = found; minIndex = i; next = m + 1L; maybeTipPos = maybeTipPos; events = decoded } : ScanResult<_>)
+        | Some (i, m), _ -> return Some ({ found = found; minIndex = i; next = m + 1L; maybeTipPos = maybeTipPos; events = decoded }: ScanResult<_>)
         | None, Some { index = tipI } -> return Some { found = found; minIndex = tipI; next = tipI; maybeTipPos = maybeTipPos; events = [||] }
         | None, _ -> return None }
 
-    let walkLazy<'event> (log : ILogger) (container, stream) maxItems maxRequests
-        (tryDecode : ITimelineEvent<EventBody> -> 'event option, isOrigin : 'event -> bool)
-        (direction, minIndex, maxIndex, ct : CancellationToken)
+    let walkLazy<'event> (log: ILogger) (container, stream) maxItems maxRequests
+        (tryDecode: ITimelineEvent<EventBody> -> 'event option, isOrigin: 'event -> bool)
+        (direction, minIndex, maxIndex, ct: CancellationToken)
         : IAsyncEnumerable<'event[]> = taskSeq {
         let query = mkQuery log (container, stream) true maxItems (direction, minIndex, maxIndex)
 
@@ -811,10 +811,10 @@ module internal Query =
     /// 1) Tip Data and/or Conflicting events
     /// 2) Querying Primary for predecessors of what's obtained from 1
     /// 3) Querying Archive for predecessors of what's obtained from 2
-    let load (log : ILogger) (minIndex, maxIndex) (tip : ScanResult<'event> option)
-            (primary : int64 option * int64 option * CancellationToken -> Task<ScanResult<'event> option>)
+    let load (log: ILogger) (minIndex, maxIndex) (tip: ScanResult<'event> option)
+            (primary: int64 option * int64 option * CancellationToken -> Task<ScanResult<'event> option>)
             // Choice1Of2 -> indicates whether it's acceptable to ignore missing events; Choice2Of2 -> Fallback store
-            (fallback : Choice<bool, int64 option * int64 option * CancellationToken -> Task<ScanResult<'event> option>>) ct
+            (fallback: Choice<bool, int64 option * int64 option * CancellationToken -> Task<ScanResult<'event> option>>) ct
             : Task<Position * 'event[]> = task {
         let minI = defaultArg minIndex 0L
         match tip with
@@ -864,15 +864,15 @@ module internal Query =
 // NOTE: module is public so BatchIndices can be deserialized into
 module Prune =
 
-    type BatchIndices = { id : string; i : int64; n : int64 }
+    type BatchIndices = { id: string; i: int64; n: int64 }
 
-    let until (log : ILogger) (container : Container, stream : string) (maxItems : int) indexInclusive ct : Task<int * int * int64> = task {
+    let until (log: ILogger) (container: Container, stream: string) (maxItems: int) indexInclusive ct: Task<int * int * int64> = task {
         let log = log |> Log.prop "stream" stream
-        let deleteItem id count : Task<float> = task {
+        let deleteItem id count: Task<float> = task {
             let ro = ItemRequestOptions(EnableContentResponseOnWrite = false) // https://devblogs.microsoft.com/cosmosdb/enable-content-response-on-write/
             let! t, res = (fun ct -> container.DeleteItemAsync(id, PartitionKey stream, ro, ct)) |> Stopwatch.time ct
             let rc, ms = res.RequestCharge, t.ElapsedMilliseconds
-            let reqMetric : Log.Measurement = { database = container.Database.Id; container = container.Id; stream = stream; interval = t; bytes = -1; count = count; ru = rc }
+            let reqMetric: Log.Measurement = { database = container.Database.Id; container = container.Id; stream = stream; interval = t; bytes = -1; count = count; ru = rc }
             let log = let evt = Log.Metric.Delete reqMetric in log |> Log.event evt
             log.Information("EqxCosmos {action:l} {id} {ms:f1}ms {ru}RU", "Delete", id, ms, rc)
             return rc }
@@ -887,26 +887,26 @@ module Prune =
             let ro = ItemRequestOptions(EnableContentResponseOnWrite = false, IfMatchEtag = tip._etag)
             let! t, updateRes = (fun ct -> container.ReplaceItemAsync(tip, tip.id, PartitionKey stream, ro, ct)) |> Stopwatch.time ct
             let rc, ms = tipRu + updateRes.RequestCharge, t.ElapsedMilliseconds
-            let reqMetric : Log.Measurement = { database = container.Database.Id; container = container.Id; stream = stream; interval = t; bytes = -1; count = count; ru = rc }
+            let reqMetric: Log.Measurement = { database = container.Database.Id; container = container.Id; stream = stream; interval = t; bytes = -1; count = count; ru = rc }
             let log = let evt = Log.Metric.Trim reqMetric in log |> Log.event evt
             log.Information("EqxCosmos {action:l} {count} {ms:f1}ms {ru}RU", "Trim", count, ms, rc)
             return rc }
         let log = log |> Log.prop "index" indexInclusive
-        let query : FeedIterator<BatchIndices> =
+        let query: FeedIterator<BatchIndices> =
              let qro = QueryRequestOptions(PartitionKey = PartitionKey stream, MaxItemCount = maxItems)
              // sort by i to guarantee we don't ever leave an observable gap in the sequence
              container.GetItemQueryIterator<_>("SELECT c.id, c.i, c.n FROM c ORDER by c.i", requestOptions = qro)
-        let mapPage i (t : StopwatchInterval) (page : FeedResponse<BatchIndices>) =
+        let mapPage i (t: StopwatchInterval) (page: FeedResponse<BatchIndices>) =
             let batches, rc, ms = Array.ofSeq page, page.RequestCharge, t.ElapsedMilliseconds
             let next = Array.tryLast batches |> Option.map (fun x -> x.n)
-            let reqMetric : Log.Measurement = { database = container.Database.Id; container = container.Id; stream = stream; interval = t; bytes = -1; count = batches.Length; ru = rc }
+            let reqMetric: Log.Measurement = { database = container.Database.Id; container = container.Id; stream = stream; interval = t; bytes = -1; count = batches.Length; ru = rc }
             let log = let evt = Log.Metric.PruneResponse reqMetric in log |> Log.prop "batchIndex" i |> Log.event evt
             log.Information("EqxCosmos {action:l} {batches} {ms:f1}ms n={next} {ru}RU", "PruneResponse", batches.Length, ms, Option.toNullable next, rc)
             batches, rc
         let! pt, outcomes =
-            let isTip (x : BatchIndices) = x.id = Tip.WellKnownDocumentId
+            let isTip (x: BatchIndices) = x.id = Tip.WellKnownDocumentId
             let isRelevant x = x.i <= indexInclusive || isTip x
-            let handle (batches : BatchIndices[], rc) = task {
+            let handle (batches: BatchIndices[], rc) = task {
                 let mutable delCharges, batchesDeleted, trimCharges, batchesTrimmed, eventsDeleted, eventsDeferred = 0., 0, 0., 0, 0, 0
                 let mutable lwm = None
                 for x in batches |> Seq.takeWhile (fun x -> isRelevant x || lwm = None) do
@@ -948,21 +948,21 @@ module Prune =
             eventsDeleted <- eventsDeleted + eDel
             eventsDeferred <- eventsDeferred + eDef
         outcomes |> Array.iter accumulate
-        let reqMetric : Log.Measurement = { database = container.Database.Id; container = container.Id; stream = stream; interval = pt; bytes = eventsDeleted; count = batches; ru = queryCharges }
+        let reqMetric: Log.Measurement = { database = container.Database.Id; container = container.Id; stream = stream; interval = pt; bytes = eventsDeleted; count = batches; ru = queryCharges }
         let log = let evt = Log.Metric.Prune (responses, reqMetric) in log |> Log.event evt
         let lwm = lwm |> Option.defaultValue 0L // If we've seen no batches at all, then the write position is 0L
         log.Information("EqxCosmos {action:l} {events}/{batches} lwm={lwm} {ms:f1}ms queryRu={queryRu} deleteRu={deleteRu} trimRu={trimRu}",
                         "Prune", eventsDeleted, batches, lwm, pt.ElapsedMilliseconds, queryCharges, delCharges, trimCharges)
         return eventsDeleted, eventsDeferred, lwm }
 
-type [<NoComparison>] Token = { pos : Position }
+type [<NoComparison>] Token = { pos: Position }
 module Token =
 
     // TOCONSIDER Could implement accumulating the streamBytes as it's loaded (but should stop counting when it hits the origin event)
     //            Should probably be optional as computing the UTF8/16 size from the JsonElement is not cheap
     //            Alternately, can mirror DynamoStore scheme where the size is maintained in the Tip, and updated as batches are calved
-    let create pos : StreamToken = { value = box { pos = pos }; version = pos.index; streamBytes = -1 }
-    let (|Unpack|) (token : StreamToken) : Position = let t = unbox<Token> token.value in t.pos
+    let create pos: StreamToken = { value = box { pos = pos }; version = pos.index; streamBytes = -1 }
+    let (|Unpack|) (token: StreamToken): Position = let t = unbox<Token> token.value in t.pos
     let supersedes struct (Unpack currentPos, Unpack xPos) =
         let currentVersion, newVersion = currentPos.index, xPos.index
         let currentETag, newETag = currentPos.etag, xPos.etag
@@ -980,9 +980,9 @@ module Internal =
 /// Defines the policies in force regarding how to split up calls when loading Event Batches via queries
 type QueryOptions
     (   // Max number of Batches to return per paged query response. Default: 10.
-        [<O; D null>] ?maxItems : int,
+        [<O; D null>] ?maxItems: int,
         // Dynamic version of `maxItems`, allowing one to react to dynamic configuration changes. Default: use `maxItems` value.
-        [<O; D null>] ?getMaxItems : unit -> int,
+        [<O; D null>] ?getMaxItems: unit -> int,
         // Maximum number of trips to permit when slicing the work into multiple responses based on `MaxItems`. Default: unlimited.
         [<O; D null>] ?maxRequests) =
     let getMaxItems = defaultArg getMaxItems (fun () -> defaultArg maxItems 10)
@@ -1004,7 +1004,7 @@ type TipOptions
         [<O; D null>] ?readRetryPolicy,
         [<O; D null>] ?writeRetryPolicy) =
     /// Maximum number of events permitted in Tip. When this is exceeded, events are moved out to a standalone Batch.
-    member val MaxEvents : int = maxEvents
+    member val MaxEvents: int = maxEvents
     /// Maximum serialized size (length of JSON.stringify representation) to permit to accumulate in Tip before they get moved out to a standalone Batch. Default: 30_000.
     member val MaxJsonLength = defaultArg maxJsonLength 30_000
     /// Whether to inhibit throwing when events are missing, but no Archive Container has been supplied
@@ -1013,13 +1013,13 @@ type TipOptions
     member val ReadRetryPolicy = readRetryPolicy
     member val WriteRetryPolicy = writeRetryPolicy
 
-type StoreClient(container : Container, archive : Container option, query : QueryOptions, tip : TipOptions) =
+type StoreClient(container: Container, archive: Container option, query: QueryOptions, tip: TipOptions) =
 
     let loadTip log stream pos = Tip.tryLoad log tip.ReadRetryPolicy (container, stream) (pos, None)
     let ignoreMissing = tip.IgnoreMissingEvents
 
     // Always yields events forward, regardless of direction
-    member internal _.Read(log, stream, direction, (tryDecode, isOrigin), ?ct, ?minIndex, ?maxIndex, ?tip) : Task<StreamToken * 'event[]> = task {
+    member internal _.Read(log, stream, direction, (tryDecode, isOrigin), ?ct, ?minIndex, ?maxIndex, ?tip): Task<StreamToken * 'event[]> = task {
         let tip = tip |> Option.map (Query.scanTip (tryDecode, isOrigin))
         let includeTip = Option.isNone tip
         let walk log container = Query.scan log (container, stream) includeTip query.MaxItems query.MaxRequests direction (tryDecode, isOrigin)
@@ -1031,17 +1031,17 @@ type StoreClient(container : Container, archive : Container option, query : Quer
         let log = log |> Log.prop "stream" stream
         let! pos, events = Query.load log (minIndex, maxIndex) tip (walk log container) walkFallback (defaultArg ct CancellationToken.None)
         return Token.create pos, events }
-    member _.ReadLazy(log, batching : QueryOptions, stream, direction, (tryDecode, isOrigin), ?ct, ?minIndex, ?maxIndex) : IAsyncEnumerable<'event[]> =
+    member _.ReadLazy(log, batching: QueryOptions, stream, direction, (tryDecode, isOrigin), ?ct, ?minIndex, ?maxIndex): IAsyncEnumerable<'event[]> =
         Query.walkLazy log (container, stream) batching.MaxItems batching.MaxRequests (tryDecode, isOrigin) (direction, minIndex, maxIndex, defaultArg ct CancellationToken.None)
 
-    member store.Load(log, (stream, maybePos), (tryDecode, isOrigin), checkUnfolds : bool, ct) : Task<StreamToken * 'event[]> =
+    member store.Load(log, (stream, maybePos), (tryDecode, isOrigin), checkUnfolds: bool, ct): Task<StreamToken * 'event[]> =
         if not checkUnfolds then store.Read(log, stream, Direction.Backward, (tryDecode, isOrigin), ct)
         else task {
             match! loadTip log stream maybePos ct with
             | Tip.Result.NotFound -> return Token.create Position.fromKnownEmpty, Array.empty
             | Tip.Result.NotModified -> return invalidOp "Not applicable"
             | Tip.Result.Found (pos, i, xs) -> return! store.Read(log, stream, Direction.Backward, (tryDecode, isOrigin), ct, tip = (pos, i, xs)) }
-    member _.GetPosition(log, stream, ct, ?pos) : Task<StreamToken> = task {
+    member _.GetPosition(log, stream, ct, ?pos): Task<StreamToken> = task {
         match! loadTip log stream pos ct with
         | Tip.Result.NotFound -> return Token.create Position.fromKnownEmpty
         | Tip.Result.NotModified -> return Token.create pos.Value
@@ -1058,7 +1058,7 @@ type StoreClient(container : Container, archive : Container option, query : Quer
             | Tip.Result.NotModified -> return LoadFromTokenResult.Unchanged
             | Tip.Result.Found (pos, i, xs) -> return! read (pos, i, xs) }
 
-    member internal _.Sync(log, stream, exp, batch : Tip, ct) : Task<InternalSyncResult> = task {
+    member internal _.Sync(log, stream, exp, batch: Tip, ct): Task<InternalSyncResult> = task {
         if Array.isEmpty batch.e && Array.isEmpty batch.u then invalidOp "Must write either events or unfolds."
         match! Sync.batch log (tip.WriteRetryPolicy, tip.MaxEvents, tip.MaxJsonLength) (container, stream) (exp, batch) ct with
         | Sync.Result.Written pos' -> return InternalSyncResult.Written (Token.create pos')
@@ -1070,14 +1070,14 @@ type StoreClient(container : Container, archive : Container option, query : Quer
 
 type internal Category<'event, 'state, 'context>
     (   store: StoreClient, codec: IEventCodec<'event, EventBody, 'context>) =
-    member _.Load(log, stream, initial, checkUnfolds, fold, isOrigin, ct) : Task<struct (StreamToken * 'state)> = task {
+    member _.Load(log, stream, initial, checkUnfolds, fold, isOrigin, ct): Task<struct (StreamToken * 'state)> = task {
         let! token, events = store.Load(log, (stream, None), (codec.TryDecode, isOrigin), checkUnfolds, ct)
         return struct (token, fold initial events) }
-    member _.Reload(log, streamName, (Token.Unpack pos as streamToken), state, fold, isOrigin, ct, ?preloaded) : Task<struct (StreamToken * 'state)> = task {
+    member _.Reload(log, streamName, (Token.Unpack pos as streamToken), state, fold, isOrigin, ct, ?preloaded): Task<struct (StreamToken * 'state)> = task {
         match! store.Reload(log, (streamName, pos), (codec.TryDecode, isOrigin), ct, ?preview = preloaded) with
         | LoadFromTokenResult.Unchanged -> return struct (streamToken, state)
         | LoadFromTokenResult.Found (token', events) -> return token', fold state events }
-    member cat.Sync(log, streamName, (Token.Unpack pos as streamToken), state, events, mapUnfolds, fold, isOrigin, context, compressUnfolds, ct) : Task<SyncResult<'state>> = task {
+    member cat.Sync(log, streamName, (Token.Unpack pos as streamToken), state, events, mapUnfolds, fold, isOrigin, context, compressUnfolds, ct): Task<SyncResult<'state>> = task {
         let state' = fold state (Seq.ofArray events)
         let encode e = codec.Encode(context, e)
         let exp, events, eventsEncoded, projectionsEncoded =
@@ -1406,14 +1406,14 @@ type AccessStrategy<'event, 'state> =
 
 type CosmosStoreCategory<'event, 'state, 'context> internal (resolveInner, empty) =
     inherit Equinox.Category<'event, 'state, 'context>(resolveInner, empty)
-    new(context : CosmosStoreContext, codec, fold, initial, caching, access,
+    new(context: CosmosStoreContext, codec, fold, initial, caching, access,
         // Compress Unfolds in Tip. Default: <c>true</c>.
         // NOTE when set to <c>false</c>, requires Equinox.CosmosStore or Equinox.Cosmos Version >= 2.3.0 to be able to read
         [<O; D null>] ?compressUnfolds) =
         let compressUnfolds = defaultArg compressUnfolds true
         let categories = System.Collections.Concurrent.ConcurrentDictionary<string, ICategory<'event, 'state, 'context>>()
         let resolveCategory (categoryName, container) =
-            let createCategory _name : ICategory<_, _, 'context> =
+            let createCategory _name: ICategory<_, _, 'context> =
                 let tryReadCache, updateCache =
                     match caching with
                     | CachingStrategy.NoCaching -> (fun _ -> Task.FromResult ValueNone), fun _ _ -> Task.FromResult ()
@@ -1447,15 +1447,15 @@ open FSharp.Control
 /// Outcome of appending events, specifying the new and/or conflicting events, together with the updated Target write position
 [<RequireQualifiedAccess; NoComparison>]
 type AppendResult<'t> =
-    | Ok of pos : 't
-    | Conflict of index : 't * conflictingEvents : ITimelineEvent<EventBody>[]
-    | ConflictUnknown of index : 't
+    | Ok of pos: 't
+    | Conflict of index: 't * conflictingEvents: ITimelineEvent<EventBody>[]
+    | ConflictUnknown of index: 't
 
 /// Encapsulates the core facilities Equinox.CosmosStore offers for operating directly on Events in Streams.
 type EventsContext internal
-    (   context : Equinox.CosmosStore.CosmosStoreContext, store : StoreClient,
+    (   context: Equinox.CosmosStore.CosmosStoreContext, store: StoreClient,
         // Logger to write to - see https://github.com/serilog/serilog/wiki/Provided-Sinks for how to wire to your logger
-        log : Serilog.ILogger) =
+        log: Serilog.ILogger) =
     do if log = null then nullArg "log"
     let maxCountPredicate count =
         let acc = ref (max (count-1) 0)
@@ -1474,16 +1474,16 @@ type EventsContext internal
         | Direction.Forward -> startPos, None
         | Direction.Backward -> None, startPos
 
-    new (context : Equinox.CosmosStore.CosmosStoreContext, log) =
+    new (context: Equinox.CosmosStore.CosmosStoreContext, log) =
         let struct (store, _streamId, _init) = context.ResolveContainerClientAndStreamIdAndInit(null, null)
         EventsContext(context, store, log)
 
     member _.ResolveStream(streamName) =
         let struct (_cc, streamName, init) = context.ResolveContainerClientAndStreamIdAndInit(null, streamName)
         struct (streamName, init)
-    member x.StreamId(streamName) : string = x.ResolveStream streamName |> ValueTuple.fst
+    member x.StreamId(streamName): string = x.ResolveStream streamName |> ValueTuple.fst
 
-    member internal _.GetLazy(stream, ?ct, ?queryMaxItems, ?direction, ?minIndex, ?maxIndex) : IAsyncEnumerable<ITimelineEvent<EventBody>[]> =
+    member internal _.GetLazy(stream, ?ct, ?queryMaxItems, ?direction, ?minIndex, ?maxIndex): IAsyncEnumerable<ITimelineEvent<EventBody>[]> =
         let direction = defaultArg direction Direction.Forward
         let batching = match queryMaxItems with Some qmi -> QueryOptions(qmi) | _ -> context.QueryOptions
         store.ReadLazy(log, batching, stream, direction, (Some, fun _ -> false), ?ct = ct, ?minIndex = minIndex, ?maxIndex = maxIndex)
@@ -1505,23 +1505,23 @@ type EventsContext internal
 
     /// Establishes the current position of the stream in as efficient a manner as possible
     /// (The ideal situation is that the preceding token is supplied as input in order to avail of 1RU low latency state checks)
-    member _.Sync(stream, [<O; D null>] ?position : Position) : Async<Position> = async {
+    member _.Sync(stream, [<O; D null>] ?position: Position): Async<Position> = async {
         let! ct = Async.CancellationToken
         let! Token.Unpack pos' = store.GetPosition(log, stream, ct, ?pos = position) |> Async.AwaitTaskCorrect
         return pos' }
 
     /// Query (with MaxItems set to `queryMaxItems`) from the specified `Position`, allowing the reader to efficiently walk away from a running query
     /// ... NB as long as they Dispose!
-    member x.Walk(stream, queryMaxItems, [<O; D null>] ?ct, [<O; D null>] ?minIndex, [<O; D null>] ?maxIndex, [<O; D null>] ?direction) : IAsyncEnumerable<ITimelineEvent<EventBody>[]> =
+    member x.Walk(stream, queryMaxItems, [<O; D null>] ?ct, [<O; D null>] ?minIndex, [<O; D null>] ?maxIndex, [<O; D null>] ?direction): IAsyncEnumerable<ITimelineEvent<EventBody>[]> =
         x.GetLazy(stream, ?ct = ct, queryMaxItems = queryMaxItems, ?direction = direction, ?minIndex = minIndex, ?maxIndex = maxIndex)
 
     /// Reads all Events from a `Position` in a given `direction`
-    member x.Read(stream, [<O; D null>] ?ct, [<O; D null>] ?position, [<O; D null>] ?maxCount, [<O; D null>] ?direction) : Task<Position*ITimelineEvent<EventBody>[]> =
+    member x.Read(stream, [<O; D null>] ?ct, [<O; D null>] ?position, [<O; D null>] ?maxCount, [<O; D null>] ?direction): Task<Position*ITimelineEvent<EventBody>[]> =
         x.GetInternal((stream, position), ?ct = ct, ?maxCount = maxCount, ?direction = direction) |> yieldPositionAndData
 
     /// Appends the supplied batch of events, subject to a consistency check based on the `position`
     /// Callers should implement appropriate idempotent handling, or use Equinox.Decider for that purpose
-    member x.Sync(stream, position, events : IEventData<_>[], ct) : Task<AppendResult<Position>> = task {
+    member x.Sync(stream, position, events: IEventData<_>[], ct): Task<AppendResult<Position>> = task {
         // Writes go through the stored proc, which we need to provision per container
         // Having to do this here in this way is far from ideal, but work on caching, external snapshots and caching is likely
         //   to move this about before we reach a final destination in any case
@@ -1536,34 +1536,34 @@ type EventsContext internal
 
     /// Low level, non-idempotent call appending events to a stream without a concurrency control mechanism in play
     /// NB Should be used sparingly; Equinox.Decider enables building equivalent equivalent idempotent handling with minimal code.
-    member x.NonIdempotentAppend(stream, events : IEventData<_>[]) : Async<Position> = async {
+    member x.NonIdempotentAppend(stream, events: IEventData<_>[]): Async<Position> = async {
         let! ct = Async.CancellationToken
         match! x.Sync(stream, Position.fromAppendAtEnd, events, ct) |> Async.AwaitTaskCorrect with
         | AppendResult.Ok token -> return token
         | x -> return x |> sprintf "Conflict despite it being disabled %A" |> invalidOp }
 
-    member _.Prune(stream, index, ct) : Task<int * int * int64> =
+    member _.Prune(stream, index, ct): Task<int * int * int64> =
         store.Prune(log, stream, index, ct)
 
 /// Provides mechanisms for building `EventData` records to be supplied to the `Events` API
 type EventData() =
     /// Creates an Event record, suitable for supplying to Append et al
-    static member FromUtf8Bytes(eventType, data, ?meta) : IEventData<_> = FsCodec.Core.EventData.Create(eventType, data, ?meta = meta) :> _
+    static member FromUtf8Bytes(eventType, data, ?meta): IEventData<_> = FsCodec.Core.EventData.Create(eventType, data, ?meta = meta) :> _
 
 /// Api as defined in the Equinox Specification
 /// Note the CosmosContext APIs can yield better performance due to the fact that a Position tracks the etag of the Stream's Tip
 module Events =
 
-    let private (|PositionIndex|) (x : Position) = x.index
-    let private stripSyncResult (f : Task<AppendResult<Position>>) : Async<AppendResult<int64>> = async {
+    let private (|PositionIndex|) (x: Position) = x.index
+    let private stripSyncResult (f: Task<AppendResult<Position>>): Async<AppendResult<int64>> = async {
         match! f |> Async.AwaitTaskCorrect with
         | AppendResult.Ok (PositionIndex index)-> return AppendResult.Ok index
         | AppendResult.Conflict (PositionIndex index, events) -> return AppendResult.Conflict (index, events)
         | AppendResult.ConflictUnknown (PositionIndex index) -> return AppendResult.ConflictUnknown index }
-    let private stripPosition (f : Async<Position>) : Async<int64> = async {
+    let private stripPosition (f: Async<Position>): Async<int64> = async {
         let! (PositionIndex index) = f
         return index }
-    let private dropPosition (f : Task<Position * ITimelineEvent<EventBody>[]>) : Async<ITimelineEvent<EventBody>[]> = async {
+    let private dropPosition (f: Task<Position * ITimelineEvent<EventBody>[]>): Async<ITimelineEvent<EventBody>[]> = async {
         let! _, xs = f |> Async.AwaitTaskCorrect
         return xs }
     let (|MinPosition|) = function
@@ -1577,7 +1577,7 @@ module Events =
     /// reading in batches of the specified size.
     /// Returns an empty sequence if the stream is empty or if the sequence number is larger than the largest
     /// sequence number in the stream.
-    let getAll (ctx : EventsContext) (streamName : string) (index : int64) (batchSize : int) : Async<IAsyncEnumerable<ITimelineEvent<EventBody>[]>> = async {
+    let getAll (ctx: EventsContext) (streamName: string) (index: int64) (batchSize: int): Async<IAsyncEnumerable<ITimelineEvent<EventBody>[]>> = async {
         let! ct = Async.CancellationToken
         return ctx.Walk(ctx.StreamId streamName, batchSize, ct, minIndex = index) }
 
@@ -1585,14 +1585,14 @@ module Events =
     /// number of events to read is specified by batchSize
     /// Returns an empty sequence if the stream is empty or if the sequence number is larger than the largest
     /// sequence number in the stream.
-    let get (ctx : EventsContext) (streamName : string) (MinPosition index : int64) (maxCount : int) : Async<ITimelineEvent<EventBody>[]> = async {
+    let get (ctx: EventsContext) (streamName: string) (MinPosition index: int64) (maxCount: int): Async<ITimelineEvent<EventBody>[]> = async {
         let! ct = Async.CancellationToken
         return! ctx.Read(ctx.StreamId streamName, ct, ?position = index, maxCount = maxCount) |> dropPosition }
 
     /// Appends a batch of events to a stream at the specified expected sequence number.
     /// If the specified expected sequence number does not match the stream, the events are not appended
     /// and a failure is returned.
-    let append (ctx : EventsContext) (streamName : string) (index : int64) (events : IEventData<_>[]) : Async<AppendResult<int64>> = async {
+    let append (ctx: EventsContext) (streamName: string) (index: int64) (events: IEventData<_>[]): Async<AppendResult<int64>> = async {
         let! ct = Async.CancellationToken
         return! ctx.Sync(ctx.StreamId streamName, Position.fromI index, events, ct) |> stripSyncResult }
 
@@ -1600,14 +1600,14 @@ module Events =
     /// NB typically, it is recommended to ensure idempotency of operations by using the `append` and related API as
     /// this facilitates ensuring consistency is maintained, and yields reduced latency and Request Charges impacts
     /// (See equivalent APIs on `Context` that yield `Position` values)
-    let appendAtEnd (ctx : EventsContext) (streamName : string) (events : IEventData<_>[]) : Async<int64> =
+    let appendAtEnd (ctx: EventsContext) (streamName: string) (events: IEventData<_>[]): Async<int64> =
         ctx.NonIdempotentAppend(ctx.StreamId streamName, events) |> stripPosition
 
     /// Requests deletion of events up and including the specified <c>index</c>.
     /// Due to the need to preserve ordering of data in the stream, only complete Batches will be removed.
     /// If the <c>index</c> is within the Tip, events are removed via an etag-checked update. Does not alter the unfolds held in the Tip, or remove the Tip itself.
     /// Returns count of events deleted this time, events that could not be deleted due to partial batches, and the stream's lowest remaining sequence number.
-    let pruneUntil (ctx : EventsContext) (streamName : string) (index : int64) : Async<int * int * int64> = async {
+    let pruneUntil (ctx: EventsContext) (streamName: string) (index: int64): Async<int * int * int64> = async {
         let! ct = Async.CancellationToken
         return! ctx.Prune(ctx.StreamId streamName, index, ct) |> Async.AwaitTaskCorrect }
 
@@ -1615,7 +1615,7 @@ module Events =
     /// reading in batches of the specified size.
     /// Returns an empty sequence if the stream is empty or if the sequence number is smaller than the smallest
     /// sequence number in the stream.
-    let getAllBackwards (ctx : EventsContext) (streamName : string) (index : int64) (batchSize : int) : Async<IAsyncEnumerable<ITimelineEvent<EventBody>[]>> = async {
+    let getAllBackwards (ctx: EventsContext) (streamName: string) (index: int64) (batchSize: int): Async<IAsyncEnumerable<ITimelineEvent<EventBody>[]>> = async {
         let! ct = Async.CancellationToken
         return ctx.Walk(ctx.StreamId streamName, batchSize, ct, maxIndex = index, direction = Direction.Backward) }
 
@@ -1623,10 +1623,10 @@ module Events =
     /// number of events to read is specified by batchSize
     /// Returns an empty sequence if the stream is empty or if the sequence number is smaller than the smallest
     /// sequence number in the stream.
-    let getBackwards (ctx : EventsContext) (streamName : string) (MaxPosition index : int64) (maxCount : int) : Async<ITimelineEvent<EventBody>[]> = async {
+    let getBackwards (ctx: EventsContext) (streamName: string) (MaxPosition index: int64) (maxCount: int): Async<ITimelineEvent<EventBody>[]> = async {
         let! ct = Async.CancellationToken
         return! ctx.Read(ctx.StreamId streamName, ct, ?position = index, maxCount = maxCount, direction = Direction.Backward) |> dropPosition }
 
     /// Obtains the `index` from the current write Position
-    let getNextIndex (ctx : EventsContext) (streamName : string) : Async<int64> =
+    let getNextIndex (ctx: EventsContext) (streamName: string): Async<int64> =
         ctx.Sync(ctx.StreamId streamName) |> stripPosition

--- a/src/Equinox.CosmosStore/CosmosStoreSerialization.fs
+++ b/src/Equinox.CosmosStore/CosmosStoreSerialization.fs
@@ -5,14 +5,14 @@ open System.Text.Json
 
 module private Deflate =
 
-    let compress (uncompressedBytes : byte array) =
+    let compress (uncompressedBytes: byte[]) =
         let output = new MemoryStream()
         let compressor = new System.IO.Compression.DeflateStream(output, System.IO.Compression.CompressionLevel.Optimal, leaveOpen = true)
         compressor.Write(uncompressedBytes)
         compressor.Flush() // Could `Close`, but not required
         output.ToArray()
 
-    let inflate (compressedBytes : byte array) =
+    let inflate (compressedBytes: byte[]) =
         let input = new MemoryStream(compressedBytes)
         let decompressor = new System.IO.Compression.DeflateStream(input, System.IO.Compression.CompressionMode.Decompress, leaveOpen = true)
         let output = new MemoryStream()

--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -66,7 +66,7 @@ module Event =
 /// Compaction/Snapshot/Projection Event based on the state at a given point in time `i`
 [<NoEquality; NoComparison>]
 type Unfold =
-    {   /// Base: Stream Position (Version) of State from which this Unfold was generated
+    {   /// Base: Stream Position (Version) of State from which this Unfold Event was generated. An unfold from State Version 1 is i=1 and includes event i=1
         i : int64
 
         /// Generation datetime

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -80,8 +80,8 @@ module Log =
                 { mutable count : int64; mutable ms : int64 }
                 static member Create() = { count = 0L; ms = 0L }
                 member x.Ingest(ms) =
-                    System.Threading.Interlocked.Increment(&x.count) |> ignore
-                    System.Threading.Interlocked.Add(&x.ms, ms) |> ignore
+                    Interlocked.Increment(&x.count) |> ignore
+                    Interlocked.Add(&x.ms, ms) |> ignore
 
             type LogSink() =
                 static let epoch = System.Diagnostics.Stopwatch.StartNew()
@@ -155,10 +155,10 @@ module private Write =
         let reqMetric : Log.Measurement = { stream = streamName; interval = t; bytes = bytes; count = count}
         let resultLog, evt =
             match result, reqMetric with
-            | EsSyncResult.Conflict actualVersion, m ->
-                log |> Log.prop "actualVersion" actualVersion, Log.WriteConflict m
             | EsSyncResult.Written x, m ->
                 log |> Log.prop "nextExpectedVersion" x.NextExpectedVersion |> Log.prop "logPosition" x.LogPosition, Log.WriteSuccess m
+            | EsSyncResult.Conflict actualVersion, m ->
+                log |> Log.prop "actualVersion" actualVersion, Log.WriteConflict m
         (resultLog |> Log.event evt).Information("Ges{action:l} count={count} conflict={conflict}",
             "Write", events.Length, match evt with Log.WriteConflict _ -> true | _ -> false)
         return result }
@@ -372,7 +372,7 @@ type EventStoreContext(connection : EventStoreConnection, batchOptions : BatchOp
     member val BatchOptions = batchOptions
 
     member _.TokenEmpty = Token.ofUncompactedVersion batchOptions.BatchSize -1L
-    member _.LoadBatched(streamName, requireLeader, log, (tryDecode, isCompactionEventType)) : Task<StreamToken * 'event[]> = task {
+    member _.LoadBatched(log, streamName, requireLeader, tryDecode, isCompactionEventType) : Task<StreamToken * 'event[]> = task {
         let! version, events = Read.loadForwardsFrom log connection.ReadRetryPolicy (conn requireLeader) batchOptions.BatchSize batchOptions.MaxBatches streamName 0L
         match tryIsResolvedEventEventType isCompactionEventType with
         | None -> return Token.ofNonCompacting version, Array.chooseV tryDecode events
@@ -380,13 +380,13 @@ type EventStoreContext(connection : EventStoreConnection, batchOptions : BatchOp
             match events |> Array.tryFindBack isCompactionEvent with
             | None -> return Token.ofUncompactedVersion batchOptions.BatchSize version, Array.chooseV tryDecode events
             | Some resolvedEvent -> return Token.ofCompactionResolvedEventAndVersion resolvedEvent batchOptions.BatchSize version, Array.chooseV tryDecode events }
-    member _.LoadBackwardsStoppingAtCompactionEvent(streamName, requireLeader, log, (tryDecode, isOrigin)) : Task<StreamToken * 'event []> = task {
+    member _.LoadBackwardsStoppingAtCompactionEvent(log, streamName, requireLeader, tryDecode, isOrigin) : Task<StreamToken * 'event []> = task {
         let! version, events =
             Read.loadBackwardsUntilCompactionOrStart log connection.ReadRetryPolicy (conn requireLeader) batchOptions.BatchSize batchOptions.MaxBatches streamName (tryDecode, isOrigin)
         match Array.tryHead events |> Option.filter (function _, ValueSome e -> isOrigin e | _ -> false) with
         | None -> return Token.ofUncompactedVersion batchOptions.BatchSize version, Array.chooseV ValueTuple.snd events
         | Some (resolvedEvent, _) -> return Token.ofCompactionResolvedEventAndVersion resolvedEvent batchOptions.BatchSize version, Array.chooseV ValueTuple.snd events }
-    member _.Reload(requireLeader, streamName, log, (Token.Unpack token as streamToken), (tryDecode, isCompactionEventType))
+    member _.Reload(log, streamName, requireLeader, (Token.Unpack token as streamToken), tryDecode, isCompactionEventType)
         : Task<StreamToken * 'event[]> = task {
         let streamPosition = token.streamVersion + 1L
         let! version, events = Read.loadForwardsFrom log connection.ReadRetryPolicy (conn requireLeader) batchOptions.BatchSize batchOptions.MaxBatches streamName streamPosition
@@ -397,11 +397,9 @@ type EventStoreContext(connection : EventStoreConnection, batchOptions : BatchOp
             | None -> return Token.ofPreviousTokenAndEventsLength streamToken events.Length batchOptions.BatchSize version, Array.chooseV tryDecode events
             | Some resolvedEvent -> return Token.ofCompactionResolvedEventAndVersion resolvedEvent batchOptions.BatchSize version, Array.chooseV tryDecode events }
 
-    member _.TrySync(log, streamName, (Token.Unpack token as streamToken), (events, encodedEvents : EventData array), isCompactionEventType) : Task<GatewaySyncResult> = task {
+    member _.TrySync(log, streamName, (Token.Unpack token as streamToken), (events, encodedEvents : EventData[]), isCompactionEventType) : Task<GatewaySyncResult> = task {
         let streamVersion = token.streamVersion
         match! Write.writeEvents log connection.WriteRetryPolicy connection.WriteConnection streamName streamVersion encodedEvents with
-        | EsSyncResult.Conflict actualVersion ->
-            return GatewaySyncResult.ConflictUnknown (Token.ofNonCompacting actualVersion)
         | EsSyncResult.Written wr ->
             let version' = wr.NextExpectedVersion
             let token =
@@ -412,17 +410,19 @@ type EventStoreContext(connection : EventStoreConnection, batchOptions : BatchOp
                     | None -> Token.ofPreviousTokenAndEventsLength streamToken encodedEvents.Length batchOptions.BatchSize version'
                     | Some compactionEventIndex ->
                         Token.ofPreviousStreamVersionAndCompactionEventDataIndex streamToken compactionEventIndex encodedEvents.Length batchOptions.BatchSize version'
-            return GatewaySyncResult.Written token }
+            return GatewaySyncResult.Written token
+        | EsSyncResult.Conflict actualVersion ->
+            return GatewaySyncResult.ConflictUnknown (Token.ofNonCompacting actualVersion) }
     // Used by Propulsion.EventStore.EventStoreSink
     member _.Sync(log, streamName, streamVersion, events : FsCodec.IEventData<EventBody>[]) : Task<GatewaySyncResult> = task {
         let encodedEvents : EventData[] = events |> Array.map UnionEncoderAdapters.eventDataOfEncodedEvent
         match! Write.writeEvents log connection.WriteRetryPolicy connection.WriteConnection streamName streamVersion encodedEvents with
-        | EsSyncResult.Conflict actualVersion ->
-            return GatewaySyncResult.ConflictUnknown (Token.ofNonCompacting actualVersion)
         | EsSyncResult.Written wr ->
             let version' = wr.NextExpectedVersion
             let token = Token.ofNonCompacting version'
-            return GatewaySyncResult.Written token }
+            return GatewaySyncResult.Written token
+        | EsSyncResult.Conflict actualVersion ->
+            return GatewaySyncResult.ConflictUnknown (Token.ofNonCompacting actualVersion) }
 
 [<NoComparison; NoEquality; RequireQualifiedAccess>]
 type AccessStrategy<'event, 'state> =
@@ -440,32 +440,30 @@ type private CompactionContext(eventsLen : int, capacityBeforeCompaction : int) 
     /// Determines whether writing a Compaction event is warranted (based on the existing state and the current accumulated changes)
     member _.IsCompactionDue = eventsLen > capacityBeforeCompaction
 
-type private Category<'event, 'state, 'context>(context : EventStoreContext, codec : FsCodec.IEventCodec<_, _, 'context>, ?access : AccessStrategy<'event, 'state>) =
-
+type private Category<'event, 'state, 'context>(context: EventStoreContext, codec: FsCodec.IEventCodec<_, _, 'context>, access) =
     let tryDecode (e : ResolvedEvent) = e |> UnionEncoderAdapters.encodedEventOfResolvedEvent |> codec.TryDecode
-
+    let isOrigin =
+        match access with
+        | None | Some AccessStrategy.LatestKnownEvent -> fun _ -> true
+        | Some (AccessStrategy.RollingSnapshots (isValid, _)) -> isValid
+    let loadAlgorithm log streamName requireLeader =
+        match access with
+        | None -> context.LoadBatched(log, streamName, requireLeader, tryDecode, None)
+        | Some AccessStrategy.LatestKnownEvent
+        | Some (AccessStrategy.RollingSnapshots _) -> context.LoadBackwardsStoppingAtCompactionEvent(log, streamName, requireLeader, tryDecode, isOrigin)
     let compactionPredicate =
         match access with
         | None -> None
         | Some AccessStrategy.LatestKnownEvent -> Some (fun _ -> true)
         | Some (AccessStrategy.RollingSnapshots (isValid, _)) -> Some isValid
-    let isOrigin =
-        match access with
-        | None | Some AccessStrategy.LatestKnownEvent -> fun _ -> true
-        | Some (AccessStrategy.RollingSnapshots (isValid, _)) -> isValid
-    let loadAlgorithm streamName requireLeader log =
-        match access with
-        | None -> context.LoadBatched(streamName, requireLeader, log, (tryDecode, None))
-        | Some AccessStrategy.LatestKnownEvent
-        | Some (AccessStrategy.RollingSnapshots _) -> context.LoadBackwardsStoppingAtCompactionEvent(streamName, requireLeader, log, (tryDecode, isOrigin))
     let load (fold : 'state -> 'event seq -> 'state) initial f = task {
         let! token, events = f
         return struct (token, fold initial events) }
 
-    member _.Load(fold : 'state -> 'event seq -> 'state, initial : 'state, streamName : string, requireLeader, log : ILogger) : Task<struct (StreamToken * 'state)> =
-        load fold initial (loadAlgorithm streamName requireLeader log)
-    member _.Reload(fold : 'state -> 'event seq -> 'state, state : 'state, streamName : string, requireLeader, token, log : ILogger) : Task<struct (StreamToken * 'state)> =
-        load fold state (context.Reload(requireLeader, streamName, log, token, (tryDecode, compactionPredicate)))
+    member _.Load(log, fold : 'state -> 'event seq -> 'state, initial : 'state, streamName : string, requireLeader) : Task<struct (StreamToken * 'state)> =
+        load fold initial (loadAlgorithm log streamName requireLeader)
+    member _.Reload(log, fold : 'state -> 'event seq -> 'state, state : 'state, streamName : string, requireLeader, token) : Task<struct (StreamToken * 'state)> =
+        load fold state (context.Reload(log, streamName, requireLeader, token, tryDecode, compactionPredicate))
 
     member _.TrySync<'context>
         (   log : ILogger, fold : 'state -> 'event seq -> 'state,
@@ -479,25 +477,25 @@ type private Category<'event, 'state, 'context>(context : EventStoreContext, cod
                 if cc.IsCompactionDue then Array.append events (fold state events |> compact |> Array.singleton) else events
         let encodedEvents : EventData[] = events |> Array.map (encode >> UnionEncoderAdapters.eventDataOfEncodedEvent)
         match! context.TrySync(log, streamName, streamToken, (events, encodedEvents), compactionPredicate) with
-        | GatewaySyncResult.ConflictUnknown _ ->
-            return SyncResult.Conflict  (fun ct -> load fold state (context.Reload(true, streamName, log, streamToken, (tryDecode, compactionPredicate))))
         | GatewaySyncResult.Written token' ->
-            return SyncResult.Written   (token', fold state (Seq.ofArray events)) }
+            return SyncResult.Written   (token', fold state (Seq.ofArray events))
+        | GatewaySyncResult.ConflictUnknown _ ->
+            return SyncResult.Conflict  (fun _ct -> load fold state (context.Reload(log, streamName, true, streamToken, tryDecode, compactionPredicate))) }
 
 type private Folder<'event, 'state, 'context>(category : Category<'event, 'state, 'context>, fold : 'state -> 'event seq -> 'state, initial : 'state, ?readCache) =
     interface ICategory<'event, 'state, 'context> with
         member _.Load(log, _categoryName, _streamId, streamName, allowStale, requireLeader, _ct) =
             match readCache with
-            | None -> category.Load(fold, initial, streamName, requireLeader, log)
+            | None -> category.Load(log, fold, initial, streamName, requireLeader)
             | Some (cache : ICache, prefix : string) -> task {
                 match! cache.TryGet(prefix + streamName) with
-                | ValueNone -> return! category.Load(fold, initial, streamName, requireLeader, log)
+                | ValueNone -> return! category.Load(log, fold, initial, streamName, requireLeader)
                 | ValueSome tokenAndState when allowStale -> return tokenAndState
-                | ValueSome (token, state) -> return! category.Reload(fold, state, streamName, requireLeader, token, log) }
+                | ValueSome (token, state) -> return! category.Reload(log, fold, state, streamName, requireLeader, token) }
         member _.TrySync(log, _categoryName, _streamId, streamName, context, _maybeInit, streamToken, initialState, events, _ct) = task {
             match! category.TrySync(log, fold, streamName, streamToken, initialState, events, context) with
-            | SyncResult.Conflict resync ->          return SyncResult.Conflict resync
-            | SyncResult.Written (token', state') -> return SyncResult.Written (token', state') }
+            | SyncResult.Written (token', state') -> return SyncResult.Written (token', state')
+            | SyncResult.Conflict resync ->          return SyncResult.Conflict resync }
 
 /// For EventStoreDB, caching is less critical than it is for e.g. CosmosDB
 /// As such, it can often be omitted, particularly if streams are short or there are snapshots being maintained
@@ -516,21 +514,20 @@ type CachingStrategy =
     /// Semantics are identical to <c>SlidingWindow</c>.
     | SlidingWindowPrefixed of ICache * window : TimeSpan * prefix : string
 
-type EventStoreCategory<'event, 'state, 'context>(resolveInner, empty) =
+type EventStoreCategory<'event, 'state, 'context> internal (resolveInner, empty) =
     inherit Equinox.Category<'event, 'state, 'context>(resolveInner, empty)
-    new (   context : EventStoreContext, codec : FsCodec.IEventCodec<_, _, 'context>, fold, initial,
-            // Caching can be overkill for EventStore esp considering the degree to which its intrinsic caching is a first class feature
-            // e.g., A key benefit is that reads of streams more than a few pages long get completed in constant time after the initial load
-            [<O; D(null)>] ?caching,
-            [<O; D(null)>] ?access) =
-
+    new(context: EventStoreContext, codec: FsCodec.IEventCodec<_, _, 'context>, fold, initial,
+        // Caching can be overkill for EventStore esp considering the degree to which its intrinsic caching is a first class feature
+        // e.g., A key benefit is that reads of streams more than a few pages long get completed in constant time after the initial load
+        [<O; D(null)>] ?caching,
+        [<O; D(null)>] ?access) =
         do  match access with
             | Some AccessStrategy.LatestKnownEvent when Option.isSome caching ->
                 "Equinox.EventStore does not support (and it would make things _less_ efficient even if it did)"
                 + "mixing AccessStrategy.LatestKnownEvent with Caching at present."
                 |> invalidOp
             | _ -> ()
-        let inner = Category<'event, 'state, 'context>(context, codec, ?access = access)
+        let inner = Category<'event, 'state, 'context>(context, codec, access)
         let readCacheOption =
             match caching with
             | None -> None

--- a/src/Equinox.EventStoreDb/Caching.fs
+++ b/src/Equinox.EventStoreDb/Caching.fs
@@ -16,10 +16,10 @@ type internal Decorator<'event, 'state, 'context>
             inner.Load(log, categoryName, streamId, streamName, allowStale, requireLeader, ct) |> cache streamName
         member _.TrySync(log, categoryName, streamId, streamName, context, maybeInit, streamToken, state, events, ct) = task {
             match! inner.TrySync((log, categoryName, streamId, streamName, context, maybeInit, streamToken, state, events, ct)) with
-            | SyncResult.Conflict resync -> return SyncResult.Conflict (fun ct -> resync ct |> cache streamName)
             | SyncResult.Written (token', state') ->
                 do! updateCache streamName (token', state')
-                return SyncResult.Written (token', state') }
+                return SyncResult.Written (token', state')
+            | SyncResult.Conflict resync -> return SyncResult.Conflict (fun ct -> resync ct |> cache streamName) }
 
 let applyCacheUpdatesWithSlidingExpiration
         (cache : ICache)

--- a/src/Equinox.MessageDb/MessageDbClient.fs
+++ b/src/Equinox.MessageDb/MessageDbClient.fs
@@ -57,7 +57,7 @@ type internal MessageDbWriter(connectionString : string) =
 
         cmd
 
-    member _.WriteMessages(streamName, events : _ array, version, ct) = task {
+    member _.WriteMessages(streamName, events : _[], version, ct) = task {
         use! conn = Npgsql.connect connectionString ct
         use transaction = conn.BeginTransaction()
         use batch = new NpgsqlBatch(conn, transaction)

--- a/src/Equinox/Core.fs
+++ b/src/Equinox/Core.fs
@@ -10,15 +10,15 @@ open System.Threading.Tasks
 type IStream<'event, 'state> =
 
     /// Generate a stream token that represents a stream one believes to be empty to use as a Null Object when optimizing out the initial load roundtrip
-    abstract LoadEmpty : unit -> struct (StreamToken * 'state)
+    abstract LoadEmpty: unit -> struct (StreamToken * 'state)
 
     /// Obtain the state from the target stream
-    abstract Load : allowStale : bool * requireLeader : bool * ct : CancellationToken -> Task<struct (StreamToken * 'state)>
+    abstract Load: allowStale: bool * requireLeader: bool * ct: CancellationToken -> Task<struct (StreamToken * 'state)>
 
     /// Given the supplied `token` [and related `originState`], attempt to move to state `state'` by appending the supplied `events` to the underlying stream
     /// SyncResult.Written: implies the state is now the value represented by the Result's value
     /// SyncResult.Conflict: implies the `events` were not synced; if desired the consumer can use the included resync workflow in order to retry
-    abstract TrySync : attempt : int * originTokenAndState : struct (StreamToken * 'state) * events : 'event array * CancellationToken -> Task<SyncResult<'state>>
+    abstract TrySync: attempt: int * originTokenAndState: struct (StreamToken * 'state) * events: 'event[] * CancellationToken -> Task<SyncResult<'state>>
 
 /// Internal type used to represent the outcome of a TrySync operation
 and [<NoEquality; NoComparison; RequireQualifiedAccess>] SyncResult<'state> =
@@ -29,16 +29,16 @@ and [<NoEquality; NoComparison; RequireQualifiedAccess>] SyncResult<'state> =
     | Conflict of (CancellationToken -> Task<struct (StreamToken * 'state)>)
 
 /// Store-specific opaque token to be used for synchronization purposes
-and [<Struct; NoEquality; NoComparison>] StreamToken = { value : obj; version : int64; streamBytes : int64 }
+and [<Struct; NoEquality; NoComparison>] StreamToken = { value: obj; version: int64; streamBytes: int64 }
 
 type internal Impl() =
 
-    static let run (stream : IStream<'e, 's>)
-            (decide : Func<struct (_ * _), CancellationToken, Task<struct ('r * 'e seq)>>)
-            (validateResync : int -> unit)
-            (mapResult : Func<'r, struct (StreamToken * 's), 'v>)
-            originTokenAndState ct : Task<'v> =
-        let rec loop attempt tokenAndState : Task<'v> = task {
+    static let run (stream: IStream<'e, 's>)
+            (decide: Func<struct (_ * _), CancellationToken, Task<struct ('r * 'e seq)>>)
+            (validateResync: int -> unit)
+            (mapResult: Func<'r, struct (StreamToken * 's), 'v>)
+            originTokenAndState ct: Task<'v> =
+        let rec loop attempt tokenAndState: Task<'v> = task {
             let! result, events = decide.Invoke(tokenAndState, ct)
             match Array.ofSeq events with
             | [||] -> return mapResult.Invoke(result, tokenAndState)
@@ -52,12 +52,12 @@ type internal Impl() =
                     return! loop (attempt + 1) tokenAndState }
         loop 1 originTokenAndState
 
-    static member TransactAsync(stream, fetch : IStream<'e, 's> -> CancellationToken -> Task<struct (StreamToken * 's)>,
-                                decide, reload, mapResult, ct) : Task<'v> = task {
+    static member TransactAsync(stream, fetch: IStream<'e, 's> -> CancellationToken -> Task<struct (StreamToken * 's)>,
+                                decide, reload, mapResult, ct): Task<'v> = task {
         let! originTokenAndState = fetch stream ct
         return! run stream decide reload mapResult originTokenAndState ct }
 
-    static member QueryAsync(stream, fetch : IStream<'e, 's> -> CancellationToken -> Task<struct (StreamToken * 's)>,
-                             projection : Func<struct (StreamToken * 's), 'v>, ct) : Task<'v> = task {
+    static member QueryAsync(stream, fetch: IStream<'e, 's> -> CancellationToken -> Task<struct (StreamToken * 's)>,
+                             projection: Func<struct (StreamToken * 's), 'v>, ct): Task<'v> = task {
         let! tokenAndState = fetch stream ct
         return projection.Invoke tokenAndState }

--- a/src/Equinox/Decider.fs
+++ b/src/Equinox/Decider.fs
@@ -264,19 +264,18 @@ and internal AttemptsPolicy() =
 and MaxResyncsExhaustedException(count) =
    inherit exn(sprintf "Concurrency violation; aborting after %i attempts." count)
 
-
 /// Exposed by TransactEx / QueryEx, providing access to extended state information for cases where that's required
 and [<NoComparison; NoEquality>]
     ISyncContext<'state> =
 
-    /// Exposes the underlying Store's internal Version for the underlying stream.
+    /// Store-independent Version associated with the present <c>State</c>, based on the underlying Stream's write position.
     /// An empty stream is Version 0; one with a single event is Version 1 etc.
-    /// It's important to consider that this Version is more authoritative than counting the events seen, or adding 1 to
-    ///   the `Index` of the last event passed to your `fold` function - the codec may opt to ignore events
+    /// NOTE Version is more authoritative than counting the events seen, or adding 1 to the `Index` of the last event
+    ///      passed to your `fold` function; the codec may opt to filter out some events
     abstract member Version : int64
 
     /// The Storage occupied by the Events written to the underlying stream at the present time.
-    /// Specific stores may vary whether this is available, the basis and preciseness for how it is computed.
+    /// Specific stores may vary whether this is available, or the basis and preciseness for how it is computed.
     abstract member StreamEventBytes : int64 voption
 
     /// The present State of the stream within the context of this Flow

--- a/src/Equinox/Decider.fs
+++ b/src/Equinox/Decider.fs
@@ -7,7 +7,7 @@ open System.Threading.Tasks
 
 /// Central Application-facing API for F#. Wraps the handling of decision or query flows in a manner that is store agnostic
 /// NOTE: For C#, direct usage of DeciderCore is recommended
-type Decider<'event, 'state>(inner : DeciderCore<'event, 'state>) =
+type Decider<'event, 'state>(inner: DeciderCore<'event, 'state>) =
 
     /// Provides access to lower-level APIs to enable building custom <c>Transact</c> / <c>Query</c> variations
     member val Core = inner
@@ -15,7 +15,7 @@ type Decider<'event, 'state>(inner : DeciderCore<'event, 'state>) =
     /// 1.  Invoke the supplied <c>interpret</c> function with the present state to determine whether any write is to occur.
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
-    member _.Transact(interpret : 'state -> 'event list, ?load, ?attempts) : Async<unit> = async {
+    member _.Transact(interpret: 'state -> 'event list, ?load, ?attempts): Async<unit> = async {
         let! ct = Async.CancellationToken
         return! inner.Transact(interpret >> Seq.ofList, ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
 
@@ -23,7 +23,7 @@ type Decider<'event, 'state>(inner : DeciderCore<'event, 'state>) =
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Uses <c>render</c> to generate a 'view from the persisted final state
-    member _.Transact(interpret : 'state -> 'event list, render : 'state -> 'view, ?load, ?attempts) : Async<'view> = async {
+    member _.Transact(interpret: 'state -> 'event list, render: 'state -> 'view, ?load, ?attempts): Async<'view> = async {
         let! ct = Async.CancellationToken
         return! inner.Transact(interpret >> Seq.ofList, render, ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
 
@@ -31,7 +31,7 @@ type Decider<'event, 'state>(inner : DeciderCore<'event, 'state>) =
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yield result
-    member _.Transact(decide : 'state -> 'result * 'event list, ?load, ?attempts) : Async<'result> = async {
+    member _.Transact(decide: 'state -> 'result * 'event list, ?load, ?attempts): Async<'result> = async {
         let! ct = Async.CancellationToken
         let inline decide' s = let r, es = decide s in struct (r, Seq.ofList es)
         return! inner.Transact(decide', ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
@@ -40,7 +40,7 @@ type Decider<'event, 'state>(inner : DeciderCore<'event, 'state>) =
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yields a final 'view produced by <c>mapResult</c> from the <c>'result</c> and/or the final persisted <c>'state</c>
-    member _.Transact(decide : 'state -> 'result * 'event list, mapResult : 'result -> 'state -> 'view, ?load, ?attempts) : Async<'view> = async {
+    member _.Transact(decide: 'state -> 'result * 'event list, mapResult: 'result -> 'state -> 'view, ?load, ?attempts): Async<'view> = async {
         let! ct = Async.CancellationToken
         let inline decide' s = let r, es = decide s in struct (r, Seq.ofList es)
         return! inner.Transact(decide', mapResult, ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
@@ -49,7 +49,7 @@ type Decider<'event, 'state>(inner : DeciderCore<'event, 'state>) =
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yields <c>result</c>
-    member _.TransactEx(decide : ISyncContext<'state> -> 'result * 'event list, ?load, ?attempts) : Async<'result> = async {
+    member _.TransactEx(decide: ISyncContext<'state> -> 'result * 'event list, ?load, ?attempts): Async<'result> = async {
         let! ct = Async.CancellationToken
         let inline decide' c = let r, es = decide c in struct (r, Seq.ofList es)
         return! inner.TransactEx(decide = decide', ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
@@ -58,19 +58,19 @@ type Decider<'event, 'state>(inner : DeciderCore<'event, 'state>) =
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yields a final 'view produced by <c>mapResult</c> from the <c>'result</c> and/or the final persisted <c>ISyncContext</c>
-    member _.TransactEx(decide : ISyncContext<'state> -> 'result * 'event list, mapResult : 'result -> ISyncContext<'state> -> 'view,
-                        ?load, ?attempts) : Async<'view> = async {
+    member _.TransactEx(decide: ISyncContext<'state> -> 'result * 'event list, mapResult: 'result -> ISyncContext<'state> -> 'view,
+                        ?load, ?attempts): Async<'view> = async {
         let! ct = Async.CancellationToken
         let inline decide' c = let r, es = decide c in struct (r, Seq.ofList es)
         return! inner.TransactEx(decide = decide', mapResult = mapResult, ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
 
     /// Project from the folded <c>'state</c>, but without executing a decision flow as <c>Transact</c> does
-    member _.Query(render : 'state -> 'view, ?load) : Async<'view> = async {
+    member _.Query(render: 'state -> 'view, ?load): Async<'view> = async {
         let! ct = Async.CancellationToken
         return! inner.Query(render, ?load = load, ct = ct) |> Async.AwaitTaskCorrect }
 
     /// Project from the stream's complete context, but without executing a decision flow as <c>TransactEx<c> does
-    member _.QueryEx(render : ISyncContext<'state> -> 'view, ?load) : Async<'view> = async {
+    member _.QueryEx(render: ISyncContext<'state> -> 'view, ?load): Async<'view> = async {
         let! ct = Async.CancellationToken
         return! inner.QueryEx(render, ?load = load, ct = ct) |> Async.AwaitTaskCorrect }
 
@@ -78,7 +78,7 @@ type Decider<'event, 'state>(inner : DeciderCore<'event, 'state>) =
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Uses <c>render</c> to generate a 'view from the persisted final state
-    member _.TransactAsync(interpret : 'state -> Async<'event list>, render : 'state -> 'view, ?load, ?attempts) : Async<'view> = async {
+    member _.TransactAsync(interpret: 'state -> Async<'event list>, render: 'state -> 'view, ?load, ?attempts): Async<'view> = async {
         let! ct = Async.CancellationToken
         let inline interpret' s ct = task { let! es = Async.StartImmediateAsTask(interpret s, ct) in return Seq.ofList es }
         return! inner.TransactAsync(interpret', render, ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
@@ -87,7 +87,7 @@ type Decider<'event, 'state>(inner : DeciderCore<'event, 'state>) =
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yield result
-    member _.TransactAsync(decide : 'state -> Async<'result * 'event list>, ?load, ?attempts) : Async<'result> = async {
+    member _.TransactAsync(decide: 'state -> Async<'result * 'event list>, ?load, ?attempts): Async<'result> = async {
         let! ct = Async.CancellationToken
         let inline decide' s ct = task { let! r, es = Async.StartImmediateAsTask(decide s, ct) in return struct (r, Seq.ofList es) }
         return! inner.TransactAsync(decide = decide', ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
@@ -96,7 +96,7 @@ type Decider<'event, 'state>(inner : DeciderCore<'event, 'state>) =
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yield result
-    member _.TransactExAsync(decide : ISyncContext<'state> -> Async<'result * 'event list>, ?load, ?attempts) : Async<'result> = async {
+    member _.TransactExAsync(decide: ISyncContext<'state> -> Async<'result * 'event list>, ?load, ?attempts): Async<'result> = async {
         let! ct = Async.CancellationToken
         let decide' c ct = task { let! r, es = Async.StartImmediateAsTask(decide c, ct) in return struct (r, Seq.ofList es) }
         return! inner.TransactExAsync(decide = decide', ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
@@ -105,33 +105,33 @@ type Decider<'event, 'state>(inner : DeciderCore<'event, 'state>) =
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yields a final 'view produced by <c>mapResult</c> from the <c>'result</c> and/or the final persisted <c>ISyncContext</c>
-    member _.TransactExAsync(decide : ISyncContext<'state> -> Async<'result * 'event list>, mapResult : 'result -> ISyncContext<'state> -> 'view,
-                             ?load, ?attempts) : Async<'view> = async {
+    member _.TransactExAsync(decide: ISyncContext<'state> -> Async<'result * 'event list>, mapResult: 'result -> ISyncContext<'state> -> 'view,
+                             ?load, ?attempts): Async<'view> = async {
         let! ct = Async.CancellationToken
         let inline decide' c ct = task { let! r, es = Async.StartImmediateAsTask(decide c, ct) in return struct (r, Seq.ofList es) }
         return! inner.TransactExAsync(decide = decide', mapResult = mapResult, ?load = load, ?attempts = attempts, ct = ct) |> Async.AwaitTaskCorrect }
 
 /// Central Application-facing API. Wraps the handling of decision or query flows in a manner that is store agnostic
 /// For F#, the async and FSharpFunc signatures in Decider tend to work better, but the API set is equivalent
-and DeciderCore<'event, 'state>(stream : IStream<'event, 'state>) =
+and DeciderCore<'event, 'state>(stream: IStream<'event, 'state>) =
 
     let (|Context|) = SyncContext<'state>.Map
 
     /// 1.  Invoke the supplied <c>interpret</c> function with the present state to determine whether any write is to occur.
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
-    member _.Transact(interpret : Func<'state, 'event seq>,
-                      [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D(CancellationToken())>]?ct) : Task<unit> =
-        let inline decide struct (_t : StreamToken, state) _ct = Task.FromResult struct ((), interpret.Invoke state)
-        let inline mapRes () struct (_t : StreamToken, _s : 'state) = ()
+    member _.Transact(interpret: Func<'state, 'event seq>,
+                      [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D(CancellationToken())>]?ct): Task<unit> =
+        let inline decide struct (_t: StreamToken, state) _ct = Task.FromResult struct ((), interpret.Invoke state)
+        let inline mapRes () struct (_t: StreamToken, _s: 'state) = ()
         Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
 
     /// 1. Invoke the supplied <c>interpret</c> function with the present state
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Uses <c>render</c> to generate a 'view from the persisted final state
-    member _.Transact(interpret : Func<'state, 'event seq>, render : Func<'state, 'view>,
-                      [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D(CancellationToken())>]?ct) : Task<'view> =
+    member _.Transact(interpret: Func<'state, 'event seq>, render: Func<'state, 'view>,
+                      [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D(CancellationToken())>]?ct): Task<'view> =
         let inline decide struct (_token, state) _ct = Task.FromResult struct ((), interpret.Invoke state)
         let inline mapRes () struct (_token, state) = render.Invoke state
         Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
@@ -140,8 +140,8 @@ and DeciderCore<'event, 'state>(stream : IStream<'event, 'state>) =
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yield result
-    member _.Transact(decide : Func<'state, struct ('result * 'event seq)>,
-                      [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct) : Task<'result> =
+    member _.Transact(decide: Func<'state, struct ('result * 'event seq)>,
+                      [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct): Task<'result> =
         let inline decide struct (_token, state) _ct = decide.Invoke state |> Task.FromResult
         let inline mapRes r _ = r
         Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
@@ -150,8 +150,8 @@ and DeciderCore<'event, 'state>(stream : IStream<'event, 'state>) =
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yields a final 'view produced by <c>mapResult</c> from the <c>'result</c> and/or the final persisted <c>'state</c>
-    member _.Transact(decide : Func<'state, struct ('result * 'event seq)>, mapResult : Func<'result, 'state, 'view>,
-                      [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct) : Task<'view> =
+    member _.Transact(decide: Func<'state, struct ('result * 'event seq)>, mapResult: Func<'result, 'state, 'view>,
+                      [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct): Task<'view> =
         let inline decide struct (_token, state) _ct = decide.Invoke state |> Task.FromResult
         let inline mapRes r struct (_, s) = mapResult.Invoke(r, s)
         Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
@@ -160,8 +160,8 @@ and DeciderCore<'event, 'state>(stream : IStream<'event, 'state>) =
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yields <c>result</c>
-    member _.TransactEx(decide : Func<ISyncContext<'state>, struct ('result * 'event seq)>,
-                        [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct) : Task<'result> =
+    member _.TransactEx(decide: Func<ISyncContext<'state>, struct ('result * 'event seq)>,
+                        [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct): Task<'result> =
         let inline decide' (Context c) _ct = let r = decide.Invoke(c) in Task.FromResult r
         let inline mapRes r _ = r
         Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide', AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
@@ -170,26 +170,26 @@ and DeciderCore<'event, 'state>(stream : IStream<'event, 'state>) =
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yields a final 'view produced by <c>mapResult</c> from the <c>'result</c> and/or the final persisted <c>ISyncContext</c>
-    member _.TransactEx(decide : Func<ISyncContext<'state>, struct ('result * 'event seq)>, mapResult : Func<'result, ISyncContext<'state>, 'view>,
-                        [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct) : Task<'view> =
+    member _.TransactEx(decide: Func<ISyncContext<'state>, struct ('result * 'event seq)>, mapResult: Func<'result, ISyncContext<'state>, 'view>,
+                        [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct): Task<'view> =
         let inline decide (Context c) _ct = c |> decide.Invoke |> Task.FromResult
         let inline mapRes r (Context c) = mapResult.Invoke(r, c)
         Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
 
     /// Project from the folded <c>'state</c>, but without executing a decision flow as <c>Transact</c> does
-    member _.Query(render : Func<'state, 'view>, [<O; D null>] ?load, [<O; D null>] ?ct) : Task<'view> =
+    member _.Query(render: Func<'state, 'view>, [<O; D null>] ?load, [<O; D null>] ?ct): Task<'view> =
         Impl.QueryAsync(stream, LoadPolicy.Fetch load, (fun struct (_token, state) -> render.Invoke state), defaultArg ct CancellationToken.None)
 
     /// Project from the stream's complete context, but without executing a decision flow as <c>TransactEx<c> does
-    member _.QueryEx(render : Func<ISyncContext<'state>, 'view>, [<O; D null>] ?load, [<O; D null>] ?ct) : Task<'view> =
+    member _.QueryEx(render: Func<ISyncContext<'state>, 'view>, [<O; D null>] ?load, [<O; D null>] ?ct): Task<'view> =
         Impl.QueryAsync(stream, LoadPolicy.Fetch load, (fun (Context c) -> render.Invoke c), defaultArg ct CancellationToken.None)
 
     /// 1. Invoke the supplied <c>Async</c> <c>interpret</c> function with the present state
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Uses <c>render</c> to generate a 'view from the persisted final state
-    member _.TransactAsync(interpret : Func<'state, CancellationToken, Task<'event seq>>, render : Func<'state, 'view>,
-                           [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct) : Task<'view> =
+    member _.TransactAsync(interpret: Func<'state, CancellationToken, Task<'event seq>>, render: Func<'state, 'view>,
+                           [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct): Task<'view> =
         let inline decide struct (_token, state) ct = task { let! es = interpret.Invoke(state, ct) in return struct ((), es) }
         let inline mapRes () struct (_token, state) = render.Invoke state
         Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
@@ -198,8 +198,8 @@ and DeciderCore<'event, 'state>(stream : IStream<'event, 'state>) =
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yield result
-    member _.TransactAsync(decide : Func<'state, CancellationToken, Task<struct ('result * 'event seq)>>,
-                           [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct) : Task<'result> =
+    member _.TransactAsync(decide: Func<'state, CancellationToken, Task<struct ('result * 'event seq)>>,
+                           [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct): Task<'result> =
         let inline decide struct (_token, state) ct = task { let! r, e = decide.Invoke(state, ct) in return struct (r, e) }
         let inline mapRes r _ = r
         Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
@@ -208,8 +208,8 @@ and DeciderCore<'event, 'state>(stream : IStream<'event, 'state>) =
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yield result
-    member _.TransactExAsync(decide : Func<ISyncContext<'state>, CancellationToken, Task<struct ('result * 'event seq)>>,
-                             [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct) : Task<'result> =
+    member _.TransactExAsync(decide: Func<ISyncContext<'state>, CancellationToken, Task<struct ('result * 'event seq)>>,
+                             [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct): Task<'result> =
         let inline decide (Context c) ct = task { let! r, e = decide.Invoke (c, ct) in return struct (r, e) }
         let inline mapRes r _ = r
         Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
@@ -218,8 +218,8 @@ and DeciderCore<'event, 'state>(stream : IStream<'event, 'state>) =
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yields a final 'view produced by <c>mapResult</c> from the <c>'result</c> and/or the final persisted <c>ISyncContext</c>
-    member _.TransactExAsync(decide : Func<ISyncContext<'state>, CancellationToken, Task<struct ('result * 'event seq)>>, mapResult : Func<'result, ISyncContext<'state>, 'view>,
-                             [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct) : Task<'view> =
+    member _.TransactExAsync(decide: Func<ISyncContext<'state>, CancellationToken, Task<struct ('result * 'event seq)>>, mapResult: Func<'result, ISyncContext<'state>, 'view>,
+                             [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct): Task<'view> =
         let inline decide (Context c) ct = decide.Invoke(c, ct)
         let inline mapRes r (Context c) = mapResult.Invoke(r, c)
         Impl.TransactAsync(stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
@@ -239,9 +239,9 @@ and [<NoComparison; NoEquality>] LoadOption<'state> =
     /// Inhibit load from database based on the fact that the stream is likely not to have been initialized yet, and we will be generating events
     | AssumeEmpty
     /// <summary>Instead of loading from database, seed the loading process with the supplied memento, obtained via <c>ISyncContext.CreateMemento()</c></summary>
-    | FromMemento of memento : struct (StreamToken * 'state)
+    | FromMemento of memento: struct (StreamToken * 'state)
 and internal LoadPolicy() =
-    static member Fetch<'state, 'event>(x : LoadOption<'state> option)
+    static member Fetch<'state, 'event>(x: LoadOption<'state> option)
         : IStream<'event, 'state> -> CancellationToken -> Task<struct (StreamToken * 'state)> =
         match x with
         | None | Some RequireLoad ->                 fun stream ct ->   stream.Load(allowStale = false, requireLeader = false, ct = ct)
@@ -253,9 +253,9 @@ and internal LoadPolicy() =
 (* Retry / Attempts policy used to define policy for resyncing state when there's an Append conflict (default 3 retries) *)
 
 and [<NoComparison; NoEquality; RequireQualifiedAccess>] Attempts =
-    | Max of count : int
+    | Max of count: int
 and internal AttemptsPolicy() =
-    static member Validate(opt : Attempts option) =
+    static member Validate(opt: Attempts option) =
         let maxAttempts = match opt with Some (Attempts.Max n) -> n | None -> 3
         if maxAttempts < 1 then raise (ArgumentOutOfRangeException(nameof opt, maxAttempts, "should be >= 1"))
         fun attempt -> if attempt = maxAttempts then raise (MaxResyncsExhaustedException attempt)
@@ -272,21 +272,21 @@ and [<NoComparison; NoEquality>]
     /// An empty stream is Version 0; one with a single event is Version 1 etc.
     /// NOTE Version is more authoritative than counting the events seen, or adding 1 to the `Index` of the last event
     ///      passed to your `fold` function; the codec may opt to filter out some events
-    abstract member Version : int64
+    abstract member Version: int64
 
     /// The Storage occupied by the Events written to the underlying stream at the present time.
     /// Specific stores may vary whether this is available, or the basis and preciseness for how it is computed.
-    abstract member StreamEventBytes : int64 voption
+    abstract member StreamEventBytes: int64 voption
 
     /// The present State of the stream within the context of this Flow
-    abstract member State : 'state
+    abstract member State: 'state
 
     /// Represents a Checkpoint position on a Stream's timeline; Can be used to manage continuations via LoadOption.FromMemento
-    abstract member CreateMemento : unit -> struct (StreamToken * 'state)
+    abstract member CreateMemento: unit -> struct (StreamToken * 'state)
 
 and internal SyncContext<'state> =
 
-    static member Map(struct (token : StreamToken, state : 'state)) =
+    static member Map(struct (token: StreamToken, state: 'state)) =
         { new ISyncContext<'state> with
             member _.State = state
             member _.Version = token.version

--- a/src/Equinox/StreamId.fs
+++ b/src/Equinox/StreamId.fs
@@ -6,7 +6,7 @@ open System
 module StreamName =
 
     /// Throws if a candidate categoryName includes a '-', is null, or is empty
-    let inline validateCategoryName (rawCategory : string) =
+    let inline validateCategoryName (rawCategory: string) =
         if rawCategory |> String.IsNullOrEmpty then invalidArg (nameof rawCategory) "may not be null or empty"
         if rawCategory.IndexOf '-' <> -1 then invalidArg (nameof rawCategory) "may not contain embedded '-' symbols"
     /// Render in canonical {categoryName}-{streamId} format. Throws if categoryName contains embedded `-` symbols
@@ -21,24 +21,24 @@ and [<Measure>] streamId
 module StreamId =
 
     /// Throws if a candidate streamId fragment includes a '_', is null, or is empty
-    let inline validateStreamIdFragment (rawFragment : string) =
+    let inline validateStreamIdFragment (rawFragment: string) =
         if rawFragment |> String.IsNullOrEmpty then invalidArg (nameof rawFragment) "may not contain null or empty fragments"
         if rawFragment.IndexOf '_' <> -1 then invalidArg (nameof rawFragment) "may not contain embedded '_' symbols"
     /// Create a StreamId, trusting the input to be well-formed (see the gen* functions for composing with validation)
-    let ofRaw (raw : string) : StreamId = UMX.tag raw
+    let ofRaw (raw: string): StreamId = UMX.tag raw
     /// Validates and generates a StreamId from an application level fragment. Throws if any of the fragments embed a `_`, are `null`, or are empty
-    let ofFragment (fragment : string) : StreamId =
+    let ofFragment (fragment: string): StreamId =
         // arguably rejection of `_` chars is a step too far, but this accommodates for more easily dealing with namespacing dictated by unforeseen needs
         validateStreamIdFragment fragment
         ofRaw fragment
     /// Combines streamId fragments. Throws if any of the fragments embed a `_`, are `null`, or are empty
-    let ofFragments (fragments : string seq) : StreamId =
+    let ofFragments (fragments: string seq): StreamId =
         fragments |> Seq.iter validateStreamIdFragment
         String.Join("_", fragments) |> ofRaw
     /// Render as a string for external use
-    let toString : StreamId -> string = UMX.untag
+    let toString: StreamId -> string = UMX.untag
     /// Render as a canonical "{categoryName}-{streamId}" StreamName. Throws if the categoryName embeds `-` chars.
-    let renderStreamName categoryName (x : StreamId) : string = toString x |> StreamName.render categoryName
+    let renderStreamName categoryName (x: StreamId): string = toString x |> StreamName.render categoryName
 
 namespace Equinox
 
@@ -46,7 +46,7 @@ namespace Equinox
 type StreamId =
 
     /// Generate a StreamId from a single application-level id, given a rendering function that maps to a non empty fragment without embedded `_` chars
-    static member Map(f : 'a -> string) = System.Func<'a, Core.StreamId>(fun id -> Core.StreamId.ofFragment (f id))
+    static member Map(f: 'a -> string) = System.Func<'a, Core.StreamId>(fun id -> Core.StreamId.ofFragment (f id))
     /// Generate a StreamId from a tuple of application-level ids, given 2 rendering functions that map to a non empty fragment without embedded `_` chars
     static member Map(f, f2) = System.Func<_, _, _>(fun id1 id2 -> Core.StreamId.ofFragments (seq { yield f id1; yield f2 id2 }))
     /// Generate a StreamId from a triple of application-level ids, given 3 rendering functions that map to a non empty fragment without embedded `_` chars
@@ -58,10 +58,10 @@ type StreamId =
 module StreamId =
 
     /// Generate a StreamId from a single application-level id, given a rendering function that maps to a non empty fragment without embedded `_` chars
-    let gen (f : 'a -> string) : 'a -> Core.StreamId = StreamId.Map(f).Invoke
+    let gen (f: 'a -> string): 'a -> Core.StreamId = StreamId.Map(f).Invoke
     /// Generate a StreamId from a tuple of application-level ids, given two rendering functions that map to a non empty fragment without embedded `_` chars
-    let gen2 f1 f2 : 'a * 'b -> Core.StreamId = StreamId.Map(f1, f2).Invoke
+    let gen2 f1 f2: 'a * 'b -> Core.StreamId = StreamId.Map(f1, f2).Invoke
     /// Generate a StreamId from a triple of application-level ids, given three rendering functions that map to a non empty fragment without embedded `_` chars
-    let gen3 f1 f2 f3 : 'a * 'b * 'c -> Core.StreamId = StreamId.Map(f1, f2, f3).Invoke
+    let gen3 f1 f2 f3: 'a * 'b * 'c -> Core.StreamId = StreamId.Map(f1, f2, f3).Invoke
     /// Generate a StreamId from a 4-tuple of application-level ids, given four rendering functions that map to a non empty fragment without embedded `_` chars
-    let gen4 f1 f2 f3 f4 : 'a * 'b * 'c * 'd -> Core.StreamId = StreamId.Map(f1, f2, f3, f4).Invoke
+    let gen4 f1 f2 f3 f4: 'a * 'b * 'c * 'd -> Core.StreamId = StreamId.Map(f1, f2, f3, f4).Invoke

--- a/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
+++ b/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
@@ -48,7 +48,7 @@ module SequenceCheck =
 
     module Fold =
 
-        type State = int array
+        type State = int[]
         let initial : State = [||]
         let evolve state = function
             | Events.Add e -> Array.append state [| e.value |]
@@ -61,11 +61,11 @@ module SequenceCheck =
 
     type Service(resolve : Guid -> Equinox.Decider<Events.Event, Fold.State>) =
 
-        member _.Read(instance : Guid) : Async<int array> =
+        member _.Read(instance : Guid) : Async<int[]> =
             let decider = resolve instance
             decider.Query(id)
 
-        member _.Add(instance : Guid, value : int, count) : Async<int array> =
+        member _.Add(instance : Guid, value : int, count) : Async<int[]> =
             let decider = resolve instance
             decider.Transact(decide (value, count), id)
 

--- a/tests/Equinox.CosmosStore.Integration/CosmosFixturesInfrastructure.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosFixturesInfrastructure.fs
@@ -16,7 +16,7 @@ type FsCheckGenerators =
 module SerilogHelpers =
     open Serilog.Events
 
-    let (|SerilogScalar|_|) : LogEventPropertyValue -> obj option = function
+    let (|SerilogScalar|_|): LogEventPropertyValue -> obj option = function
         | :? ScalarValue as x -> Some x.Value
         | _ -> None
 #if STORE_DYNAMO
@@ -91,17 +91,17 @@ module SerilogHelpers =
 #endif
         | Delete (Rc rc) | Trim (Rc rc) | Prune (Rc rc) as e -> TotalRequestCharge (e, rc)
         | Response _ -> ResponseBreakdown
-    let (|EqxEvent|_|) (logEvent : LogEvent) : Metric option =
+    let (|EqxEvent|_|) (logEvent: LogEvent): Metric option =
         logEvent.Properties.Values |> Seq.tryPick (function
             | SerilogScalar (:? Metric as e) -> Some e
             | _ -> None)
 
-    let (|HasProp|_|) (name : string) (e : LogEvent) : LogEventPropertyValue option =
+    let (|HasProp|_|) (name: string) (e: LogEvent): LogEventPropertyValue option =
         match e.Properties.TryGetValue name with
         | true, (SerilogScalar _ as s) -> Some s
         | _ -> None
-    let (|SerilogString|_|) : LogEventPropertyValue -> string option = function SerilogScalar (:? string as y) -> Some y | _ -> None
-    let (|SerilogBool|_|) : LogEventPropertyValue -> bool option = function SerilogScalar (:? bool as y) -> Some y | _ -> None
+    let (|SerilogString|_|): LogEventPropertyValue -> string option = function SerilogScalar (:? string as y) -> Some y | _ -> None
+    let (|SerilogBool|_|): LogEventPropertyValue -> bool option = function SerilogScalar (:? bool as y) -> Some y | _ -> None
 
 type LogCapture() =
     inherit LogCaptureBuffer()
@@ -111,6 +111,6 @@ type LogCapture() =
 type TestContext(testOutputHelper) =
     let output = TestOutput testOutputHelper
 
-    member _.CreateLoggerWithCapture() : Serilog.Core.Logger * LogCapture =
+    member _.CreateLoggerWithCapture(): Serilog.Core.Logger * LogCapture =
         let capture = LogCapture()
         output.CreateLogger(capture), capture

--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -151,7 +151,7 @@ type Tests(testOutputHelper) =
         let context = createPrimaryContextEx log queryMaxBatches eventsInTip
         let service = Cart.createServiceWithSnapshotStrategy log context
 
-        let cartId : CartId = % Guid.NewGuid()
+        let cartId: CartId = % Guid.NewGuid()
 
         do! addAndThenRemoveItemsManyTimesExceptTheLastOne cartContext cartId skuId service addRemoveCount
 
@@ -186,7 +186,7 @@ type Tests(testOutputHelper) =
                     do! addAndThenRemoveItemsManyTimesExceptTheLastOne cartContext cartId skuId service1 addRemoveCount
                     return Some (skuId, addRemoveCount) }
 
-        let act prepare (service : Cart.Service) skuId count =
+        let act prepare (service: Cart.Service) skuId count =
             service.ExecuteManyAsync(cartId, false, prepare = prepare, commands = [Cart.SyncItem (cartContext, skuId, Some count, None)])
 
         let eventWaitSet () = let e = new ManualResetEvent(false) in (Async.AwaitWaitHandle e |> Async.Ignore), async { e.Set() |> ignore }
@@ -251,7 +251,7 @@ type Tests(testOutputHelper) =
     }
 
     [<AutoData(MaxTest = 2, SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
-    let ``Can correctly read and update Contacts against DocStore with LatestKnownEvent without Caching`` (eventsInTip, value : ContactPreferences.Events.Preferences) = Async.RunSynchronously <| async {
+    let ``Can correctly read and update Contacts against DocStore with LatestKnownEvent without Caching`` (eventsInTip, value: ContactPreferences.Events.Preferences) = Async.RunSynchronously <| async {
         let context = createPrimaryContextEx log 1 (if eventsInTip then 1 else 0)
         let service = ContactPreferences.createServiceWithoutCaching log context
         // We need to be sure every Update changes something as we rely on an expected number of events in the end
@@ -350,7 +350,7 @@ type Tests(testOutputHelper) =
                     do! addAndThenRemoveItemsManyTimesExceptTheLastOne cartContext cartId skuId service1 addRemoveCount
                     return Some (skuId, addRemoveCount) }
 
-        let act prepare (service : Cart.Service) skuId count =
+        let act prepare (service: Cart.Service) skuId count =
             service.ExecuteManyAsync(cartId, false, prepare = prepare, commands = [Cart.SyncItem (cartContext, skuId, Some count, None)])
 
         let eventWaitSet () = let e = new ManualResetEvent(false) in (Async.AwaitWaitHandle e |> Async.Ignore), async { e.Set() |> ignore }

--- a/tests/Equinox.EventStore.Integration/EventStoreTokenTests.fs
+++ b/tests/Equinox.EventStore.Integration/EventStoreTokenTests.fs
@@ -10,7 +10,7 @@ open FsCheck.Xunit
 open Swensen.Unquote.Assertions
 open Xunit
 
-let unpack (Token.Unpack token : StreamToken) =
+let unpack (Token.Unpack token: StreamToken) =
     token.streamVersion, token.compactionEventNumber, token.batchCapacityLimit
 
 [<Theory
@@ -37,7 +37,7 @@ let ``ofUncompactedVersion - batchCapacityLimit`` streamVersion batchSize expect
     ; InlineData(   0,  2, 1, 3, 0)
     ; InlineData(   1,  2, 1, 3, 0)
     ; InlineData(   2,  2, 1, 3, 1)>]
-let ``ofPreviousTokenAndEventsLength - batchCapacityLimit`` (previousCompactionEventNumber : System.Nullable<int>) streamVersion eventsLength batchSize expectedCapacity =
+let ``ofPreviousTokenAndEventsLength - batchCapacityLimit`` (previousCompactionEventNumber: System.Nullable<int>) streamVersion eventsLength batchSize expectedCapacity =
     let previousToken =
         if not previousCompactionEventNumber.HasValue then Token.ofCompactionEventNumber None 0 -84 -42L
         else Token.ofCompactionEventNumber (Some previousCompactionEventNumber.Value) 0 -84 -42L
@@ -45,7 +45,7 @@ let ``ofPreviousTokenAndEventsLength - batchCapacityLimit`` (previousCompactionE
     test <@ Some expectedCapacity = batchCapacityLimit @>
 
 [<Property>]
-let ``Properties of tokens based on various generation mechanisms `` streamVersion (previousCompactionEventNumber : int64 option) eventsLength batchSize =
+let ``Properties of tokens based on various generation mechanisms `` streamVersion (previousCompactionEventNumber: int64 option) eventsLength batchSize =
     let ovStreamVersion, ovCompactionEventNumber, ovBatchCapacityLimit =
         unpack <| Token.ofNonCompacting streamVersion
     let uvStreamVersion, uvCompactionEventNumber, uvBatchCapacityLimit =

--- a/tests/Equinox.EventStore.Integration/Infrastructure.fs
+++ b/tests/Equinox.EventStore.Integration/Infrastructure.fs
@@ -29,12 +29,12 @@ open Equinox.EventStore
 module SerilogHelpers =
     open Serilog.Events
 
-    let (|SerilogScalar|_|) : LogEventPropertyValue -> obj option = function
+    let (|SerilogScalar|_|): LogEventPropertyValue -> obj option = function
         | :? ScalarValue as x -> Some x.Value
         | _ -> None
     [<RequireQualifiedAccess>]
     type EsAct = Append | AppendConflict | SliceForward | SliceBackward | BatchForward | BatchBackward | ReadLast
-    let (|EsAction|) (evt : Log.Metric) =
+    let (|EsAction|) (evt: Log.Metric) =
         match evt with
         | Log.WriteSuccess _ -> EsAct.Append
         | Log.WriteConflict _ -> EsAct.AppendConflict
@@ -50,17 +50,17 @@ module SerilogHelpers =
         | Log.Batch (Direction.Forward,_,_) -> EsAct.BatchForward
         | Log.Batch (Direction.Backward,_,_) -> EsAct.BatchBackward
 #endif
-    let (|EsEvent|_|) (logEvent : LogEvent) : Log.Metric option =
+    let (|EsEvent|_|) (logEvent: LogEvent): Log.Metric option =
         logEvent.Properties.Values |> Seq.tryPick (function
             | SerilogScalar (:? Log.Metric as e) -> Some e
             | _ -> None)
 
-    let (|HasProp|_|) (name : string) (e : LogEvent) : LogEventPropertyValue option =
+    let (|HasProp|_|) (name: string) (e: LogEvent): LogEventPropertyValue option =
         match e.Properties.TryGetValue name with
         | true, (SerilogScalar _ as s) -> Some s
         | _ -> None
-    let (|SerilogString|_|) : LogEventPropertyValue -> string option = function SerilogScalar (:? string as y) -> Some y | _ -> None
-    let (|SerilogBool|_|) : LogEventPropertyValue -> bool option = function SerilogScalar (:? bool as y) -> Some y | _ -> None
+    let (|SerilogString|_|): LogEventPropertyValue -> string option = function SerilogScalar (:? string as y) -> Some y | _ -> None
+    let (|SerilogBool|_|): LogEventPropertyValue -> bool option = function SerilogScalar (:? bool as y) -> Some y | _ -> None
 
 type LogCapture() =
     inherit LogCaptureBuffer()

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -14,7 +14,7 @@ let defaultBatchSize = 500
 open Equinox.SqlStreamStore
 open Equinox.SqlStreamStore.Postgres
 
-let connectToLocalStore (_ : ILogger) =
+let connectToLocalStore (_: ILogger) =
     Connector("Host=localhost;User Id=postgres;password=password;database=EQUINOX_TEST_DB",autoCreate=true).Establish()
 
 type Context = SqlStreamStoreContext
@@ -24,7 +24,7 @@ type Category<'event, 'state, 'context> = SqlStreamStoreCategory<'event, 'state,
 open Equinox.SqlStreamStore
 open Equinox.SqlStreamStore.MsSql
 
-let connectToLocalStore (_ : ILogger) =
+let connectToLocalStore (_: ILogger) =
     Connector("Server=localhost,1433;User=sa;Password=mssql1Ipw;Database=EQUINOX_TEST_DB", autoCreate = true).Establish()
 
 (* WORKAROUND FOR https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719
@@ -37,7 +37,7 @@ type Category<'event, 'state, 'context> = SqlStreamStoreCategory<'event, 'state,
 open Equinox.SqlStreamStore
 open Equinox.SqlStreamStore.MySql
 
-let connectToLocalStore (_ : ILogger) =
+let connectToLocalStore (_: ILogger) =
     Connector(sprintf "Server=localhost;User=root;Database=EQUINOX_TEST_DB",autoCreate=true).Establish()
 
 type Context = SqlStreamStoreContext
@@ -60,7 +60,7 @@ type Category<'event, 'state, 'context> = MessageDbCategory<'event, 'state, 'con
 open Equinox.EventStoreDb
 
 /// Connect directly to a locally running EventStoreDB Node using gRPC, without using Gossip-driven discovery
-let connectToLocalStore (_log : ILogger) = async {
+let connectToLocalStore (_log: ILogger) = async {
     let c = EventStoreConnector(reqTimeout=TimeSpan.FromSeconds 3., reqRetries=3, (*, log=Logger.SerilogVerbose log,*) tags=["I",Guid.NewGuid() |> string])
     let conn = c.Establish("Equinox-integration", Discovery.ConnectionString "esdb://localhost:2111,localhost:2112,localhost:2113?tls=true&tlsVerifyCert=false", ConnectionStrategy.ClusterSingle EventStore.Client.NodePreference.Leader)
     return conn }
@@ -256,7 +256,7 @@ type GeneralTests(testOutputHelper) =
                     do! addAndThenRemoveItemsManyTimesExceptTheLastOne ctx cartId skuId service1 addRemoveCount
                     return Some (skuId, addRemoveCount) }
 
-        let act prepare (service : Cart.Service) log skuId count =
+        let act prepare (service: Cart.Service) log skuId count =
             service.ExecuteManyAsync(cartId, false, prepare = prepare, commands = [Cart.SyncItem (ctx, skuId, Some count, None)])
 
         let eventWaitSet () = let e = new ManualResetEvent(false) in (Async.AwaitWaitHandle e |> Async.Ignore), async { e.Set() |> ignore }
@@ -429,7 +429,7 @@ type GeneralTests(testOutputHelper) =
         let batchSize = 3
         let context = createContext connection batchSize
         let id = Guid.NewGuid()
-        let toStreamId (x : Guid) = x.ToString "N"
+        let toStreamId (x: Guid) = x.ToString "N"
         let decider = SimplestThing.resolve log context SimplestThing.Category (Equinox.StreamId.gen toStreamId id)
 
         let! before, after = decider.TransactEx(
@@ -547,7 +547,7 @@ type RollingSnapshotTests(testOutputHelper) =
         do! addAndThenRemoveItemsManyTimes ctx cartId skuId service1 1
         // and we _could_ reload the 24 events with a single read if reading backwards. However we are using the cache, which last saw it with 10 events, which necessitates two reads
         let! _ = service2.Read cartId
-        let suboptimalExtraSlice : EsAct list = sliceForward
+        let suboptimalExtraSlice: EsAct list = sliceForward
         test <@ singleBatchBackwards @ batchBackwardsAndAppend @ suboptimalExtraSlice @ singleBatchForward = capture.ExternalCalls @>
     }
 #endif

--- a/tools/Equinox.Tools.TestHarness/Aggregate.fs
+++ b/tools/Equinox.Tools.TestHarness/Aggregate.fs
@@ -8,7 +8,7 @@ open System.Reactive.Linq
 open System.Text
 
 type TestResultAggregate with
-    static member FromEventBucket (span : TimeSpan) (bucket : seq<LoadTestEvent>) =
+    static member FromEventBucket (span: TimeSpan) (bucket: seq<LoadTestEvent>) =
         let sessionErrorCount =
             bucket
             |> Seq.choose (function SessionCreationFailed e -> Some e | _ -> None)
@@ -54,10 +54,10 @@ type TestResultAggregate with
             latency = latency
         }
 
-    static member Render(e : Envelope<TestResultAggregate>) =
+    static member Render(e: Envelope<TestResultAggregate>) =
         let sb = new StringBuilder()
 
-        let renderOutcome (sb:StringBuilder) (kvs : OutcomeDistribution) =
+        let renderOutcome (sb:StringBuilder) (kvs: OutcomeDistribution) =
             for k,v in kvs |> Seq.sortBy fst do sb.Appendf " %s=%d" k.Id v
             sb.AppendLine() |> ignore
 
@@ -86,7 +86,7 @@ type TestResultAggregate with
 module Observable =
 
     /// Aggregates a stream of load test events into a stream of bucketed aggregates with given timespan
-    let aggregateLoadTests (bucketSize : TimeSpan) (source : IObservable<Envelope<LoadTestEvent>>) =
+    let aggregateLoadTests (bucketSize: TimeSpan) (source: IObservable<Envelope<LoadTestEvent>>) =
         Observable.Buffer(source, bucketSize)
         |> Observable.filter (fun bucket -> bucket.Count > 0)
         |> Observable.map (fun bucket ->
@@ -96,14 +96,14 @@ module Observable =
         |> Observable.filter (fun agg -> agg.payload.count > 0 || agg.payload.sessionErrors.Length > 0)
 
     /// Logs a stream of aggregates using supplied logger function
-    let logAggregate (log: ILogger) (source : IObservable<Envelope<TestResultAggregate>>) : IDisposable =
+    let logAggregate (log: ILogger) (source: IObservable<Envelope<TestResultAggregate>>): IDisposable =
         source
         |> Observable.map TestResultAggregate.Render
         |> Observable.subscribe (fun r -> log.Information("Aggregate: {result:l}",r))
 
     /// Logs load test events with provided log level
-    let logEvents (log : ILogger) (events : IObservable<Envelope<LoadTestEvent>>) =
-        let eventLogger (e : Envelope<LoadTestEvent>) =
+    let logEvents (log: ILogger) (events: IObservable<Envelope<LoadTestEvent>>) =
+        let eventLogger (e: Envelope<LoadTestEvent>) =
             match e.payload with
             | SessionCreated _ -> ()
             | SingleTestRun _ -> ()

--- a/tools/Equinox.Tools.TestHarness/HttpHelpers.fs
+++ b/tools/Equinox.Tools.TestHarness/HttpHelpers.fs
@@ -23,19 +23,19 @@ type InvalidHttpResponseException =
     inherit Exception
 
     // TODO: include headers
-    val private userMessage : string
-    val private requestMethod : string
-    val RequestUri : Uri
-    val RequestBody : string
-    val StatusCode : HttpStatusCode
-    val ReasonPhrase : string
-    val ResponseBody : string
+    val private userMessage: string
+    val private requestMethod: string
+    val RequestUri: Uri
+    val RequestBody: string
+    val StatusCode: HttpStatusCode
+    val ReasonPhrase: string
+    val ResponseBody: string
 
     member x.RequestMethod = HttpMethod(x.requestMethod)
 
-    private new (userMessage : string, requestMethod : HttpMethod, requestUri : Uri, requestBody : string,
-                   statusCode : HttpStatusCode, reasonPhrase : string, responseBody : string,
-                   ?innerException : exn) =
+    private new (userMessage: string, requestMethod: HttpMethod, requestUri: Uri, requestBody: string,
+                   statusCode: HttpStatusCode, reasonPhrase: string, responseBody: string,
+                   ?innerException: exn) =
         {
             inherit Exception(message = null, innerException = defaultArg innerException null) ; userMessage = userMessage ;
             requestMethod = string requestMethod ; RequestUri = requestUri ; RequestBody = requestBody ;
@@ -50,13 +50,13 @@ type InvalidHttpResponseException =
             sb.Appendfn "ResponseBody=%s" (getBodyString e.ResponseBody))
 
     interface ISerializable with
-        member e.GetObjectData(si : SerializationInfo, sc : StreamingContext) =
+        member e.GetObjectData(si: SerializationInfo, sc: StreamingContext) =
             let add name (value:obj) = si.AddValue(name, value)
             base.GetObjectData(si, sc) ; add "userMessage" e.userMessage ;
             add "requestUri" e.RequestUri ; add "requestMethod" e.requestMethod ; add "requestBody" e.RequestBody
             add "statusCode" e.StatusCode ; add "reasonPhrase" e.ReasonPhrase ; add "responseBody" e.ResponseBody
 
-    new (si : SerializationInfo, sc : StreamingContext) =
+    new (si: SerializationInfo, sc: StreamingContext) =
         let get name = si.GetValue(name, typeof<'a>) :?> 'a
         {
             inherit Exception(si, sc) ; userMessage = get "userMessage" ;
@@ -64,7 +64,7 @@ type InvalidHttpResponseException =
             StatusCode = get "statusCode" ; ReasonPhrase = get "reasonPhrase" ; ResponseBody = get "responseBody"
         }
 
-    static member Create(userMessage : string, response : HttpResponseMessage, ?innerException : exn) = async {
+    static member Create(userMessage: string, response: HttpResponseMessage, ?innerException: exn) = async {
         let request = response.RequestMessage
         let! responseBodyC = response.Content.ReadAsStringDiapered() |> Async.StartChild
         let! requestBody = request.Content.ReadAsStringDiapered()
@@ -76,5 +76,5 @@ type InvalidHttpResponseException =
                 ?innerException = innerException)
     }
 
-    static member Create(response : HttpResponseMessage, ?innerException : exn) =
+    static member Create(response: HttpResponseMessage, ?innerException: exn) =
         InvalidHttpResponseException.Create("HTTP request yielded unexpected response.", response, ?innerException = innerException)

--- a/tools/Equinox.Tools.TestHarness/Infrastructure.fs
+++ b/tools/Equinox.Tools.TestHarness/Infrastructure.fs
@@ -6,8 +6,8 @@ open System.Diagnostics
 open System.Text
 
 /// Extracts the innermost exception if defined
-let (|InnermostExn|) (exn : exn) =
-    let rec aux (e : exn) =
+let (|InnermostExn|) (exn: exn) =
+    let rec aux (e: exn) =
         match e with
         | :? AggregateException as agg when agg.InnerExceptions.Count > 1 -> e
         | _ ->
@@ -26,9 +26,9 @@ type Async with
     /// </summary>
     /// <param name="task">Task to be awaited.</param>
     [<DebuggerStepThrough>]
-    static member AwaitTaskCorrect(task : System.Threading.Tasks.Task<'T>) : Async<'T> =
+    static member AwaitTaskCorrect(task: System.Threading.Tasks.Task<'T>): Async<'T> =
         Async.FromContinuations(fun (sc,ec,_) ->
-            task.ContinueWith(fun (t : System.Threading.Tasks.Task<'T>) ->
+            task.ContinueWith(fun (t: System.Threading.Tasks.Task<'T>) ->
                 if t.IsFaulted then
                     let e = t.Exception
                     if e.InnerExceptions.Count = 1 then ec e.InnerExceptions[0]
@@ -37,9 +37,9 @@ type Async with
                 else sc t.Result)
             |> ignore)
     [<DebuggerStepThrough>]
-    static member AwaitTaskCorrect(task : System.Threading.Tasks.Task) : Async<unit> =
+    static member AwaitTaskCorrect(task: System.Threading.Tasks.Task): Async<unit> =
         Async.FromContinuations(fun (sc,ec,_) ->
-            task.ContinueWith(fun (task : System.Threading.Tasks.Task) ->
+            task.ContinueWith(fun (task: System.Threading.Tasks.Task) ->
                 if task.IsFaulted then
                     let e = task.Exception
                     if e.InnerExceptions.Count = 1 then ec e.InnerExceptions[0]
@@ -50,7 +50,7 @@ type Async with
                     sc ())
             |> ignore)
 
-    static member map (f:'a -> 'b) (a:Async<'a>) : Async<'b> = async.Bind(a, f >> async.Return)
+    static member map (f:'a -> 'b) (a:Async<'a>): Async<'b> = async.Bind(a, f >> async.Return)
     static member choose a b = async {
         let! result = Async.Choice [|Async.map Some a ; Async.map Some b |]
         return Option.get result
@@ -61,7 +61,7 @@ type StringBuilder with
     member sb.Appendf fmt = Printf.ksprintf (ignore << sb.Append) fmt
     member sb.Appendfn fmt = Printf.ksprintf (ignore << sb.AppendLine) fmt
 
-    static member inline Build(builder : StringBuilder -> unit) =
+    static member inline Build(builder: StringBuilder -> unit) =
         let instance = StringBuilder() // TOCONSIDER PooledStringBuilder.GetInstance()
         builder instance
         instance.ToString()

--- a/tools/Equinox.Tools.TestHarness/Types.fs
+++ b/tools/Equinox.Tools.TestHarness/Types.fs
@@ -8,7 +8,7 @@ open HttpHelpers
 
 /// Generic message envelope
 [<NoEquality; NoComparison>]
-type Envelope<'T> = { payload : 'T ; timestamp : DateTimeOffset ; hostname : string }
+type Envelope<'T> = { payload: 'T; timestamp: DateTimeOffset; hostname: string }
 
 /// Load Test outcome classification
 type LoadTestOutcomeType =
@@ -23,7 +23,7 @@ type LoadTestOutcomeType =
         | InvalidHttpResponse s -> sprintf "HttpStatusCode.%O" s
         | OtherError e -> e
 
-    static member FromException(e : exn) =
+    static member FromException(e: exn) =
         match e with
         | InnermostExn (:? TimeoutException | :? TaskCanceledException) -> Timeout
         | InnermostExn (:? InvalidHttpResponseException as e) -> InvalidHttpResponse e.StatusCode

--- a/tools/Equinox.Tools.TestHarness/Types.fs
+++ b/tools/Equinox.Tools.TestHarness/Types.fs
@@ -73,7 +73,7 @@ type LoadTestEvent =
     | SingleTestRun of info:TestRunInfo
     | LoadTestCompleting of reason:string option
     | LoadTestCompleted
-    static member IsErrorEvent (e : LoadTestEvent) =
+    static member IsErrorEvent (e: LoadTestEvent) =
         match e with
         | SessionCreationFailed _ -> true
         | SingleTestRun { error = Some _ } -> true


### PR DESCRIPTION
Docs tweaks originally doe in #380:
- Version clarifications, prompted by @epNickColeman 
- Some obvious DDB terms, are there any missing?
Code cleanup:
- whitespace changes: ` :` -> `:` in declarations per F# style guide
- `array` -> `[]` per F# style guide
- `log` arg first
- remove some redundant tuples
- handle `Written` case of DUs first