### PR TITLE
Async cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `CosmosStore.AccessStrategy.MultiSnapshot`,`Custom`: Change `list` and `seq` types to `array` [#338](https://github.com/jet/equinox/pull/338)
 - `EventStore`: Target `EventStore.Client` v `22.0.0-preview`; rename `Connector` -> `EventStoreConnector` [#317](https://github.com/jet/equinox/pull/317)
 - `Equinox.Tool`/`samples/`: switched to use `Equinox.EventStoreDb` [#196](https://github.com/jet/equinox/pull/196)
-- Replace `AsyncSeq` usage with `FSharp.Control.TaskSeq` v `0.4.0` [#361](https://github.com/jet/equinox/pull/361)
+- Replace `AsyncSeq` usage with `FSharp.Control.TaskSeq` v `0.4.0` [#361](https://github.com/jet/equinox/pull/361) [#391](https://github.com/jet/equinox/pull/391)
 - Raise `FSharp.Core` requirement to `6.0.7` [#337](https://github.com/jet/equinox/pull/337) [#33](https://github.com/jet/equinox/pull/362)
 - Update all Stores to use `FsCodec` v `3.0.0`, with [`EventBody` types switching from `byte[]` to `ReadOnlyMemory<byte>` and/or `JsonElement` see FsCodec#75](https://github.com/jet/FsCodec/pull/75) [#323](https://github.com/jet/equinox/pull/323)
 - Update all non-Client dependencies except `FSharp.Core`, `FSharp.Control.AsyncSeq` [#310](https://github.com/jet/equinox/pull/310)

--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ _If you're looking to learn more about and/or discuss Event Sourcing and it's my
   - `Box.Codec`: lightweight [non-serializing substitute equivalent to `NewtonsoftJson.Codec` for use in unit and integration tests](https://github.com/jet/FsCodec#boxcodec)
   - `Codec`: an explicitly coded pair of `encode` and `tryDecode` functions for when you need to customize
 - Caching using the .NET `MemoryCache` to:
-  - Minimize round trips (pluggable via [`ICache`](https://github.com/jet/equinox/blob/master/src/Equinox.Core/Cache.fs#L22) :pray: [@DSilence](https://github.com/jet/equinox/pull/161)
-  - Minimize latency and bandwidth / Request Charges by maintaining the folded state, without making the Domain Model folded state serializable
+  - Minimize round trips; consistent implementation across stores :pray: [@DSilence](https://github.com/jet/equinox/pull/161)
+  - Minimize latency and bandwidth / Request Charges by maintaining the folded state, without needing the Domain Model folded state to be serializable
+  - Enable read through caching, coalescing concurrent reads via opt-in `LoadOption.AllowStale`
 - Mature and comprehensive logging (using [Serilog](https://github.com/serilog/serilog) internally), with optimal performance and pluggable integration with your apps hosting context (we ourselves typically feed log info to Splunk and the metrics embedded in the `Serilog.Events.LogEvent` Properties to Prometheus; see relevant tests for examples)
 - OpenTelemetry Integration (presently only implemented in `Equinox.Core` and `Equinox.MessageDb` ... `#help-wanted`)
 - **`Equinox.EventStore`, `Equinox.SqlStreamStore`: In-stream Rolling Snapshots**:

--- a/diagrams/container.puml
+++ b/diagrams/container.puml
@@ -38,7 +38,7 @@ frame "Consistent Event Stores" as stores <<Expanded>> {
     interface IStream <<Component>>
     rectangle "Equinox.Core" as core <<External>> {
         rectangle "System.MemoryCache" <<External Container>>
-        interface ICache <<Component>>
+        interface Cache <<Component>>
     }
     frame "SqlStreamStore" as ssss <<Internal>> {
         rectangle "Equinox.SqlStreamStore.MsSql" <<Component>> as ssm
@@ -78,13 +78,13 @@ publishers <--  cr         : can feed from
 publishers <--  er         : can feed from
 
 ms           .> IStream    : implements
-es           -> ICache
+es           -> Cache
 es           .> IStream    : implements
 es           -> esc
-cs          --> ICache
+cs          --> Cache
 cs           .> IStream    : implements
 cs          <-> cc
-sss          -> ICache
+sss          -> Cache
 sss          .> IStream    : implements
 
 ssm          -> sss        : is a

--- a/src/Equinox.Core/AsyncCacheCell.fs
+++ b/src/Equinox.Core/AsyncCacheCell.fs
@@ -1,5 +1,6 @@
 namespace Equinox.Core
 
+open System
 open System.Threading
 open System.Threading.Tasks
 
@@ -31,7 +32,7 @@ type AsyncLazy<'T>(workflow: unit -> Task<'T>) =
     member _.Await() = workflow.Value
 
     /// Singleton Empty value
-    static member val Empty = AsyncLazy(fun () -> Task.FromException<'T>(System.InvalidOperationException "Uninitialized AsyncLazy"))
+    static member val Empty = AsyncLazy(fun () -> Task.FromException<'T>(InvalidOperationException "Uninitialized AsyncLazy"))
 
 /// Generic async lazy caching implementation that admits expiration/recomputation/retry on exception semantics.
 /// If `workflow` fails, all readers entering while the load/refresh is in progress will share the failure

--- a/src/Equinox.Core/Cache.fs
+++ b/src/Equinox.Core/Cache.fs
@@ -3,6 +3,7 @@ namespace Equinox
 open Equinox.Core
 open Equinox.Core.Tracing
 open System
+open System.Threading
 
 type private CacheEntry<'state>(initialToken: StreamToken, initialState: 'state, initialTimestamp: int64) =
     let mutable currentToken = initialToken

--- a/src/Equinox.Core/Equinox.Core.fsproj
+++ b/src/Equinox.Core/Equinox.Core.fsproj
@@ -8,10 +8,10 @@
     <Compile Include="Tracing.fs" />
     <Compile Include="Category.fs" />
     <Compile Include="StopwatchInterval.fs" />
+    <Compile Include="Infrastructure.fs" />
     <Compile Include="AsyncCacheCell.fs" />
     <Compile Include="Cache.fs" />
     <Compile Include="Caching.fs" />
-    <Compile Include="Infrastructure.fs" />
     <Compile Include="Retry.fs" />
     <Compile Include="AsyncBatchingGate.fs" />
   </ItemGroup>

--- a/src/Equinox.Core/Infrastructure.fs
+++ b/src/Equinox.Core/Infrastructure.fs
@@ -54,6 +54,9 @@ type Async with
 module Async =
 
     let inline startImmediateAsTask ct computation = Async.StartImmediateAsTask(computation, ct)
+    let inline call (f : System.Threading.CancellationToken -> Task<'T>) = async {
+        let! ct = Async.CancellationToken
+        return! f ct |> Async.AwaitTaskCorrect }
 
 module ValueTuple =
 

--- a/src/Equinox.EventStoreDb/EventStoreDb.fs
+++ b/src/Equinox.EventStoreDb/EventStoreDb.fs
@@ -1,10 +1,10 @@
 ﻿namespace Equinox.EventStoreDb
 
-open System.Threading
 open Equinox.Core
 open EventStore.Client
 open Serilog
 open System
+open System.Threading
 open System.Threading.Tasks
 
 type EventBody = ReadOnlyMemory<byte>
@@ -227,7 +227,7 @@ module ClientCodec =
 
     let timelineEvent (x: EventRecord): FsCodec.ITimelineEvent<EventBody> =
         // TOCONSIDER wire e.Metadata["$correlationId"] and ["$causationId"] into correlationId and causationId
-        // https://eventstore.org/docs/server/metadata-and-reserved-names/index.html#event-metadata
+        // https://developers.eventstore.com/server/v21.10/streams.html#reserved-names
         let n, eu, ts = x.EventNumber, x.EventId, DateTimeOffset x.Created
         let et, data, meta = x.EventType, x.Data, x.Metadata
         let size = et.Length + data.Length + meta.Length
@@ -237,7 +237,7 @@ module ClientCodec =
 
     let eventData (x: FsCodec.IEventData<EventBody>) =
         // TOCONSIDER wire x.CorrelationId, x.CausationId into x.Meta.["$correlationId"] and .["$causationId"]
-        // https://eventstore.org/docs/server/metadata-and-reserved-names/index.html#event-metadata
+        // https://developers.eventstore.com/server/v21.10/streams.html#reserved-names
         EventData(Uuid.FromGuid x.EventId, x.EventType, contentType = "application/json", data = x.Data, metadata = x.Meta)
 
 type Position = { streamVersion: int64; compactionEventNumber: int64 option; batchCapacityLimit: int option }

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -208,7 +208,7 @@ module Read =
             | _ -> ()
 
             let batchLog = log |> Log.prop "batchIndex" batchCount
-            let! slice = readSlice pos batchCount batchLog ct |> Async.AwaitTaskCorrect
+            let! slice = readSlice pos batchCount batchLog ct
             version <- max version slice.LastVersion
             result.AddRange(slice.Messages)
             if not slice.IsEnd then

--- a/tests/Equinox.Core.Tests/AsyncBatchingGateTests.fs
+++ b/tests/Equinox.Core.Tests/AsyncBatchingGateTests.fs
@@ -21,11 +21,11 @@ let ``AsyncBatchingGate correctness`` () = async {
         0 =! concurrency
         return reqs
     }
-    let cell = AsyncBatchingGate(dispatch, linger = TimeSpan.FromMilliseconds 5)
+    let cell = AsyncBatchingGate(dispatch, linger = TimeSpan.FromMilliseconds 40)
     let! results = [1 .. 100] |> Seq.map cell.Execute |> Async.Parallel
     test <@ set (Seq.collect id results) = set [1 .. 100] @>
-    // Linger of 5ms makes this tend strongly to only be 1 batch
-    test <@ batches < 2 @>
+    // Linger of 40ms makes this tend strongly to only be 1 batch
+    1 =! batches
 }
 
 [<Property>]

--- a/tests/Equinox.Core.Tests/CachingTests.fs
+++ b/tests/Equinox.Core.Tests/CachingTests.fs
@@ -133,7 +133,8 @@ type Tests() =
     let [<Fact>] ``allowStale handles concurrent incompatible loads correctly`` () = task {
         cat.Delay <- TimeSpan.FromMilliseconds 50
         let t1 = allowStale 1
-        let t2 = allowStale 5 // any cached value should be at least 50 old (and the overlapping call should not have started 45 late)
+        do! Task.Delay 20 // Give the load a chance to start
+        let t2 = allowStale 1 // any cached value should be at least 50 old (and the overlapping call should not have started 45 late)
         let! struct (_token, state) = t2
         test <@ (2, 2) = (state, cat.Loads + cat.Reloads) @>
         let! struct (_token, state) = t1

--- a/tests/Equinox.Core.Tests/CachingTests.fs
+++ b/tests/Equinox.Core.Tests/CachingTests.fs
@@ -134,12 +134,10 @@ type Tests() =
         cat.Delay <- TimeSpan.FromMilliseconds 50
         let t1 = allowStale 1
         let t2 = allowStale 5 // any cached value should be at least 50 old (and the overlapping call should not have started 45 late)
-        do! Task.Delay 20 // One should be in flight by now, but second will be awaiting the first
-        test <@ (1, 0) = (cat.Loads, cat.Reloads) @>
         let! struct (_token, state) = t2
-        test <@ (2, 2, 0) = (state, cat.Loads, cat.Reloads) @>
+        test <@ (2, 2) = (state, cat.Loads + cat.Reloads) @>
         let! struct (_token, state) = t1
-        test <@ (1, 2, 0) = (state, cat.Loads, cat.Reloads) @> }
+        test <@ (1, 2) = (state, cat.Loads + cat.Reloads) @> }
 
     let [<Fact>] ``allowStale handles overlapped incompatible loads correctly`` () = task {
         cat.Delay <- TimeSpan.FromMilliseconds 50


### PR DESCRIPTION
Calved from #390
- Adds an `Async.call` helper, and cleans up some final straggler `Async` vs `Task` inconsistencies
- Includes some straggler cleanup and docs
- and lots of annoying test hardening; CI, xunit, sleeps and Task are a bad combo