### PR TITLE
perf: use a literal for queries, and stop doing silly stuff with correlation/causation ids

### DIFF
--- a/src/Equinox.MessageDb/MessageDbClient.fs
+++ b/src/Equinox.MessageDb/MessageDbClient.fs
@@ -17,18 +17,18 @@ type ExpectedVersion = Any | StreamVersion of int64
 [<AutoOpen>]
 module private Sql =
     type private NpgsqlParameterCollection with
-      member this.AddNullableString(value: string option) =
-          match value with
-          | Some value -> this.AddWithValue(NpgsqlDbType.Text, value)
-          | None       -> this.AddWithValue(NpgsqlDbType.Text, DBNull.Value)
-      member this.AddExpectedVersion(value: ExpectedVersion) =
-        match value with
-        | StreamVersion value -> this.AddWithValue(NpgsqlDbType.Bigint, value)
-        | Any                 -> this.AddWithValue(NpgsqlDbType.Bigint, DBNull.Value)
+        member this.AddNullableString(value: string option) =
+            match value with
+            | Some value -> this.AddWithValue(NpgsqlDbType.Text, value)
+            | None       -> this.AddWithValue(NpgsqlDbType.Text, DBNull.Value)
+        member this.AddExpectedVersion(value: ExpectedVersion) =
+            match value with
+            | StreamVersion value -> this.AddWithValue(NpgsqlDbType.Bigint, value)
+            | Any                 -> this.AddWithValue(NpgsqlDbType.Bigint, DBNull.Value)
 
-      member this.AddJson(value: Format) =
-        if value.Length = 0 then this.AddWithValue(NpgsqlDbType.Jsonb, DBNull.Value)
-        else this.AddWithValue(NpgsqlDbType.Jsonb, value.ToArray())
+        member this.AddJson(value: Format) =
+            if value.Length = 0 then this.AddWithValue(NpgsqlDbType.Jsonb, DBNull.Value)
+            else this.AddWithValue(NpgsqlDbType.Jsonb, value.ToArray())
 
 
 module private Queries =


### PR DESCRIPTION
Noticed during my memory leak investigation in propulsion that using `@Variable` style Commands in Npgsql leads to `StringBuilder` allocations and all sorts of fun processing in the application that is avoidable by using `$1, $2` etc (the native format that pg parameterised queries take).

Secondly while scanning the code the queries looked a bit off with the `CorrelationId` and `CausationId` being picked from the json metadata. This makes sense if and only if we also place the id's onto these fields during writes. Since we don't this is just waste so 🧹  it