### PR TITLE
DynamoStore: Feed all appends through tip

### DIFF
--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -989,10 +989,7 @@ module Token =
         { value = box { pos = pos }; version = v; streamBytes = b }
     let create: Position -> StreamToken = Some >> create_
     let empty = create_ None
-    let (|Unpack|) (token: StreamToken): Position option =
-        match token.value  with
-        | :? Token as t -> t.pos
-        | _ -> None
+    let (|Unpack|) (token: StreamToken): Position option = let t = unbox<Token> token.value in t.pos
 
     // TOCONSIDER for RollingState, comparing etags is not meaningful, and they are under our control;
     //            => should be replaced with a `revision` that increments if `index` is not changing as part of a write

--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -990,7 +990,10 @@ module Token =
         { value = box { pos = pos }; version = v; streamBytes = b }
     let create: Position -> StreamToken = Some >> create_
     let empty = create_ None
-    let (|Unpack|) (token: StreamToken): Position option = let t = unbox<Token> token.value in t.pos
+    let (|Unpack|) (token: StreamToken): Position option =
+        match token.value  with
+        | :? Token as t -> t.pos
+        | _ -> None
 
     // TOCONSIDER for RollingState, comparing etags is not meaningful, and they are under our control;
     //            => should be replaced with a `revision` that increments if `index` is not changing as part of a write

--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -625,8 +625,7 @@ module internal Sync =
                 || Event.arrayBytes cur.events + Event.arrayBytes events > maxEventBytes
                 || Event.arrayBytes cur.events + Event.arrayBytes events + Unfold.arrayBytes unfolds > maxBytes)
                && (not << Array.isEmpty) cur.events then // even if a rule says we should calve, we don't want to produce empty ones
-                let calfE, tipE = cur.events, events
-                Req.Calve (calfE, tipE), cur.calvedBytes + Event.arrayBytes calfE, tipE
+                Req.Calve (cur.events, events), cur.calvedBytes + Event.arrayBytes cur.events, events
             else Req.Append (Array.isEmpty cur.events, events), cur.calvedBytes, Array.append cur.events events
         match! transactLogged (container, stream) (cur.baseBytes, cur.events.Length, req, unfolds, exp pos, predecessorBytes', n', ct) log with
         | Res.Written etag' -> return Result.Written (etag', predecessorBytes', tipEvents', unfolds)

--- a/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
+++ b/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
@@ -1,13 +1,10 @@
 module Equinox.Store.Integration.AccessStrategies
 
-open Equinox.Core
 #if STORE_DYNAMO
 open Equinox.DynamoStore
-open Equinox.DynamoStore.Core
 open Equinox.DynamoStore.Integration.CosmosFixtures
 #else
 open Equinox.CosmosStore
-open Equinox.CosmosStore.Core
 open Equinox.CosmosStore.Integration.CosmosFixtures
 #endif
 open Swensen.Unquote
@@ -100,7 +97,7 @@ module Props =
     type FsCheckAttribute() =
         inherit AutoDataAttribute(MaxTest = maxTest, Arbitrary=[|typeof<GapGen>|])
 
-[<Xunit.Collection "DocStore">]
+[<Collection "DocStore">]
 type UnoptimizedTipReadingCorrectness(testOutputHelper) =
     let output = TestOutput(testOutputHelper)
     let log = output.CreateLogger()
@@ -140,9 +137,12 @@ type UnoptimizedTipReadingCorrectness(testOutputHelper) =
 
 module Token =
 
+// Helpers for producing tokens are note presently exposed, so we produce the records directly here
 #if STORE_DYNAMO
+    open Equinox.DynamoStore.Core
     let getPos index = { index = index; etag = ""; calvedBytes = 0; baseBytes = 0; unfoldsBytes = 0; events = Array.empty }
 #else
+    open Equinox.CosmosStore.Core
     let getPos index = { index = index; etag = None }
 #endif
 

--- a/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
+++ b/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
@@ -138,13 +138,14 @@ type UnoptimizedTipReadingCorrectness(testOutputHelper) =
         let! s2'' = service2.Read instanceId
         test <@ s1'' = s2'' @> }
 
-
 module Token =
+
 #if STORE_DYNAMO
     let getPos index = { index = index; etag = ""; calvedBytes = 0; baseBytes = 0; unfoldsBytes = 0; events = Array.empty }
 #else
     let getPos index = { index = index; etag = None }
 #endif
+
     let [<Fact>] ``Candidate is not stale if we have no current`` () =
         let emptyToken = Unchecked.defaultof<StreamToken>
         let pos = getPos 0

--- a/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
+++ b/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
@@ -146,25 +146,12 @@ module Token =
     let getPos index = { index = index; etag = None }
 #endif
 
-    let [<Fact>] ``Candidate is not stale if we have no current`` () =
-        let emptyToken = Unchecked.defaultof<StreamToken>
-        let pos = getPos 0
-        let candidate = Token.create pos
+    [<Theory;
+      InlineData(1, 1, false); // If we re-read the same data, either as a 200 or a 304 NotModified, we still need to update the lastVerified stamp
+      InlineData(1, 2, false);
+      InlineData(2, 1, true)>]
+    let ``Candidate is stale iff lower than current`` (currentIndex, candidateIndex, expectStale) =
+        let current = Token.create (getPos currentIndex)
+        let candidate = Token.create (getPos candidateIndex)
 
-        test <@ false = Token.isStale emptyToken candidate @>
-
-    let [<Fact>] ``Candidate is not stale if higher index than current`` () =
-        let pos1 = getPos 1
-        let pos2 = getPos 2
-        let current = Token.create pos1
-        let candidate = Token.create pos2
-
-        test <@ false = Token.isStale current candidate @>
-
-    let [<Fact>] ``Candidate is stale if lower index than current`` () =
-        let pos1 = getPos 1
-        let pos2 = getPos 2
-        let current = Token.create pos2
-        let candidate = Token.create pos1
-
-        test <@ true = Token.isStale current candidate @>
+        test <@ expectStale = Token.isStale current candidate @>

--- a/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
+++ b/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
@@ -1,12 +1,11 @@
 module Equinox.Store.Integration.AccessStrategies
 
-#if STORE_DYNAMO
 open Equinox.Core
+#if STORE_DYNAMO
 open Equinox.DynamoStore
 open Equinox.DynamoStore.Core
 open Equinox.DynamoStore.Integration.CosmosFixtures
 #else
-open Equinox.Core
 open Equinox.CosmosStore
 open Equinox.CosmosStore.Core
 open Equinox.CosmosStore.Integration.CosmosFixtures
@@ -14,8 +13,6 @@ open Equinox.CosmosStore.Integration.CosmosFixtures
 open Swensen.Unquote
 open System
 open Xunit
-
-
 
 [<AutoOpen>]
 module WiringHelpers =
@@ -143,17 +140,17 @@ type UnoptimizedTipReadingCorrectness(testOutputHelper) =
 
 
 module Token =
-    #if STORE_DYNAMO
+#if STORE_DYNAMO
     let getPos index = { index = index; etag = ""; calvedBytes = 0; baseBytes = 0; unfoldsBytes = 0; events = Array.empty }
-    #else
+#else
     let getPos index = { index = index; etag = None }
-    #endif
+#endif
     let [<Fact>] ``Candidate is not stale if we have no current`` () =
         let emptyToken = Unchecked.defaultof<StreamToken>
         let pos = getPos 0
         let candidate = Token.create pos
 
-        test <@ false = Token.isStale emptyToken candidate  @>
+        test <@ false = Token.isStale emptyToken candidate @>
 
     let [<Fact>] ``Candidate is not stale if higher index than current`` () =
         let pos1 = getPos 1
@@ -161,7 +158,7 @@ module Token =
         let current = Token.create pos1
         let candidate = Token.create pos2
 
-        test <@ false = Token.isStale current candidate  @>
+        test <@ false = Token.isStale current candidate @>
 
     let [<Fact>] ``Candidate is stale if lower index than current`` () =
         let pos1 = getPos 1
@@ -169,4 +166,4 @@ module Token =
         let current = Token.create pos2
         let candidate = Token.create pos1
 
-        test <@ true = Token.isStale current candidate  @>
+        test <@ true = Token.isStale current candidate @>

--- a/tests/Equinox.CosmosStore.Integration/CosmosFixtures.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosFixtures.fs
@@ -12,9 +12,10 @@ let private tableName = tryRead "EQUINOX_DYNAMO_TABLE" |> Option.defaultValue "e
 let private archiveTableName = tryRead "EQUINOX_DYNAMO_TABLE_ARCHIVE" |> Option.defaultValue "equinox-test-archive"
 
 let discoverConnection () =
-    match tryRead "EQUINOX_DYNAMO_SERVICE_URL" with // NOT USING EQUINOX_DYNAMO_SERVICE_URL env var as we don't want to go provisioning 2 tables in a random DB
+    // NOTE NOT using the EQUINOX_DYNAMO_SERVICE_URL env var that's commonly used in dotnet-templates, as we don't want to go provisioning 2 tables in a random DB
+    match tryRead "EQUINOX_DYNAMO_CONNECTION" with
     | None -> "dynamodb-local", "http://localhost:8000"
-    | Some connectionString -> "EQUINOX_DYNAMO_CONNECTION", connectionString
+    | Some connectionString -> "EQUINOX_DYNAMO_CONNECTION", connectionString // e.g "https://dynamodb.eu-west-1.amazonaws.com"
 let isSimulatorServiceUrl url = Uri(url).IsLoopback
 
 let createClient (log : Serilog.ILogger) name serviceUrl =


### PR DESCRIPTION
Resolves #403; Adjusts the write algorithm to ensure all newly appended events are always first written to the tip (as opposed to potentially going straight to a calf batch as they do in the Cosmos impl, which would generally be more optimal both in RU cost and in density of events per Batch/Item in the store)

This is to enable downstream consumers of the DDB Streams (including `Propulsion.DynamoStore.Indexer`) to be guaranteed to see all appends for a given stream in the correct order.

----
Prompted by observations and analysis by @epNickColeman that writes to non-tip events (calved batches) were arriving out of order under non-trivial write load (previous load tests had not included triggering the calving of ). On closer investigation, the documentation for DDB Streams turns out to be written very tightly to only guarantee ordering at the individual item level, not for relative positions of writes to the same logical partition (even in a transactional batch).

While the commits here bear my name, Nick and I paired on the implementation and cleanup, and the actual leg of work of figuring out the problem, convincing me it was real, and what the core of the fix needed to be was entirely due to his time, effort and insight 🙌