### PR TITLE
MessageDb: cleanup trace spans hierarchy

### DIFF
--- a/src/Equinox.Core/Caching.fs
+++ b/src/Equinox.Core/Caching.fs
@@ -7,62 +7,52 @@ open System.Diagnostics
 open System.Threading
 open System.Threading.Tasks
 
-type IReloadableCategory<'event, 'state, 'context> =
-    inherit ICategory<'event, 'state, 'context>
-
+type IReloadable<'state> =
     abstract Reload: log: ILogger * streamName: string * requireLeader: bool * streamToken: StreamToken * state: 'state * ct: CancellationToken
                      -> Task<struct (StreamToken * 'state)>
 
-type private Decorator<'event, 'state, 'context>
-    (   category: IReloadableCategory<'event, 'state, 'context>,
-        tryReadCache: string -> Task<voption<struct (StreamToken * 'state)>>,
-        updateCache: string -> struct (StreamToken * 'state) -> Task<unit>) =
-    let cache streamName (inner: CancellationToken -> Task<struct (StreamToken * 'state)>) ct = task {
+type private Decorator<'event, 'state, 'context, 'cat when 'cat :> ICategory<'event, 'state, 'context> and 'cat :> IReloadable<'state> >
+    (category: 'cat, tryGet, updateCache: string -> struct (StreamToken * 'state) -> Task<unit>) =
+    let tryRead key = task {
+        let! cacheItem = tryGet key
+        let act = Activity.Current
+        if act <> null then act.AddCacheHit(ValueOption.isSome cacheItem) |> ignore
+        return cacheItem }
+    let save streamName (inner: CancellationToken -> Task<struct (StreamToken * 'state)>) ct = task {
         let! tokenAndState = inner ct
         do! updateCache streamName tokenAndState
         return tokenAndState }
     interface ICategory<'event, 'state, 'context> with
         member _.Load(log, categoryName, streamId, streamName, allowStale, requireLeader, ct) = task {
-            match! tryReadCache streamName with
-            | ValueNone -> return! cache streamName (fun ct -> category.Load(log, categoryName, streamId, streamName, allowStale, requireLeader, ct)) ct
+            match! tryRead streamName with
+            | ValueNone -> return! save streamName (fun ct -> category.Load(log, categoryName, streamId, streamName, allowStale, requireLeader, ct)) ct
             | ValueSome tokenAndState when allowStale -> return tokenAndState // read already updated TTL, no need to write
-            | ValueSome (token, state) -> return! cache streamName (fun ct -> category.Reload(log, streamName, requireLeader, token, state, ct)) ct }
-        member _.TrySync(log: ILogger, categoryName, streamId, streamName, context, maybeInit, streamToken, state, events, ct) = task {
+            | ValueSome (token, state) -> return! save streamName (fun ct -> category.Reload(log, streamName, requireLeader, token, state, ct)) ct }
+        member _.TrySync(log, categoryName, streamId, streamName, context, maybeInit, streamToken, state, events, ct) = task {
             match! category.TrySync(log, categoryName, streamId, streamName, context, maybeInit, streamToken, state, events, ct) with
             | SyncResult.Written tokenAndState' ->
                 do! updateCache streamName tokenAndState'
                 return SyncResult.Written tokenAndState'
             | SyncResult.Conflict resync ->
-                return SyncResult.Conflict (cache streamName resync) }
+                return SyncResult.Conflict (save streamName resync) }
 
-let private updateWithSlidingExpiration (cache: ICache, prefix: string) (slidingExpiration: TimeSpan) supersedes =
-    let mkCacheEntry struct (initialToken: StreamToken, initialState: 'state) = CacheEntry<'state>(initialToken, initialState)
+let private mkCacheEntry struct (initialToken: StreamToken, initialState: 'state) = CacheEntry<'state>(initialToken, initialState)
+let private updateWithSlidingExpiration (cache: ICache) (prefix: string) supersedes (slidingExpiration: TimeSpan) streamName value =
     let options = CacheItemOptions.RelativeExpiration slidingExpiration
-    fun streamName value ->
-        cache.UpdateIfNewer(prefix + streamName, options, supersedes, mkCacheEntry value)
+    cache.UpdateIfNewer(prefix + streamName, options, supersedes, mkCacheEntry value)
+let private updateWithFixedTimeSpan (cache: ICache) (prefix: string) supersedes (period: TimeSpan) streamName value =
+    let expirationPoint = let creationDate = DateTimeOffset.UtcNow in creationDate.Add period
+    let options = CacheItemOptions.AbsoluteExpiration expirationPoint
+    cache.UpdateIfNewer(prefix + streamName, options, supersedes, mkCacheEntry value)
 
-let private updateWithFixedTimeSpan (cache: ICache, prefix: string) (period: TimeSpan) supersedes =
-    let mkCacheEntry struct (initialToken: StreamToken, initialState: 'state) = CacheEntry<'state>(initialToken, initialState)
-    fun streamName value ->
-        let expirationPoint = let creationDate = DateTimeOffset.UtcNow in creationDate.Add period
-        let options = CacheItemOptions.AbsoluteExpiration expirationPoint
-        cache.UpdateIfNewer(prefix + streamName, options, supersedes, mkCacheEntry value)
+let private fixed_ cache supersedes period = struct (cache, updateWithFixedTimeSpan cache null supersedes period)
+let private sliding cache prefix supersedes window = struct (cache, updateWithSlidingExpiration cache prefix supersedes window)
+let private mapStrategy supersedes = function
+    | Equinox.CachingStrategy.FixedTimeSpan (cache, period) -> fixed_ cache supersedes period
+    | Equinox.CachingStrategy.SlidingWindow (cache, window) -> sliding cache null supersedes window
+    | Equinox.CachingStrategy.SlidingWindowPrefixed (cache, window, prefix) -> sliding cache prefix supersedes window
 
-let private decorate x supersedes (cat: IReloadableCategory<_, _, _>): ICategory<_, _, _> =
-    let tryGet (cache: ICache) key = task {
-        let! cacheItem = cache.TryGet key
-        let act = Activity.Current
-        if act <> null then act.AddCacheHit(ValueOption.isSome cacheItem) |> ignore
-        return cacheItem }
-    let dec (cache: ICache) upd = Decorator(cat, tryGet cache, upd)
-    let sliding cache window  prefix = dec cache (updateWithSlidingExpiration (cache, prefix) window supersedes)
-    let fixed_ cache period = dec cache (updateWithFixedTimeSpan (cache, null) period supersedes)
-    match x with
-    | Equinox.CachingStrategy.SlidingWindow (cache, window) -> sliding cache window null
-    | Equinox.CachingStrategy.FixedTimeSpan (cache, period) -> fixed_ cache period
-    | Equinox.CachingStrategy.SlidingWindowPrefixed (cache, window, prefix) -> sliding cache window prefix
-
-let apply supersedes x (cat: IReloadableCategory<_, _, _>): ICategory<_, _, _> =
+let apply supersedes x (cat: 'cat when 'cat :> ICategory<'event, 'state, 'context> and 'cat :> IReloadable<'state>): ICategory<_, _, _> =
     match x with
     | None -> cat
-    | Some x -> decorate x supersedes cat
+    | Some x -> let struct (cache, upd) = mapStrategy supersedes x in Decorator(cat, cache.TryGet, upd)

--- a/src/Equinox.EventStoreDb/EventStoreDb.fs
+++ b/src/Equinox.EventStoreDb/EventStoreDb.fs
@@ -401,11 +401,10 @@ type private Category<'event, 'state, 'context>(context: EventStoreContext, code
         | Some (AccessStrategy.RollingSnapshots (isValid, _)) -> Some isValid
     let fetch state f = task { let! struct (token', events) = f in return struct (token', fold state (Seq.ofArray events)) }
     let reload (log, sn, leader, token, state) ct = fetch state (context.Reload(log, sn, leader, token, tryDecode, compactionPredicate, ct))
-    interface Caching.IReloadableCategory<'event, 'state, 'context> with
+    interface Caching.IReloadable<'state> with member _.Reload(log, sn, leader, token, state, ct) = reload (log, sn, leader, token, state) ct
+    interface ICategory<'event, 'state, 'context> with
         member _.Load(log, _categoryName, _streamId, streamName, _allowStale, requireLeader, ct) =
             fetch initial (loadAlgorithm log streamName requireLeader ct)
-        member _.Reload(log, streamName, requireLeader, streamToken, state, ct) =
-            reload (log, streamName, requireLeader, streamToken, state) ct
         member _.TrySync(log, _categoryName, _streamId, streamName, ctx, _maybeInit, (Token.Unpack token as streamToken), state, events, ct) = task {
             let events =
                 match access with

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -154,10 +154,8 @@ module private Write =
         (resultLog |> Log.event evt).Information("Mdb{action:l} count={count} conflict={conflict}",
                                                  "Write", count, match evt with Log.WriteConflict _ -> true | _ -> false)
         return result }
-    let writeEvents log retryPolicy writer (category, streamId, streamName) version events ct: Task<MdbSyncResult> = task {
-        let act = Activity.Current
-        if act <> null then act.AddStream(category, streamId, streamName) |> ignore
-        let call = writeEventsLogged writer streamName version events act
+    let writeEvents log retryPolicy writer (_category, _streamId, streamName) version events ct: Task<MdbSyncResult> = task {
+        let call = writeEventsLogged writer streamName version events Activity.Current
         return! Log.withLoggedRetries retryPolicy "writeAttempt" call log ct }
 
 module Read =

--- a/src/Equinox.MessageDb/Tracing.fs
+++ b/src/Equinox.MessageDb/Tracing.fs
@@ -32,3 +32,7 @@ type ActivityExtensions =
     [<System.Runtime.CompilerServices.Extension>]
     static member AddLoadMethod(act: Activity, method: string) =
         act.AddTag("eqx.load_method", method)
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member RecordConflict(act: Activity) =
+        act.AddTag("eqx.conflict", true).SetStatus(ActivityStatusCode.Error, "WrongExpectedVersion")

--- a/src/Equinox.MessageDb/Tracing.fs
+++ b/src/Equinox.MessageDb/Tracing.fs
@@ -1,7 +1,6 @@
 [<AutoOpen>]
 module internal Equinox.MessageDb.Tracing
 
-open Equinox.Core.Tracing
 open System.Diagnostics
 open Equinox.MessageDb.Core
 

--- a/src/Equinox.MessageDb/Tracing.fs
+++ b/src/Equinox.MessageDb/Tracing.fs
@@ -11,15 +11,6 @@ let source = new ActivitySource("Equinox.MessageDb")
 type ActivityExtensions =
 
     [<System.Runtime.CompilerServices.Extension>]
-    static member AddStreamFromParent(act: Activity, parent: Activity) =
-        if parent <> null then
-            let streamName = parent.GetTagItem("eqx.stream_name") |> unbox<string>
-            let streamId = parent.GetTagItem("eqx.stream_id") |> unbox<string>
-            let category = parent.GetTagItem("eqx.category") |> unbox<string>
-            act.AddStream(streamName, streamId, category) |> ignore
-        act
-
-    [<System.Runtime.CompilerServices.Extension>]
     static member AddExpectedVersion(act: Activity, version) =
         match version with StreamVersion v -> act.AddTag("eqx.expected_version", v) | Any -> act
 
@@ -32,10 +23,6 @@ type ActivityExtensions =
         act.AddTag("eqx.batch_size", size)
 
     [<System.Runtime.CompilerServices.Extension>]
-    static member AddBatch(act: Activity, size: int64, index: int) =
-        act.AddBatchSize(size).AddTag("eqx.batch_index", index)
-
-    [<System.Runtime.CompilerServices.Extension>]
     static member AddBatches(act: Activity, batches: int) =
         act.AddTag("eqx.batches", batches)
 
@@ -44,13 +31,5 @@ type ActivityExtensions =
         act.AddTag("eqx.start_position", pos)
 
     [<System.Runtime.CompilerServices.Extension>]
-    static member AddStale(act: Activity, allowStale: bool) =
-        act.AddTag("eqx.allow_stale", allowStale)
-
-    [<System.Runtime.CompilerServices.Extension>]
     static member AddLoadMethod(act: Activity, method: string) =
         act.AddTag("eqx.load_method", method)
-
-    [<System.Runtime.CompilerServices.Extension>]
-    static member RecordConflict(act: Activity) =
-        act.AddTag("eqx.conflict", true).SetStatus(ActivityStatusCode.Error, "WrongExpectedVersion")


### PR DESCRIPTION
<img width="882" alt="Screenshot 2023-05-15 at 23 08 42" src="https://github.com/jet/equinox/assets/3721521/d37c45a1-2730-4007-8377-fd42c75bdf7b">

It's bothering me that we essentially create three spans to represent a single operation. With this change I'm hoping to bring it down to 2, relying on the Npgsql instrumentation to see what is actually going on in the database