### PR TITLE
MessageDB: remove TaskSeq dep

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,18 +15,6 @@ services:
       - "8081:8081" # so docker-cosmos-init.sh can get the cert and/or humans can use https://localhost:8081/_explorer/index.html
       - "10250-10256:10250-10256" # tests connect using Direct mode
 
-  equinox-postgres:
-    container_name: equinox-postgres
-    image: postgres
-    restart: unless-stopped
-    environment:
-      - PG_TRUST_LOCALNET=true
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=password
-      - POSTGRES_DB=EQUINOX_TEST_DB
-    ports:
-      - "5432:5432"
-
   # NOTE MANUAL STEP until MS get with the program https://github.com/microsoft/mssql-docker/issues/2#issuecomment-1059819719
   #      after `docker compose up`, run `bash docker-compose-mssql.sh`
   equinox-mssql:
@@ -179,7 +167,7 @@ services:
   equinox-messagedb:
     image: ethangarofolo/message-db
     ports:
-      - "5433:5432"
+      - "5432:5432"
 
 networks:
   clusternetwork:

--- a/src/Equinox.Core/Infrastructure.fs
+++ b/src/Equinox.Core/Infrastructure.fs
@@ -51,6 +51,9 @@ type Async with
                     sc ())
             |> ignore)
 
+module Async =
+    let inline startImmediateAsTask ct computation = Async.StartImmediateAsTask(computation, ct)
+
 module ValueTuple =
 
     let inline fst struct (f, _s) = f

--- a/src/Equinox.Core/Internal.fs
+++ b/src/Equinox.Core/Internal.fs
@@ -12,6 +12,7 @@ module Log =
         | :? Serilog.Events.ScalarValue as x -> ValueSome x.Value
         | _ -> ValueNone
 
+#if !NO_TASK_SEQ
 module TaskSeq =
 
     open FSharp.Control
@@ -43,3 +44,4 @@ module TaskSeq =
             else
                 go <- false
     }
+#endif

--- a/src/Equinox.MessageDb/Equinox.MessageDb.fsproj
+++ b/src/Equinox.MessageDb/Equinox.MessageDb.fsproj
@@ -23,7 +23,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FSharp.Control.AsyncSeq" Version="3.2.1" />
         <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
         <PackageReference Include="FSharp.Core" Version="6.0.7" />
         <PackageReference Include="FsCodec" Version="3.0.0-rc.9.6" />

--- a/src/Equinox.MessageDb/Equinox.MessageDb.fsproj
+++ b/src/Equinox.MessageDb/Equinox.MessageDb.fsproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <DefineConstants>NO_TASK_SEQ</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup>
@@ -22,9 +23,9 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="FSharp.Control.AsyncSeq" Version="3.2.1" />
         <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
         <PackageReference Include="FSharp.Core" Version="6.0.7" />
-        <PackageReference Include="FSharp.Control.TaskSeq" Version="0.3.0" />
         <PackageReference Include="FsCodec" Version="3.0.0-rc.9.6" />
         <PackageReference Include="Npgsql" Version="7.0.0" />
     </ItemGroup>

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -214,8 +214,7 @@ module Read =
             if not slice.IsEnd then
               batchCount <- batchCount + 1
               pos <- slice.LastVersion  + 1L
-              do! loop ()
-        }
+              do! loop () }
 
         do! loop ()
         return version, Array.ofSeq result }

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -196,8 +196,8 @@ module Read =
             "Read", count, slice.LastVersion)
         return slice }
 
-    let private readBatches (log : ILogger) batchSize (readSlice : int64 -> int -> ILogger -> CancellationToken -> Task<StreamEventsSlice>)
-            (maxPermittedBatchReads : int option) (startPosition : int64) ct
+    let private readBatches (log: ILogger) batchSize (readSlice: int64 -> int -> ILogger -> CancellationToken -> Task<StreamEventsSlice>)
+            (maxPermittedBatchReads: int option) (startPosition: int64) ct
         : Task<int64 * ITimelineEvent<EventBody>[]> = task {
         let mutable batchCount, pos = 0, startPosition
         let mutable version = -1L

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -212,9 +212,9 @@ module Read =
             version <- max version slice.LastVersion
             result.AddRange(slice.Messages)
             if not slice.IsEnd then
-              batchCount <- batchCount + 1
-              pos <- slice.LastVersion  + 1L
-              do! loop () }
+                batchCount <- batchCount + 1
+                pos <- slice.LastVersion  + 1L
+                do! loop () }
 
         do! loop ()
         return version, Array.ofSeq result }

--- a/tests/Equinox.EventStore.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStore.Integration/StoreIntegration.fs
@@ -15,7 +15,7 @@ open Equinox.SqlStreamStore
 open Equinox.SqlStreamStore.Postgres
 
 let connectToLocalStore (_: ILogger) =
-    Connector("Host=localhost;User Id=postgres;password=password;database=EQUINOX_TEST_DB",autoCreate=true).Establish()
+    Connector("Host=localhost;Username=postgres;password=postgres;database=postgres",autoCreate=true).Establish()
 
 type Context = SqlStreamStoreContext
 type Category<'event, 'state, 'context> = SqlStreamStoreCategory<'event, 'state, 'context>
@@ -50,7 +50,7 @@ open OpenTelemetry.Trace
 open OpenTelemetry.Resources
 
 let connectToLocalStore _ = async {
-  let connectionString = "Host=localhost; Username=message_store; Password=; Database=message_store; Port=5433; Maximum Pool Size=10"
+  let connectionString = "Host=localhost; Username=message_store; Password=; Database=message_store; Port=5432; Maximum Pool Size=10"
   return MessageDbClient(connectionString)
 }
 type Context = MessageDbContext


### PR DESCRIPTION
It's simply not justifiable to have a dependency on the library for this one little thing that doesn't benefit from it 😅 