### PR TITLE
Update TaskSeq to 0.4.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `CosmosStore.AccessStrategy.MultiSnapshot`,`Custom`: Change `list` and `seq` types to `array` [#338](https://github.com/jet/equinox/pull/338)
 - `EventStore`: Target `EventStore.Client` v `22.0.0-preview`; rename `Connector` -> `EventStoreConnector` [#317](https://github.com/jet/equinox/pull/317)
 - `Equinox.Tool`/`samples/`: switched to use `Equinox.EventStoreDb` [#196](https://github.com/jet/equinox/pull/196)
-- Replace `AsyncSeq` usage with `FSharp.Control.TaskSeq` v `0.3.0` [#361](https://github.com/jet/equinox/pull/361)
+- Replace `AsyncSeq` usage with `FSharp.Control.TaskSeq` v `0.4.0` [#361](https://github.com/jet/equinox/pull/361)
 - Raise `FSharp.Core` requirement to `6.0.7` [#337](https://github.com/jet/equinox/pull/337) [#33](https://github.com/jet/equinox/pull/362)
 - Update all Stores to use `FsCodec` v `3.0.0`, with [`EventBody` types switching from `byte[]` to `ReadOnlyMemory<byte>` and/or `JsonElement` see FsCodec#75](https://github.com/jet/FsCodec/pull/75) [#323](https://github.com/jet/equinox/pull/323)
 - Update all non-Client dependencies except `FSharp.Core`, `FSharp.Control.AsyncSeq` [#310](https://github.com/jet/equinox/pull/310)

--- a/src/Equinox.Core/Internal.fs
+++ b/src/Equinox.Core/Internal.fs
@@ -11,37 +11,3 @@ module Log =
     let [<return: Struct>] (|ScalarValue|_|): Serilog.Events.LogEventPropertyValue -> obj voption = function
         | :? Serilog.Events.ScalarValue as x -> ValueSome x.Value
         | _ -> ValueNone
-
-#if !NO_TASK_SEQ
-module TaskSeq =
-
-    open FSharp.Control
-
-    let takeWhile predicate (source: taskSeq<_>) = taskSeq {
-        use e = source.GetAsyncEnumerator(System.Threading.CancellationToken())
-        let! step = e.MoveNextAsync()
-        let mutable go = step
-        while go do
-            let value = e.Current
-            if predicate value then
-                yield value
-                let! more = e.MoveNextAsync()
-                go <- more
-            else
-                go <- false
-    }
-
-    let takeWhileInclusive predicate (source: taskSeq<_>) = taskSeq {
-        use e = source.GetAsyncEnumerator(System.Threading.CancellationToken())
-        let! step = e.MoveNextAsync()
-        let mutable go = step
-        while go do
-            let value = e.Current
-            yield value
-            if predicate value then
-                let! more = e.MoveNextAsync()
-                go <- more
-            else
-                go <- false
-    }
-#endif

--- a/src/Equinox.CosmosStore/Equinox.CosmosStore.fsproj
+++ b/src/Equinox.CosmosStore/Equinox.CosmosStore.fsproj
@@ -21,7 +21,7 @@
     <PackageReference Include="FSharp.Core" Version="6.0.7" />
 
     <PackageReference Include="FsCodec" Version="3.0.0-rc.10" />
-    <PackageReference Include="FSharp.Control.TaskSeq" Version="0.3.0" />
+    <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0-alpha.1" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.30.1" />
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
   </ItemGroup>

--- a/src/Equinox.DynamoStore/Equinox.DynamoStore.fsproj
+++ b/src/Equinox.DynamoStore/Equinox.DynamoStore.fsproj
@@ -21,7 +21,7 @@
 
     <PackageReference Include="FsCodec" Version="3.0.0-rc.10" />
     <PackageReference Include="FSharp.AWS.DynamoDB" Version="0.11.2-beta" />
-    <PackageReference Include="FSharp.Control.TaskSeq" Version="0.3.0" />
+    <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0-alpha.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Equinox.EventStore/Equinox.EventStore.fsproj
+++ b/src/Equinox.EventStore/Equinox.EventStore.fsproj
@@ -21,7 +21,7 @@
 
     <PackageReference Include="EventStore.Client" Version="22.0.0-preview" />
     <PackageReference Include="FsCodec" Version="3.0.0-rc.10" />
-    <PackageReference Include="FSharp.Control.TaskSeq" Version="0.3.0" />
+    <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0-alpha.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Equinox.EventStoreDb/Equinox.EventStoreDb.fsproj
+++ b/src/Equinox.EventStoreDb/Equinox.EventStoreDb.fsproj
@@ -21,7 +21,7 @@
 
     <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
     <PackageReference Include="FsCodec" Version="3.0.0-rc.10" />
-    <PackageReference Include="FSharp.Control.TaskSeq" Version="0.3.0" />
+    <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0-alpha.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Equinox.MessageDb/Equinox.MessageDb.fsproj
+++ b/src/Equinox.MessageDb/Equinox.MessageDb.fsproj
@@ -2,8 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <DefineConstants>NO_TASK_SEQ</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Equinox.SqlStreamStore/Equinox.SqlStreamStore.fsproj
+++ b/src/Equinox.SqlStreamStore/Equinox.SqlStreamStore.fsproj
@@ -20,7 +20,7 @@
     <PackageReference Include="FSharp.Core" Version="6.0.7" />
 
     <PackageReference Include="FsCodec" Version="3.0.0-rc.10" />
-    <PackageReference Include="FSharp.Control.TaskSeq" Version="0.3.0" />
+    <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0-alpha.1" />
     <PackageReference Include="SqlStreamStore" Version="1.2.0-beta.8" />
   </ItemGroup>
 


### PR DESCRIPTION
- means we can remove shim versions of `takeWhile` etc in favor of the official version (0.4.0 release line)
- means `try`/`finally` and `use`/`use!` no longer leak (originally planned as 0.3.1, now rolled into 0.4.0)