### PR TITLE
Avoid null reference on cache read

### DIFF
--- a/src/Equinox.Core/Equinox.Core.fsproj
+++ b/src/Equinox.Core/Equinox.Core.fsproj
@@ -21,7 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SSOOIDC" Version="3.7.100.143" />
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
     <PackageReference Include="FSharp.Core" Version="6.0.7">

--- a/src/Equinox.Core/Equinox.Core.fsproj
+++ b/src/Equinox.Core/Equinox.Core.fsproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.SSOOIDC" Version="3.7.100.143" />
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
     <PackageReference Include="FSharp.Core" Version="6.0.7">

--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -990,7 +990,10 @@ module Token =
         { value = box { pos = pos }; version = v; streamBytes = b }
     let create: Position -> StreamToken = Some >> create_
     let empty = create_ None
-    let (|Unpack|) (token: StreamToken): Position option = let t = unbox<Token> token.value in t.pos
+    let (|Unpack|) (token: StreamToken): Position option =
+        match token.value  with
+        | :? Token as t -> t.pos
+        | _ -> None
 
     // TOCONSIDER for RollingState, comparing etags is not meaningful, and they are under our control;
     //            => should be replaced with a `revision` that increments if `index` is not changing as part of a write


### PR DESCRIPTION
Handle nulls when unpacking Equinox.DynamoStore.Core.Token.isStale