### PR TITLE
feat!(Stores): Category ctors take name + caching argument goes last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Equinox`: Merge `ResolveOption` and `XXXStoreCategory.FromMemento` as `LoadOption` [#308](https://github.com/jet/equinox/pull/308)
 - `Equinox`: Merge `XXXStoreCategory.Resolve(sn, ?ResolveOption)` and `XXXStoreCategory.FromMemento` as option `LoadOption` parameter on all `Transact` and `Query` methods [#308](https://github.com/jet/equinox/pull/308)
 - `Equinox.*.*Category`: Added mandatory `name` argument, and `Name` property [#410](https://github.com/jet/equinox/pull/410)
+- `Equinox.*.*Category`: Changed caching to be last argument, to reflect that it is applied over the top [#410](https://github.com/jet/equinox/pull/410)
 - `Equinox.LoadOption`: Rename `AllowStale` to `AnyCachedValue` [#386](https://github.com/jet/equinox/pull/386)
 - `Equinox.Decider`: `log` is now supplied via `Equinox.Category` [#337](https://github.com/jet/equinox/pull/337)
 - `Equinox.Decider`: Replaced `maxAttempts` with a default policy and an optional argument on `Transact*` APIs [#337](https://github.com/jet/equinox/pull/337)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - Performance: Switch surface APIs to `struct` Tuples and Options where relevant, some due to `struct` changes in [`FsCodec` #82](https://github.com/jet/FsCodec/pull/82), and use `task` in hot paths [#337](https://github.com/jet/equinox/pull/337)
 - `Equinox`: Merge `ResolveOption` and `XXXStoreCategory.FromMemento` as `LoadOption` [#308](https://github.com/jet/equinox/pull/308)
 - `Equinox`: Merge `XXXStoreCategory.Resolve(sn, ?ResolveOption)` and `XXXStoreCategory.FromMemento` as option `LoadOption` parameter on all `Transact` and `Query` methods [#308](https://github.com/jet/equinox/pull/308)
+- `Equinox.*.*Category`: Added mandatory `name` argument, and `Name` property [#410](https://github.com/jet/equinox/pull/410)
 - `Equinox.LoadOption`: Rename `AllowStale` to `AnyCachedValue` [#386](https://github.com/jet/equinox/pull/386)
 - `Equinox.Decider`: `log` is now supplied via `Equinox.Category` [#337](https://github.com/jet/equinox/pull/337)
 - `Equinox.Decider`: Replaced `maxAttempts` with a default policy and an optional argument on `Transact*` APIs [#337](https://github.com/jet/equinox/pull/337)

--- a/samples/Infrastructure/Services.fs
+++ b/samples/Infrastructure/Services.fs
@@ -8,27 +8,28 @@ open System
 
 type Store(store) =
     member _.Category
-        (   codec: FsCodec.IEventCodec<'event, ReadOnlyMemory<byte>, unit>,
+        (   name,
+            codec: FsCodec.IEventCodec<'event, ReadOnlyMemory<byte>, unit>,
             fold: 'state -> 'event seq -> 'state,
             initial: 'state,
             snapshot: ('event -> bool) * ('state -> 'event)): Category<'event, 'state, unit> =
         match store with
         | Store.Context.Memory store ->
-            Equinox.MemoryStore.MemoryStoreCategory(store, codec, fold, initial)
+            Equinox.MemoryStore.MemoryStoreCategory(store, name, codec, fold, initial)
         | Store.Context.Cosmos (store, caching, unfolds) ->
             let accessStrategy = if unfolds then Equinox.CosmosStore.AccessStrategy.Snapshot snapshot else Equinox.CosmosStore.AccessStrategy.Unoptimized
-            Equinox.CosmosStore.CosmosStoreCategory<'event,'state,_>(store, codec.ToJsonElementCodec(), fold, initial, caching, accessStrategy)
+            Equinox.CosmosStore.CosmosStoreCategory<'event,'state,_>(store, name, codec.ToJsonElementCodec(), fold, initial, caching, accessStrategy)
         | Store.Context.Dynamo (store, caching, unfolds) ->
             let accessStrategy = if unfolds then Equinox.DynamoStore.AccessStrategy.Snapshot snapshot else Equinox.DynamoStore.AccessStrategy.Unoptimized
-            Equinox.DynamoStore.DynamoStoreCategory<'event,'state,_>(store, FsCodec.Deflate.EncodeTryDeflate codec, fold, initial, caching, accessStrategy)
+            Equinox.DynamoStore.DynamoStoreCategory<'event,'state,_>(store, name, FsCodec.Deflate.EncodeTryDeflate codec, fold, initial, caching, accessStrategy)
         | Store.Context.Es (context, caching, unfolds) ->
             let accessStrategy = if unfolds then Equinox.EventStoreDb.AccessStrategy.RollingSnapshots snapshot |> Some else None
-            Equinox.EventStoreDb.EventStoreCategory<'event,'state,_>(context, codec, fold, initial, ?caching = caching, ?access = accessStrategy)
+            Equinox.EventStoreDb.EventStoreCategory<'event,'state,_>(context, name, codec, fold, initial, ?caching = caching, ?access = accessStrategy)
         | Store.Context.Sql (context, caching, unfolds) ->
             let accessStrategy = if unfolds then Equinox.SqlStreamStore.AccessStrategy.RollingSnapshots snapshot |> Some else None
-            Equinox.SqlStreamStore.SqlStreamStoreCategory<'event,'state,_>(context, codec, fold, initial, ?caching = caching, ?access = accessStrategy)
+            Equinox.SqlStreamStore.SqlStreamStoreCategory<'event,'state,_>(context, name, codec, fold, initial, ?caching = caching, ?access = accessStrategy)
         | Store.Context.Mdb (context, caching) ->
-            Equinox.MessageDb.MessageDbCategory<'event,'state,_>(context, codec, fold, initial, ?caching = caching)
+            Equinox.MessageDb.MessageDbCategory<'event,'state,_>(context, name, codec, fold, initial, ?caching = caching)
 
 type ServiceBuilder(storageConfig, handlerLog) =
      let store = Store storageConfig
@@ -36,22 +37,22 @@ type ServiceBuilder(storageConfig, handlerLog) =
      member _.CreateFavoritesService() =
         let fold, initial = Favorites.Fold.fold, Favorites.Fold.initial
         let snapshot = Favorites.Fold.isOrigin, Favorites.Fold.snapshot
-        store.Category(Favorites.Events.codec, fold, initial, snapshot)
-        |> Decider.resolve handlerLog
+        store.Category(Favorites.Category, Favorites.Events.codec, fold, initial, snapshot)
+        |> Decider.forStream handlerLog
         |> Favorites.create
 
      member _.CreateSaveForLaterService() =
         let fold, initial = SavedForLater.Fold.fold, SavedForLater.Fold.initial
         let snapshot = SavedForLater.Fold.isOrigin, SavedForLater.Fold.compact
-        store.Category(SavedForLater.Events.codec, fold, initial, snapshot)
-        |> Decider.resolve handlerLog
+        store.Category(SavedForLater.Category, SavedForLater.Events.codec, fold, initial, snapshot)
+        |> Decider.forStream handlerLog
         |> SavedForLater.create 50
 
      member _.CreateTodosService() =
         let fold, initial = TodoBackend.Fold.fold, TodoBackend.Fold.initial
         let snapshot = TodoBackend.Fold.isOrigin, TodoBackend.Fold.snapshot
-        store.Category(TodoBackend.Events.codec, fold, initial, snapshot)
-        |> Decider.resolve handlerLog
+        store.Category(TodoBackend.Category, TodoBackend.Events.codec, fold, initial, snapshot)
+        |> Decider.forStream handlerLog
         |> TodoBackend.create
 
 let register (services : IServiceCollection, storageConfig, handlerLog) =

--- a/samples/Infrastructure/Services.fs
+++ b/samples/Infrastructure/Services.fs
@@ -18,16 +18,16 @@ type Store(store) =
             Equinox.MemoryStore.MemoryStoreCategory(store, name, codec, fold, initial)
         | Store.Context.Cosmos (store, caching, unfolds) ->
             let accessStrategy = if unfolds then Equinox.CosmosStore.AccessStrategy.Snapshot snapshot else Equinox.CosmosStore.AccessStrategy.Unoptimized
-            Equinox.CosmosStore.CosmosStoreCategory<'event,'state,_>(store, name, codec.ToJsonElementCodec(), fold, initial, caching, accessStrategy)
+            Equinox.CosmosStore.CosmosStoreCategory<'event,'state,_>(store, name, codec.ToJsonElementCodec(), fold, initial, accessStrategy, caching)
         | Store.Context.Dynamo (store, caching, unfolds) ->
             let accessStrategy = if unfolds then Equinox.DynamoStore.AccessStrategy.Snapshot snapshot else Equinox.DynamoStore.AccessStrategy.Unoptimized
-            Equinox.DynamoStore.DynamoStoreCategory<'event,'state,_>(store, name, FsCodec.Deflate.EncodeTryDeflate codec, fold, initial, caching, accessStrategy)
+            Equinox.DynamoStore.DynamoStoreCategory<'event,'state,_>(store, name, FsCodec.Deflate.EncodeTryDeflate codec, fold, initial, accessStrategy, caching)
         | Store.Context.Es (context, caching, unfolds) ->
             let accessStrategy = if unfolds then Equinox.EventStoreDb.AccessStrategy.RollingSnapshots snapshot |> Some else None
-            Equinox.EventStoreDb.EventStoreCategory<'event,'state,_>(context, name, codec, fold, initial, ?caching = caching, ?access = accessStrategy)
+            Equinox.EventStoreDb.EventStoreCategory<'event,'state,_>(context, name, codec, fold, initial, ?access = accessStrategy, ?caching = caching)
         | Store.Context.Sql (context, caching, unfolds) ->
             let accessStrategy = if unfolds then Equinox.SqlStreamStore.AccessStrategy.RollingSnapshots snapshot |> Some else None
-            Equinox.SqlStreamStore.SqlStreamStoreCategory<'event,'state,_>(context, name, codec, fold, initial, ?caching = caching, ?access = accessStrategy)
+            Equinox.SqlStreamStore.SqlStreamStoreCategory<'event,'state,_>(context, name, codec, fold, initial, ?access = accessStrategy, ?caching = caching)
         | Store.Context.Mdb (context, caching) ->
             Equinox.MessageDb.MessageDbCategory<'event,'state,_>(context, name, codec, fold, initial, ?caching = caching)
 

--- a/samples/Store/Domain/Cart.fs
+++ b/samples/Store/Domain/Cart.fs
@@ -169,4 +169,4 @@ type Service internal (resolve: CartId -> Equinox.Decider<Events.Event, Fold.Sta
         decider.Query(id, Equinox.LoadOption.AnyCachedValue)
 
 let create resolve =
-    Service(streamId >> resolve Category)
+    Service(streamId >> resolve)

--- a/samples/Store/Domain/ContactPreferences.fs
+++ b/samples/Store/Domain/ContactPreferences.fs
@@ -60,4 +60,4 @@ type Service internal (resolve: ClientId -> Equinox.Decider<Events.Event, Fold.S
         decider.Query(id, Equinox.AnyCachedValue)
 
 let create resolve =
-    Service(streamId >> resolve Category)
+    Service(streamId >> resolve)

--- a/samples/Store/Domain/Favorites.fs
+++ b/samples/Store/Domain/Favorites.fs
@@ -79,4 +79,4 @@ type Service internal (resolve: ClientId -> Equinox.Decider<Events.Event, Fold.S
         decider.TransactEx((fun c -> (), decideUnfavorite sku c.State), fun () c -> c.Version)
 
 let create resolve =
-    Service(streamId >> resolve Category)
+    Service(streamId >> resolve)

--- a/samples/Store/Domain/SavedForLater.fs
+++ b/samples/Store/Domain/SavedForLater.fs
@@ -144,4 +144,4 @@ type Service internal (resolve: ClientId -> Equinox.Decider<Events.Event, Fold.S
         return! execute targetId (Merge state) }
 
 let create maxSavedItems resolve =
-    Service(streamId >> resolve Category, maxSavedItems)
+    Service(streamId >> resolve, maxSavedItems)

--- a/samples/Store/Integration/CartIntegration.fs
+++ b/samples/Store/Integration/CartIntegration.fs
@@ -24,9 +24,9 @@ let categoryGesStreamWithoutCustomAccessStrategy context =
     EventStoreDb.EventStoreCategory(context, Cart.Category, codec, fold, initial)
 
 let categoryCosmosStreamWithSnapshotStrategy context =
-    CosmosStore.CosmosStoreCategory(context, Cart.Category, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Snapshot snapshot)
+    CosmosStore.CosmosStoreCategory(context, Cart.Category, codecJe, fold, initial, CosmosStore.AccessStrategy.Snapshot snapshot, CosmosStore.CachingStrategy.NoCaching)
 let categoryCosmosStreamWithoutCustomAccessStrategy context =
-    CosmosStore.CosmosStoreCategory(context, Cart.Category, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Unoptimized)
+    CosmosStore.CosmosStoreCategory(context, Cart.Category, codecJe, fold, initial, CosmosStore.AccessStrategy.Unoptimized, CosmosStore.CachingStrategy.NoCaching)
 
 let addAndThenRemoveItemsManyTimesExceptTheLastOne context cartId skuId (service: Cart.Service) count =
     service.ExecuteManyAsync(cartId, false, seq {

--- a/samples/Store/Integration/CartIntegration.fs
+++ b/samples/Store/Integration/CartIntegration.fs
@@ -11,22 +11,22 @@ let snapshot = Cart.Fold.isOrigin, Cart.Fold.snapshot
 
 let createMemoryStore () = MemoryStore.VolatileStore<ReadOnlyMemory<byte>>()
 let createServiceMemory log store =
-    MemoryStore.MemoryStoreCategory(store, Cart.Events.codec, fold, initial)
-    |> Decider.resolve log
+    MemoryStore.MemoryStoreCategory(store, Cart.Category, Cart.Events.codec, fold, initial)
+    |> Decider.forStream log
     |> Cart.create
 
 let codec = Cart.Events.codec
 let codecJe = Cart.Events.codecJe
 
 let categoryGesStreamWithRollingSnapshots context =
-    EventStoreDb.EventStoreCategory(context, codec, fold, initial, access = EventStoreDb.AccessStrategy.RollingSnapshots snapshot)
+    EventStoreDb.EventStoreCategory(context, Cart.Category, codec, fold, initial, access = EventStoreDb.AccessStrategy.RollingSnapshots snapshot)
 let categoryGesStreamWithoutCustomAccessStrategy context =
-    EventStoreDb.EventStoreCategory(context, codec, fold, initial)
+    EventStoreDb.EventStoreCategory(context, Cart.Category, codec, fold, initial)
 
 let categoryCosmosStreamWithSnapshotStrategy context =
-    CosmosStore.CosmosStoreCategory(context, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Snapshot snapshot)
+    CosmosStore.CosmosStoreCategory(context, Cart.Category, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Snapshot snapshot)
 let categoryCosmosStreamWithoutCustomAccessStrategy context =
-    CosmosStore.CosmosStoreCategory(context, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Unoptimized)
+    CosmosStore.CosmosStoreCategory(context, Cart.Category, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Unoptimized)
 
 let addAndThenRemoveItemsManyTimesExceptTheLastOne context cartId skuId (service: Cart.Service) count =
     service.ExecuteManyAsync(cartId, false, seq {
@@ -56,7 +56,7 @@ type Tests(testOutputHelper) =
     let arrangeEs connect choose createCategory = async {
         let client = connect log
         let context = choose client defaultBatchSize
-        return Cart.create (createCategory context |> Decider.resolve log) }
+        return Cart.create (createCategory context |> Decider.forStream log) }
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
     let ``Can roundtrip against EventStore, correctly folding the events without compaction semantics`` args = async {
@@ -72,7 +72,7 @@ type Tests(testOutputHelper) =
 
     let arrangeCosmos connect createCategory =
         let context : CosmosStore.CosmosStoreContext = connect log defaultQueryMaxItems
-        Cart.create (createCategory context |> Decider.resolve log)
+        Cart.create (createCategory context |> Decider.forStream log)
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let ``Can roundtrip against Cosmos, correctly folding the events without custom access strategy`` args = async {

--- a/samples/Store/Integration/ContactPreferencesIntegration.fs
+++ b/samples/Store/Integration/ContactPreferencesIntegration.fs
@@ -9,24 +9,25 @@ let fold, initial = ContactPreferences.Fold.fold, ContactPreferences.Fold.initia
 
 let createMemoryStore () = MemoryStore.VolatileStore<_>()
 let createServiceMemory log store =
-    MemoryStore.MemoryStoreCategory(store, FsCodec.Box.Codec.Create(), fold, initial)
-    |> Decider.resolve log
+    MemoryStore.MemoryStoreCategory(store, ContactPreferences.Category, FsCodec.Box.Codec.Create(), fold, initial)
+    |> Decider.forStream log
     |> ContactPreferences.create
 
+let Category = ContactPreferences.Category
 let codec = ContactPreferences.Events.codec
 let codecJe = ContactPreferences.Events.codecJe
 let categoryGesWithOptimizedStorageSemantics context =
-    EventStoreDb.EventStoreCategory(context 1, codec, fold, initial, access = EventStoreDb.AccessStrategy.LatestKnownEvent)
+    EventStoreDb.EventStoreCategory(context 1, Category, codec, fold, initial, access = EventStoreDb.AccessStrategy.LatestKnownEvent)
 let categoryGesWithoutAccessStrategy context =
-    EventStoreDb.EventStoreCategory(context defaultBatchSize, codec, fold, initial)
+    EventStoreDb.EventStoreCategory(context defaultBatchSize, Category, codec, fold, initial)
 
 let categoryCosmosWithLatestKnownEventSemantics context =
-    CosmosStore.CosmosStoreCategory(context, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.LatestKnownEvent)
+    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.LatestKnownEvent)
 let categoryCosmosUnoptimized context =
-    CosmosStore.CosmosStoreCategory(context, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Unoptimized)
+    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Unoptimized)
 let categoryCosmosRollingUnfolds context =
     let access = CosmosStore.AccessStrategy.Custom(ContactPreferences.Fold.isOrigin, ContactPreferences.Fold.transmute)
-    CosmosStore.CosmosStoreCategory(context, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, access)
+    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, access)
 
 type Tests(testOutputHelper) =
     let testOutput = TestOutput testOutputHelper
@@ -48,7 +49,7 @@ type Tests(testOutputHelper) =
     let arrangeEs connect choose createCategory = async {
         let client = connect log
         let context = choose client
-        return ContactPreferences.create (createCategory context |> Decider.resolve log) }
+        return ContactPreferences.create (createCategory context |> Decider.forStream log) }
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_EVENTSTORE")>]
     let ``Can roundtrip against EventStore, correctly folding the events with normal semantics`` args = async {
@@ -64,7 +65,7 @@ type Tests(testOutputHelper) =
 
     let arrangeCosmos connect createCategory queryMaxItems =
         let context: CosmosStore.CosmosStoreContext = connect log queryMaxItems
-        ContactPreferences.create (createCategory context |> Decider.resolve log)
+        ContactPreferences.create (createCategory context |> Decider.forStream log)
 
     [<AutoData(SkipIfRequestedViaEnvironmentVariable="EQUINOX_INTEGRATION_SKIP_COSMOS")>]
     let ``Can roundtrip against Cosmos, correctly folding the events with Unoptimized semantics`` args = async {

--- a/samples/Store/Integration/ContactPreferencesIntegration.fs
+++ b/samples/Store/Integration/ContactPreferencesIntegration.fs
@@ -22,12 +22,12 @@ let categoryGesWithoutAccessStrategy context =
     EventStoreDb.EventStoreCategory(context defaultBatchSize, Category, codec, fold, initial)
 
 let categoryCosmosWithLatestKnownEventSemantics context =
-    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.LatestKnownEvent)
+    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.AccessStrategy.LatestKnownEvent, CosmosStore.CachingStrategy.NoCaching)
 let categoryCosmosUnoptimized context =
-    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Unoptimized)
+    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.AccessStrategy.Unoptimized, CosmosStore.CachingStrategy.NoCaching)
 let categoryCosmosRollingUnfolds context =
     let access = CosmosStore.AccessStrategy.Custom(ContactPreferences.Fold.isOrigin, ContactPreferences.Fold.transmute)
-    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, access)
+    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, access, CosmosStore.CachingStrategy.NoCaching)
 
 type Tests(testOutputHelper) =
     let testOutput = TestOutput testOutputHelper

--- a/samples/Store/Integration/FavoritesIntegration.fs
+++ b/samples/Store/Integration/FavoritesIntegration.fs
@@ -23,13 +23,13 @@ let createServiceGes log context =
     |> Favorites.create
 
 let createServiceCosmosSnapshotsUncached log context =
-    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, CosmosStore.AccessStrategy.Snapshot snapshot)
+    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.AccessStrategy.Snapshot snapshot, CosmosStore.CachingStrategy.NoCaching)
     |> Decider.forStream log
     |> Favorites.create
 
 let createServiceCosmosRollingStateUncached log context =
     let access = CosmosStore.AccessStrategy.RollingState Favorites.Fold.snapshot
-    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.CachingStrategy.NoCaching, access)
+    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, access, CosmosStore.CachingStrategy.NoCaching)
     |> Decider.forStream log
     |> Favorites.create
 
@@ -38,7 +38,7 @@ let createServiceCosmosUnoptimizedButCached log context =
     let caching =
         let cache = Cache ("name", 10)
         CosmosStore.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
-    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, caching, access)
+    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, access, caching)
     |> Decider.forStream log
     |> Favorites.create
 

--- a/samples/Store/Integration/LogIntegration.fs
+++ b/samples/Store/Integration/LogIntegration.fs
@@ -109,7 +109,7 @@ type Tests(testOutputHelper) =
         let log = createLoggerWithMetricsExtraction buffer.Enqueue
         let client = connectToLocalEventStoreNode log
         let context = createContext client batchSize
-        let service = Cart.create (CartIntegration.categoryGesStreamWithRollingSnapshots context |> Equinox.Decider.resolve log)
+        let service = Cart.create (CartIntegration.categoryGesStreamWithRollingSnapshots context |> Equinox.Decider.forStream log)
         let itemCount = batchSize / 2 + 1
         let cartId = % Guid.NewGuid()
         do! act buffer service itemCount ctx cartId skuId "ReadStreamAsyncB-Duration"
@@ -121,7 +121,7 @@ type Tests(testOutputHelper) =
         let buffer = ConcurrentQueue<string>()
         let log = createLoggerWithMetricsExtraction buffer.Enqueue
         let context = createPrimaryContext log queryMaxItems
-        let service = Cart.create (CartIntegration.categoryCosmosStreamWithSnapshotStrategy context |> Equinox.Decider.resolve log)
+        let service = Cart.create (CartIntegration.categoryCosmosStreamWithSnapshotStrategy context |> Equinox.Decider.forStream log)
         let itemCount = queryMaxItems / 2 + 1
         let cartId = % Guid.NewGuid()
         do! act buffer service itemCount ctx cartId skuId "EqxCosmos Tip " // one is a 404, one is a 200

--- a/samples/TodoBackend/Todo.fs
+++ b/samples/TodoBackend/Todo.fs
@@ -80,4 +80,4 @@ type Service internal (resolve: ClientId -> Equinox.Decider<Events.Event, Fold.S
         let! state' = handle clientId (Command.Update item)
         return List.find (fun x -> x.id = item.id) state' }
 
-let create resolve = Service(streamId >> resolve Category)
+let create resolve = Service(streamId >> resolve)

--- a/samples/Tutorial/AsAt.fsx
+++ b/samples/Tutorial/AsAt.fsx
@@ -160,8 +160,8 @@ module EventStore =
     let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
     // rig snapshots to be injected as events into the stream every `snapshotWindow` events
     let accessStrategy = AccessStrategy.RollingSnapshots (Fold.isValid,Fold.snapshot)
-    let cat = EventStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
-    let resolve = Equinox.Decider.resolve Log.log cat
+    let cat = EventStoreCategory(context, Category, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
+    let resolve = Equinox.Decider.forStream Log.log cat
 
 module Cosmos =
 
@@ -174,10 +174,10 @@ module Cosmos =
     let context = CosmosStoreContext(storeClient, tipMaxEvents = 10)
     let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
     let accessStrategy = AccessStrategy.Snapshot (Fold.isValid,Fold.snapshot)
-    let cat = CosmosStoreCategory(context, Events.codecJe, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
-    let resolve = Equinox.Decider.resolve Log.log cat
+    let cat = CosmosStoreCategory(context, Category, Events.codecJe, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
+    let resolve = Equinox.Decider.forStream Log.log cat
 
-let service = Service(streamId >> EventStore.resolve Category)
+let service = Service(streamId >> EventStore.resolve)
 //let service= Service(streamId >> Cosmos.resolve)
 
 let client = "ClientA"

--- a/samples/Tutorial/Counter.fsx
+++ b/samples/Tutorial/Counter.fsx
@@ -99,10 +99,8 @@ let logEvents sn (events : FsCodec.ITimelineEvent<_>[]) =
 let store = Equinox.MemoryStore.VolatileStore()
 let _ = store.Committed.Subscribe(fun struct (sn, xs) -> logEvents sn xs)
 let codec = FsCodec.Box.Codec.Create()
-let resolve =
-    Equinox.MemoryStore.MemoryStoreCategory(store, codec, fold, initial)
-    |> Equinox.Decider.resolve log
-let service = Service(streamId >> resolve Category)
+let cat = Equinox.MemoryStore.MemoryStoreCategory(store, Category, codec, fold, initial)
+let service = Service(streamId >> Equinox.Decider.forStream log cat)
 
 let clientId = "ClientA"
 service.Read(clientId) |> Async.RunSynchronously

--- a/samples/Tutorial/Favorites.fsx
+++ b/samples/Tutorial/Favorites.fsx
@@ -118,13 +118,13 @@ let codec =
     FsCodec.Codec.Create(encode, tryDecode)
 // Each store has a <Store>Category that is used to resolve IStream instances binding to a specific stream in a specific store
 // ... because the nature of the contract with the handler is such that the store hands over State, we also pass the `initial` and `fold` as we used above
-let cat = Equinox.MemoryStore.MemoryStoreCategory(store, codec, fold, initial)
-let resolve = Equinox.Decider.resolve log cat
+let cat = Equinox.MemoryStore.MemoryStoreCategory(store, Category, codec, fold, initial)
+let decider = Equinox.Decider.forStream log cat
 
-// We hand the streamId to the resolver
-let clientAStream = resolve Category clientAFavoritesStreamId
-// ... and pass the stream to the Handler
-let handler = Handler(clientAStream)
+// We get a Decider instance for the streamId
+let clientADecider = decider Category clientAFavoritesStreamId
+// ... and wrap that in a Handler
+let handler = Handler(clientADecider)
 
 (* Run some commands *)
 

--- a/samples/Tutorial/FulfilmentCenter.fsx
+++ b/samples/Tutorial/FulfilmentCenter.fsx
@@ -145,10 +145,8 @@ module Store =
 open FulfilmentCenter
 
 let service =
-    let resolve =
-        CosmosStoreCategory(Store.context, Events.codec, Fold.fold, Fold.initial, Store.cacheStrategy, AccessStrategy.Unoptimized)
-        |> Equinox.Decider.resolve Log.log
-    Service(streamId >> resolve Category)
+    let cat = CosmosStoreCategory(Store.context, Category, Events.codec, Fold.fold, Fold.initial, Store.cacheStrategy, AccessStrategy.Unoptimized)
+    Service(streamId >> Equinox.Decider.forStream Log.log cat)
 
 let fc = "fc0"
 service.UpdateName(fc, { code="FC000"; name="Head" }) |> Async.RunSynchronously

--- a/samples/Tutorial/Gapless.fs
+++ b/samples/Tutorial/Gapless.fs
@@ -81,7 +81,7 @@ module Cosmos =
     open Equinox.CosmosStore
     let private category (context, cache, accessStrategy) =
         let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
-        CosmosStoreCategory(context, Category, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
+        CosmosStoreCategory(context, Category, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
 
     module Snapshot =
 

--- a/samples/Tutorial/Index.fs
+++ b/samples/Tutorial/Index.fs
@@ -45,7 +45,7 @@ type Service<'t> internal (decider : Equinox.Decider<Events.Event<'t>, Fold.Stat
     member _.Read() : Async<Map<string,'t>> =
         decider.Query id
 
-let create<'t> cat indexId =
+let create<'t> indexId cat =
     Service(streamId indexId |> Equinox.Decider.forStream Serilog.Log.Logger cat)
 
 module Cosmos =

--- a/samples/Tutorial/Index.fs
+++ b/samples/Tutorial/Index.fs
@@ -54,7 +54,7 @@ module Cosmos =
     let category (context,cache) =
         let cacheStrategy = CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
         let accessStrategy = AccessStrategy.RollingState Fold.snapshot
-        CosmosStoreCategory(context, Category, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
+        CosmosStoreCategory(context, Category, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
 
 module MemoryStore =
 

--- a/samples/Tutorial/Sequence.fs
+++ b/samples/Tutorial/Sequence.fs
@@ -43,7 +43,7 @@ module Cosmos =
     open Equinox.CosmosStore
     let private create (context, cache, accessStrategy) =
         let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
-        CosmosStoreCategory(context, Category, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
+        CosmosStoreCategory(context, Category, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
 
     module LatestKnownEvent =
 

--- a/samples/Tutorial/Set.fs
+++ b/samples/Tutorial/Set.fs
@@ -55,7 +55,7 @@ module Cosmos =
     let category (context, cache) =
         let cacheStrategy = CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
         let accessStrategy = AccessStrategy.RollingState Fold.snapshot
-        CosmosStoreCategory(context, Category, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
+        CosmosStoreCategory(context, Category, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
 
 module MemoryStore =
 

--- a/samples/Tutorial/Todo.fsx
+++ b/samples/Tutorial/Todo.fsx
@@ -135,13 +135,10 @@ module Store =
     let context = CosmosStoreContext(storeClient, tipMaxEvents = 100) // Keep up to 100 events in tip before moving events to a new document
     let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
 
-module TodosCategory =
-
     let access = AccessStrategy.Snapshot (isOrigin,snapshot)
-    let resolve = CosmosStoreCategory(Store.context, codec, fold, initial, Store.cacheStrategy, access=access)
-                  |> Equinox.Decider.resolve log
+    let category = CosmosStoreCategory(context, Category, codec, fold, initial, cacheStrategy, access=access)
 
-let service = Service(streamId >> TodosCategory.resolve Category)
+let service = Service(streamId >> Equinox.Decider.forStream log Store.category)
 
 let client = "ClientJ"
 let item = { id = 0; order = 0; title = "Feed cat"; completed = false }

--- a/samples/Tutorial/Upload.fs
+++ b/samples/Tutorial/Upload.fs
@@ -59,7 +59,7 @@ module Cosmos =
     open Equinox.CosmosStore
     let category (context, cache) =
         let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
-        CosmosStoreCategory(context, Category, Events.codecJe, Fold.fold, Fold.initial, cacheStrategy, AccessStrategy.LatestKnownEvent)
+        CosmosStoreCategory(context, Category, Events.codecJe, Fold.fold, Fold.initial, AccessStrategy.LatestKnownEvent, cacheStrategy)
 
 module EventStore =
     open Equinox.EventStoreDb

--- a/src/Equinox.Core/Caching.fs
+++ b/src/Equinox.Core/Caching.fs
@@ -17,6 +17,7 @@ let private tee f (inner: CancellationToken -> Task<struct (StreamToken * 'state
 type private Decorator<'event, 'state, 'context, 'cat when 'cat :> ICategory<'event, 'state, 'context> and 'cat :> IReloadable<'state> >
     (category: 'cat, cache: Equinox.Cache, isStale, createKey, createOptions) =
     interface ICategory<'event, 'state, 'context> with
+        member _.Empty = category.Empty
         member _.Load(log, categoryName, streamId, streamName, maxAge, requireLeader, ct) = task {
             let loadOrReload ct = function
                 | ValueNone -> category.Load(log, categoryName, streamId, streamName, maxAge, requireLeader, ct)

--- a/src/Equinox.Core/Category.fs
+++ b/src/Equinox.Core/Category.fs
@@ -32,42 +32,39 @@ open System.Threading.Tasks
 /// Store-agnostic baseline functionality for a Category of 'event representations that fold to a given 'state
 [<NoComparison; NoEquality>]
 type Category<'event, 'state, 'context>
-    (   resolveInner: string -> string-> struct (Core.ICategory<'event, 'state, 'context> * string * (CancellationToken -> Task<unit>) voption),
+    (   name,
+        resolveStream: string -> string -> struct (Core.ICategory<'event, 'state, 'context> * string * (CancellationToken -> Task<unit>) voption),
         empty: struct (Core.StreamToken * 'state)) =
+    member val private Name = name
     /// Provides access to the low level store operations used for Loading and/or Syncing updates via the Decider
-    /// (Normal usage is via the adjacent `module Decider` / `Factory.Resolve` helpers)
-    member _.Stream(log: Serilog.ILogger, context: 'context, categoryName, streamId) =
-        let struct (inner, streamName, init) = resolveInner categoryName streamId
+    /// (Normal usage is via the adjacent `module Decider` / `Stream.Resolve` helpers)
+    member _.Stream(log: Serilog.ILogger, context: 'context, streamId) =
+        let struct (inner, streamName, init) = resolveStream name streamId
         { new Core.IStream<'event, 'state> with
             member _.Name = streamName
             member _.LoadEmpty() =
                 empty
             member _.Load(maxAge, requireLeader, ct) = task {
                 use act = source.StartActivity("Load", ActivityKind.Client)
-                if act <> null then act.AddStream(categoryName, streamId, streamName).AddLeader(requireLeader).AddStale(maxAge) |> ignore
-                return! inner.Load(log, categoryName, streamId, streamName, maxAge, requireLeader, ct) }
+                if act <> null then act.AddStream(name, streamId, streamName).AddLeader(requireLeader).AddStale(maxAge) |> ignore
+                return! inner.Load(log, name, streamId, streamName, maxAge, requireLeader, ct) }
             member _.Sync(attempt, token, originState, events, ct) = task {
                 use act = source.StartActivity("Sync", ActivityKind.Client)
-                if act <> null then act.AddStream(categoryName, streamId, streamName).AddSyncAttempt(attempt) |> ignore
+                if act <> null then act.AddStream(name, streamId, streamName).AddSyncAttempt(attempt) |> ignore
                 let log = if attempt = 1 then log else log.ForContext("attempts", attempt)
-                return! inner.Sync(log, categoryName, streamId, streamName, context, init, token, originState, events, ct) } }
-
-[<AbstractClass; Sealed>]
-type private Stream private () =
-    static member Resolve(cat: Category<'event, 'state, 'context>, log, context): System.Func<string, Core.StreamId, Core.IStream<'event, 'state>> =
-        System.Func<string, Core.StreamId, _>(fun categoryName streamId -> cat.Stream(log, context, categoryName, Core.StreamId.toString streamId))
+                return! inner.Sync(log, name, streamId, streamName, context, init, token, originState, events, ct) } }
 
 [<AbstractClass; Sealed; System.Runtime.CompilerServices.Extension>]
-type Factory private () =
+type Stream private () =
     [<System.Runtime.CompilerServices.Extension>]
-    static member Resolve(cat: Category<'event, 'state, 'context>, log, context): System.Func<string, Core.StreamId, DeciderCore<'event, 'state>> =
-         System.Func<_, _, _>(fun c s -> Stream.Resolve(cat, log, context).Invoke(c, s) |> DeciderCore<'event, 'state>)
+    static member Resolve(cat: Category<'event, 'state, 'context>, log, context): System.Func<Core.StreamId, DeciderCore<'event, 'state>> =
+         System.Func<_, _>(fun sid -> cat.Stream(log, context, Core.StreamId.toString sid) |> DeciderCore<'event, 'state>)
     [<System.Runtime.CompilerServices.Extension>]
-    static member Resolve(cat: Category<'event, 'state, unit>, log): System.Func<string, Core.StreamId, DeciderCore<'event, 'state>> =
-        Factory.Resolve(cat, log, ())
+    static member Resolve(cat: Category<'event, 'state, unit>, log): System.Func<Core.StreamId, DeciderCore<'event, 'state>> =
+        Stream.Resolve(cat, log, ())
 
 module Decider =
-    let resolveWithContext log (cat: Category<'event, 'state, 'context>) categoryName context streamId =
-        Factory.Resolve(cat, log, context).Invoke(categoryName, streamId) |> Decider<'event, 'state>
-    let resolve log (cat: Category<'event, 'state, unit>) categoryName streamId =
-        resolveWithContext log cat categoryName () streamId
+    let forContext log (cat: Category<'event, 'state, 'context>) context streamId =
+        Stream.Resolve(cat, log, context).Invoke(streamId) |> Decider<'event, 'state>
+    let forStream log (cat: Category<'event, 'state, unit>) streamId =
+        forContext log cat () streamId

--- a/src/Equinox.Core/Category.fs
+++ b/src/Equinox.Core/Category.fs
@@ -35,7 +35,6 @@ type Category<'event, 'state, 'context>
     (   name,
         resolveStream: string -> string -> struct (Core.ICategory<'event, 'state, 'context> * string * (CancellationToken -> Task<unit>) voption),
         empty: struct (Core.StreamToken * 'state)) =
-    member val private Name = name
     /// Provides access to the low level store operations used for Loading and/or Syncing updates via the Decider
     /// (Normal usage is via the adjacent `module Decider` / `Stream.Resolve` helpers)
     member _.Stream(log: Serilog.ILogger, context: 'context, streamId) =

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -1366,9 +1366,9 @@ type AccessStrategy<'event, 'state> =
     /// </remarks>
     | Custom of isOrigin: ('event -> bool) * transmute: ('event[] -> 'state -> 'event[] * 'event[])
 
-type CosmosStoreCategory<'event, 'state, 'context> internal (resolveInner, empty) =
-    inherit Equinox.Category<'event, 'state, 'context>(resolveInner, empty)
-    new(context: CosmosStoreContext, codec, fold, initial, caching, access,
+type CosmosStoreCategory<'event, 'state, 'context> internal (name, resolveInner, empty) =
+    inherit Equinox.Category<'event, 'state, 'context>(name, resolveInner, empty)
+    new(context: CosmosStoreContext, name, codec, fold, initial, caching, access,
         // Compress Unfolds in Tip. Default: <c>true</c>.
         // NOTE when set to <c>false</c>, requires Equinox.CosmosStore or Equinox.Cosmos Version >= 2.3.0 to be able to read
         [<O; D null>] ?compressUnfolds) =
@@ -1395,7 +1395,7 @@ type CosmosStoreCategory<'event, 'state, 'context> internal (resolveInner, empty
             let struct (container, streamName, maybeContainerInitializationGate) = context.ResolveContainerClientAndStreamIdAndInit(categoryName, streamId)
             struct (resolveCategory (categoryName, container), streamName, maybeContainerInitializationGate)
         let empty = struct (Token.create Position.fromKnownEmpty, initial)
-        CosmosStoreCategory(resolveInner, empty)
+        CosmosStoreCategory(name, resolveInner, empty)
 
 namespace Equinox.CosmosStore.Core
 

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -1075,6 +1075,7 @@ type internal Category<'event, 'state, 'context>
         | LoadFromTokenResult.Unchanged -> return struct (streamToken, state)
         | LoadFromTokenResult.Found (token', events) -> return token', fold state events }
     interface ICategory<'event, 'state, 'context> with
+        member _.Empty = Token.create Position.fromKnownEmpty, initial
         member _.Load(log, _categoryName, _streamId, stream, _maxAge, _requireLeader, ct): Task<struct (StreamToken * 'state)> = task {
             let! token, events = store.Load(log, (stream, None), (codec.TryDecode, isOrigin), checkUnfolds, ct)
             return struct (token, fold initial events) }
@@ -1366,9 +1367,9 @@ type AccessStrategy<'event, 'state> =
     /// </remarks>
     | Custom of isOrigin: ('event -> bool) * transmute: ('event[] -> 'state -> 'event[] * 'event[])
 
-type CosmosStoreCategory<'event, 'state, 'context> internal (name, resolveInner, empty) =
-    inherit Equinox.Category<'event, 'state, 'context>(name, resolveInner, empty)
-    new(context: CosmosStoreContext, name, codec, fold, initial, caching, access,
+type CosmosStoreCategory<'event, 'state, 'context> internal (name, resolveStream) =
+    inherit Equinox.Category<'event, 'state, 'context>(name, resolveStream = resolveStream)
+    new(context: CosmosStoreContext, name, codec, fold, initial, access, caching,
         // Compress Unfolds in Tip. Default: <c>true</c>.
         // NOTE when set to <c>false</c>, requires Equinox.CosmosStore or Equinox.Cosmos Version >= 2.3.0 to be able to read
         [<O; D null>] ?compressUnfolds) =
@@ -1386,16 +1387,15 @@ type CosmosStoreCategory<'event, 'state, 'context> internal (name, resolveInner,
             | CachingStrategy.SlidingWindow (cache, window) -> Some (Equinox.CachingStrategy.SlidingWindow (cache, window))
             | CachingStrategy.FixedTimeSpan (cache, period) -> Some (Equinox.CachingStrategy.FixedTimeSpan (cache, period))
         let categories = System.Collections.Concurrent.ConcurrentDictionary<string, ICategory<'event, 'state, 'context>>()
-        let resolveCategory (categoryName, container) =
+        let resolveInner (categoryName, container) =
             let createCategory _name: ICategory<_, _, 'context> =
                 Category<'event, 'state, 'context>(container, codec, fold, initial, isOrigin, checkUnfolds, compressUnfolds, mapUnfolds)
                 |> Caching.apply Token.isStale caching
             categories.GetOrAdd(categoryName, createCategory)
-        let resolveInner categoryName streamId =
-            let struct (container, streamName, maybeContainerInitializationGate) = context.ResolveContainerClientAndStreamIdAndInit(categoryName, streamId)
-            struct (resolveCategory (categoryName, container), streamName, maybeContainerInitializationGate)
-        let empty = struct (Token.create Position.fromKnownEmpty, initial)
-        CosmosStoreCategory(name, resolveInner, empty)
+        let resolveStream streamId =
+            let struct (container, streamName, maybeContainerInitializationGate) = context.ResolveContainerClientAndStreamIdAndInit(name, streamId)
+            struct (resolveInner (name, container), streamName, maybeContainerInitializationGate)
+        CosmosStoreCategory(name, resolveStream)
 
 namespace Equinox.CosmosStore.Core
 

--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -1318,9 +1318,9 @@ type AccessStrategy<'event, 'state> =
     /// </remarks>
     | Custom of isOrigin: ('event -> bool) * transmute: ('event[] -> 'state -> 'event[] * 'event[])
 
-type DynamoStoreCategory<'event, 'state, 'context>(resolveInner, empty) =
-    inherit Equinox.Category<'event, 'state, 'context>(resolveInner, empty)
-    new(context: DynamoStoreContext, codec, fold, initial, caching, access) =
+type DynamoStoreCategory<'event, 'state, 'context>(name, resolveInner, empty) =
+    inherit Equinox.Category<'event, 'state, 'context>(name, resolveInner, empty)
+    new(context: DynamoStoreContext, name, codec, fold, initial, caching, access) =
         let isOrigin, checkUnfolds, mapUnfolds =
             match access with
             | AccessStrategy.Unoptimized ->                      (fun _ -> false), false, Choice1Of3 ()
@@ -1343,7 +1343,7 @@ type DynamoStoreCategory<'event, 'state, 'context>(resolveInner, empty) =
             let struct (container, streamName) = context.ResolveContainerClientAndStreamName(categoryName, streamId)
             struct (resolveCategory (categoryName, container), streamName, ValueNone)
         let empty = struct (Token.empty, initial)
-        DynamoStoreCategory(resolveInner, empty)
+        DynamoStoreCategory(name, resolveInner, empty)
 
 module Exceptions =
 

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -457,6 +457,7 @@ type private Category<'event, 'state, 'context>(context: EventStoreContext, code
     let fetch state f = task { let! token', events = f in return struct (token', fold state (Seq.ofArray events)) }
     let reload (log, sn, leader, token, state) = fetch state (context.Reload(log, sn, leader, token, tryDecode, compactionPredicate))
     interface ICategory<'event, 'state, 'context> with
+        member _.Empty = context.TokenEmpty, initial
         member _.Load(log, _categoryName, _streamId, streamName, _maxAge, requireLeader, _ct) =
             fetch initial (loadAlgorithm log streamName requireLeader)
         member _.Sync(log, _categoryName, _streamId, streamName, ctx, _maybeInit, (Token.Unpack token as streamToken), state, events, _ct) = task {
@@ -473,13 +474,12 @@ type private Category<'event, 'state, 'context>(context: EventStoreContext, code
             | GatewaySyncResult.ConflictUnknown _ -> return SyncResult.Conflict (fun _ct -> reload (log, streamName, true, streamToken, state)) }
     interface Caching.IReloadable<'state> with member _.Reload(log, sn, leader, token, state, _ct) = reload (log, sn, leader, token, state)
 
-type EventStoreCategory<'event, 'state, 'context> internal (name, resolveInner, empty) =
-    inherit Equinox.Category<'event, 'state, 'context>(name, resolveInner, empty)
-    new(context: EventStoreContext, name, codec: FsCodec.IEventCodec<_, _, 'context>, fold, initial,
+type EventStoreCategory<'event, 'state, 'context> internal (name, inner) =
+    inherit Equinox.Category<'event, 'state, 'context>(name, inner = inner)
+    new(context: EventStoreContext, name, codec: FsCodec.IEventCodec<_, _, 'context>, fold, initial, [<O; D(null)>] ?access,
         // Caching can be overkill for EventStore esp considering the degree to which its intrinsic caching is a first class feature
         // e.g., A key benefit is that reads of streams more than a few pages long get completed in constant time after the initial load
-        [<O; D(null)>] ?caching,
-        [<O; D(null)>] ?access) =
+        [<O; D(null)>] ?caching) =
         do  match access with
             | Some AccessStrategy.LatestKnownEvent when Option.isSome caching ->
                 "Equinox.EventStore does not support (and it would make things _less_ efficient even if it did)"
@@ -487,9 +487,7 @@ type EventStoreCategory<'event, 'state, 'context> internal (name, resolveInner, 
                 |> invalidOp
             | _ -> ()
         let cat = Category<'event, 'state, 'context>(context, codec, fold, initial, access) |> Caching.apply Token.isStale caching
-        let resolveInner categoryName streamId = struct (cat, StreamName.render categoryName streamId, ValueNone)
-        let empty = struct (context.TokenEmpty, initial)
-        EventStoreCategory(name, resolveInner, empty)
+        EventStoreCategory(name, inner = cat)
 
 type private SerilogAdapter(log: ILogger) =
     interface EventStore.ClientAPI.ILogger with

--- a/src/Equinox.EventStoreDb/EventStoreDb.fs
+++ b/src/Equinox.EventStoreDb/EventStoreDb.fs
@@ -416,9 +416,9 @@ type private Category<'event, 'state, 'context>(context: EventStoreContext, code
             | GatewaySyncResult.Written token' ->    return SyncResult.Written  (token', fold state events)
             | GatewaySyncResult.ConflictUnknown _ -> return SyncResult.Conflict (reload (log, streamName, (*requireLeader*)true, streamToken, state)) }
 
-type EventStoreCategory<'event, 'state, 'context> internal (resolveInner, empty) =
-    inherit Equinox.Category<'event, 'state, 'context>(resolveInner, empty)
-    new(context: EventStoreContext, codec: FsCodec.IEventCodec<_, _, 'context>, fold, initial,
+type EventStoreCategory<'event, 'state, 'context> internal (name, resolveInner, empty) =
+    inherit Equinox.Category<'event, 'state, 'context>(name, resolveInner, empty)
+    new(context: EventStoreContext, name, codec: FsCodec.IEventCodec<_, _, 'context>, fold, initial,
         // Caching can be overkill for EventStore esp considering the degree to which its intrinsic caching is a first class feature
         // e.g., A key benefit is that reads of streams more than a few pages long get completed in constant time after the initial load
         [<O; D(null)>] ?caching,
@@ -432,7 +432,7 @@ type EventStoreCategory<'event, 'state, 'context> internal (resolveInner, empty)
         let cat = Category<'event, 'state, 'context>(context, codec, fold, initial, access) |> Caching.apply Token.isStale caching
         let resolveInner categoryName streamId = struct (cat, StreamName.render categoryName streamId, ValueNone)
         let empty = struct (context.TokenEmpty, initial)
-        EventStoreCategory(resolveInner, empty)
+        EventStoreCategory(name, resolveInner, empty)
 
 [<RequireQualifiedAccess; NoComparison>]
 type Discovery =

--- a/src/Equinox.MemoryStore/MemoryStore.fs
+++ b/src/Equinox.MemoryStore/MemoryStore.fs
@@ -87,10 +87,10 @@ type private Category<'event, 'state, 'context, 'Format>(store: VolatileStore<'F
                     return struct (token', fold state (conflictingEvents |> Seq.skip eventCount |> Seq.chooseV codec.TryDecode)) }
                 return SyncResult.Conflict resync }
 
-type MemoryStoreCategory<'event, 'state, 'Format, 'context> internal (resolveInner, empty) =
-    inherit Equinox.Category<'event, 'state, 'context>(resolveInner, empty)
-    new(store: VolatileStore<'Format>, codec: FsCodec.IEventCodec<'event, 'Format, 'context>, fold, initial) =
+type MemoryStoreCategory<'event, 'state, 'Format, 'context> internal (categoryName, resolveInner, empty) =
+    inherit Equinox.Category<'event, 'state, 'context>(categoryName, resolveInner, empty)
+    new(store: VolatileStore<'Format>, name: string, codec: FsCodec.IEventCodec<'event, 'Format, 'context>, fold, initial) =
         let impl = Category<'event, 'state, 'context, 'Format>(store, codec, fold, initial) :> ICategory<_, _, _>
-        let resolveInner categoryName streamId = struct (impl, StreamName.render categoryName streamId, ValueNone)
+        let resolveStream categoryName streamId = struct (impl, StreamName.render categoryName streamId, ValueNone)
         let empty = struct (Token.ofEmpty, initial)
-        MemoryStoreCategory(resolveInner, empty)
+        MemoryStoreCategory(name, resolveStream, empty)

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -387,6 +387,7 @@ type private Category<'event, 'state, 'context>(context: MessageDbContext, codec
             | ValueNone -> return! context.LoadBatched(log, streamName, requireLeader, codec.TryDecode, fold, initial, ct) }
     let reload (log, sn, leader, token, state) ct = context.Reload(log, sn, leader, token, codec.TryDecode, fold, state, ct)
     interface ICategory<'event, 'state, 'context> with
+        member _.Empty = context.TokenEmpty, initial
         member _.Load(log, categoryName, streamId, streamName, _maxAge, requireLeader, ct) =
             loadAlgorithm log categoryName streamId streamName requireLeader ct
         member x.Sync(log, categoryName, streamId, streamName, ctx, _maybeInit, token, state, events, ct) = task {
@@ -411,14 +412,8 @@ type private Category<'event, 'state, 'context>(context: MessageDbContext, codec
             FsCodec.Core.EventData.Create(rawEvent.EventType, rawEvent.Data, meta = Snapshot.meta token)
         context.StoreSnapshot(log, category, streamId, encodedWithMeta, ct)
 
-type MessageDbCategory<'event, 'state, 'context> internal (name, resolveInner, empty) =
-    inherit Equinox.Category<'event, 'state, 'context>(name, resolveInner, empty)
-    new(context: MessageDbContext, name, codec: IEventCodec<_, _, 'context>, fold, initial,
+type MessageDbCategory<'event, 'state, 'context>(context: MessageDbContext, name, codec, fold, initial, [<O; D(null)>]?access,
         // For MessageDb, caching is less critical than it is for e.g. CosmosDB
         // As such, it can often be omitted, particularly if streams are short, or events are small and/or database latency aligns with request latency requirements
-        [<O; D(null)>]?caching,
-        [<O; D(null)>]?access) =
-        let cat = Category<'event, 'state, 'context>(context, codec, fold, initial, access) |> Caching.apply Token.isStale caching
-        let resolveInner categoryName streamId = struct (cat, StreamName.render categoryName streamId, ValueNone)
-        let empty = struct (context.TokenEmpty, initial)
-        MessageDbCategory(name, resolveInner, empty)
+        [<O; D(null)>]?caching) =
+    inherit Equinox.Category<'event, 'state, 'context>(name, Category(context, codec, fold, initial, access) |> Caching.apply Token.isStale caching)

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -411,9 +411,9 @@ type private Category<'event, 'state, 'context>(context: MessageDbContext, codec
             FsCodec.Core.EventData.Create(rawEvent.EventType, rawEvent.Data, meta = Snapshot.meta token)
         context.StoreSnapshot(log, category, streamId, encodedWithMeta, ct)
 
-type MessageDbCategory<'event, 'state, 'context> internal (resolveInner, empty) =
-    inherit Equinox.Category<'event, 'state, 'context>(resolveInner, empty)
-    new(context: MessageDbContext, codec: IEventCodec<_, _, 'context>, fold, initial,
+type MessageDbCategory<'event, 'state, 'context> internal (name, resolveInner, empty) =
+    inherit Equinox.Category<'event, 'state, 'context>(name, resolveInner, empty)
+    new(context: MessageDbContext, name, codec: IEventCodec<_, _, 'context>, fold, initial,
         // For MessageDb, caching is less critical than it is for e.g. CosmosDB
         // As such, it can often be omitted, particularly if streams are short, or events are small and/or database latency aligns with request latency requirements
         [<O; D(null)>]?caching,
@@ -421,4 +421,4 @@ type MessageDbCategory<'event, 'state, 'context> internal (resolveInner, empty) 
         let cat = Category<'event, 'state, 'context>(context, codec, fold, initial, access) |> Caching.apply Token.isStale caching
         let resolveInner categoryName streamId = struct (cat, StreamName.render categoryName streamId, ValueNone)
         let empty = struct (context.TokenEmpty, initial)
-        MessageDbCategory(resolveInner, empty)
+        MessageDbCategory(name, resolveInner, empty)

--- a/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
+++ b/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
@@ -16,10 +16,10 @@ module WiringHelpers =
 
     let private createCategoryUncached name codec initial fold accessStrategy context =
         let noCachingCacheStrategy = CachingStrategy.NoCaching
-        StoreCategory(context, name, codec, fold, initial, noCachingCacheStrategy, accessStrategy)
+        StoreCategory(context, name, codec, fold, initial, accessStrategy, noCachingCacheStrategy)
     let private createCategory name codec initial fold accessStrategy (context, cache) =
         let sliding20mCacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        StoreCategory(context, name, codec, fold, initial, sliding20mCacheStrategy, accessStrategy)
+        StoreCategory(context, name, codec, fold, initial, accessStrategy, sliding20mCacheStrategy)
 
     let createCategoryUnoptimizedUncached name codec initial fold context =
         let accessStrategy = AccessStrategy.Unoptimized

--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -23,28 +23,28 @@ module Cart =
     let codec = Cart.Events.codecJe
 #endif
     let createServiceWithoutOptimization log context =
-        StoreCategory(context, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.Unoptimized)
-        |> Equinox.Decider.resolve log
+        StoreCategory(context, Cart.Category, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.Unoptimized)
+        |> Equinox.Decider.forStream log
         |> Cart.create
     /// Trigger looking in Tip (we want those calls to occur, but without leaning on snapshots, which would reduce the paths covered)
     let createServiceWithEmptyUnfolds log context =
         let unfArgs = Cart.Fold.isOrigin, fun _ -> Array.empty
-        StoreCategory(context, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.MultiSnapshot unfArgs)
-        |> Equinox.Decider.resolve log
+        StoreCategory(context, Cart.Category, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.MultiSnapshot unfArgs)
+        |> Equinox.Decider.forStream log
         |> Cart.create
     let createServiceWithSnapshotStrategy log context =
-        StoreCategory(context, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.Snapshot snapshot)
-        |> Equinox.Decider.resolve log
+        StoreCategory(context, Cart.Category, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.Snapshot snapshot)
+        |> Equinox.Decider.forStream log
         |> Cart.create
     let createServiceWithSnapshotStrategyAndCaching log context cache =
         let sliding20m = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        StoreCategory(context, codec, fold, initial, sliding20m, AccessStrategy.Snapshot snapshot)
-        |> Equinox.Decider.resolve log
+        StoreCategory(context, Cart.Category, codec, fold, initial, sliding20m, AccessStrategy.Snapshot snapshot)
+        |> Equinox.Decider.forStream log
         |> Cart.create
     let createServiceWithRollingState log context =
         let access = AccessStrategy.RollingState Cart.Fold.snapshot
-        StoreCategory(context, codec, fold, initial, CachingStrategy.NoCaching, access)
-        |> Equinox.Decider.resolve log
+        StoreCategory(context, Cart.Category, codec, fold, initial, CachingStrategy.NoCaching, access)
+        |> Equinox.Decider.forStream log
         |> Cart.create
     let streamName = Cart.streamId >> StreamName.render Cart.Category
 
@@ -56,8 +56,8 @@ module ContactPreferences =
     let codec = ContactPreferences.Events.codecJe
 #endif
     let private createServiceWithLatestKnownEvent context log cachingStrategy =
-        StoreCategory(context, codec, fold, initial, cachingStrategy, AccessStrategy.LatestKnownEvent)
-        |> Equinox.Decider.resolve log
+        StoreCategory(context, ContactPreferences.Category, codec, fold, initial, cachingStrategy, AccessStrategy.LatestKnownEvent)
+        |> Equinox.Decider.forStream log
         |> ContactPreferences.create
     let createServiceWithoutCaching log context =
         createServiceWithLatestKnownEvent context log CachingStrategy.NoCaching

--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -23,27 +23,27 @@ module Cart =
     let codec = Cart.Events.codecJe
 #endif
     let createServiceWithoutOptimization log context =
-        StoreCategory(context, Cart.Category, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.Unoptimized)
+        StoreCategory(context, Cart.Category, codec, fold, initial, AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> Cart.create
     /// Trigger looking in Tip (we want those calls to occur, but without leaning on snapshots, which would reduce the paths covered)
     let createServiceWithEmptyUnfolds log context =
         let unfArgs = Cart.Fold.isOrigin, fun _ -> Array.empty
-        StoreCategory(context, Cart.Category, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.MultiSnapshot unfArgs)
+        StoreCategory(context, Cart.Category, codec, fold, initial, AccessStrategy.MultiSnapshot unfArgs, CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> Cart.create
     let createServiceWithSnapshotStrategy log context =
-        StoreCategory(context, Cart.Category, codec, fold, initial, CachingStrategy.NoCaching, AccessStrategy.Snapshot snapshot)
+        StoreCategory(context, Cart.Category, codec, fold, initial, AccessStrategy.Snapshot snapshot, CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> Cart.create
     let createServiceWithSnapshotStrategyAndCaching log context cache =
         let sliding20m = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        StoreCategory(context, Cart.Category, codec, fold, initial, sliding20m, AccessStrategy.Snapshot snapshot)
+        StoreCategory(context, Cart.Category, codec, fold, initial, AccessStrategy.Snapshot snapshot, sliding20m)
         |> Equinox.Decider.forStream log
         |> Cart.create
     let createServiceWithRollingState log context =
         let access = AccessStrategy.RollingState Cart.Fold.snapshot
-        StoreCategory(context, Cart.Category, codec, fold, initial, CachingStrategy.NoCaching, access)
+        StoreCategory(context, Cart.Category, codec, fold, initial, access, CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> Cart.create
     let streamName = Cart.streamId >> StreamName.render Cart.Category
@@ -56,7 +56,7 @@ module ContactPreferences =
     let codec = ContactPreferences.Events.codecJe
 #endif
     let private createServiceWithLatestKnownEvent context log cachingStrategy =
-        StoreCategory(context, ContactPreferences.Category, codec, fold, initial, cachingStrategy, AccessStrategy.LatestKnownEvent)
+        StoreCategory(context, ContactPreferences.Category, codec, fold, initial, AccessStrategy.LatestKnownEvent, cachingStrategy)
         |> Equinox.Decider.forStream log
         |> ContactPreferences.create
     let createServiceWithoutCaching log context =

--- a/tests/Equinox.EventStoreDb.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStoreDb.Integration/StoreIntegration.fs
@@ -131,20 +131,20 @@ module Cart =
 
     let createServiceWithCaching log context cache =
         let sliding20m = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        Category(context, Cart.Category, codec, fold, initial, sliding20m)
+        Category(context, Cart.Category, codec, fold, initial, caching = sliding20m)
         |> Equinox.Decider.forStream log
         |> Cart.create
 
     #if STORE_MESSAGEDB
     let createServiceWithSnapshottingAndCaching log context cache =
             let sliding20m = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-            Category(context, Cart.Category, codec, fold, initial, sliding20m, AccessStrategy.AdjacentSnapshots snapshot)
+            Category(context, Cart.Category, codec, fold, initial, AccessStrategy.AdjacentSnapshots snapshot, sliding20m)
             |> Equinox.Decider.forStream log
             |> Cart.create
     #else
     let createServiceWithCompactionAndCaching log context cache =
         let sliding20m = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        Category(context, Cart.Category, codec, fold, initial, sliding20m, AccessStrategy.RollingSnapshots snapshot)
+        Category(context, Cart.Category, codec, fold, initial, AccessStrategy.RollingSnapshots snapshot, sliding20m)
         |> Equinox.Decider.forStream log
         |> Cart.create
     #endif

--- a/tests/Equinox.EventStoreDb.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStoreDb.Integration/StoreIntegration.fs
@@ -101,50 +101,51 @@ module SimplestThing =
     let evolve (_state: Event) (event: Event) = event
     let fold = Seq.fold evolve
     let initial = StuffHappened
-    let resolve log context =
-        Category(context, codec, fold, initial)
-        |> Equinox.Decider.resolve log
-    let [<Literal>] Category = "SimplestThing"
+    let [<Literal>] CategoryName = "SimplestThing"
+    let streamId = Equinox.StreamId.gen Guid.toStringN
+    let decider log context id =
+        let cat = Category(context, CategoryName, codec, fold, initial)
+        Equinox.Decider.forStream log cat (streamId id)
 
 module Cart =
     let fold, initial = Cart.Fold.fold, Cart.Fold.initial
     let codec = Cart.Events.codec
     let createServiceWithoutOptimization log context =
-        Category(context, codec, fold, initial)
-        |> Equinox.Decider.resolve log
+        Category(context, Cart.Category, codec, fold, initial)
+        |> Equinox.Decider.forStream log
         |> Cart.create
 
     #if STORE_MESSAGEDB
     let snapshot = Cart.Fold.snapshotEventCaseName, Cart.Fold.snapshot
     let createServiceWithAdjacentSnapshotting log context =
-        Category(context, codec, fold, initial, access = AccessStrategy.AdjacentSnapshots snapshot)
-        |> Equinox.Decider.resolve log
+        Category(context, Cart.Category, codec, fold, initial, access = AccessStrategy.AdjacentSnapshots snapshot)
+        |> Equinox.Decider.forStream log
         |> Cart.create
     #else
     let snapshot = Cart.Fold.isOrigin, Cart.Fold.snapshot
     let createServiceWithCompaction log context =
-        Category(context, codec, fold, initial, access = AccessStrategy.RollingSnapshots snapshot)
-        |> Equinox.Decider.resolve log
+        Category(context, Cart.Category, codec, fold, initial, access = AccessStrategy.RollingSnapshots snapshot)
+        |> Equinox.Decider.forStream log
         |> Cart.create
     #endif
 
     let createServiceWithCaching log context cache =
         let sliding20m = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        Category(context, codec, fold, initial, sliding20m)
-        |> Equinox.Decider.resolve log
+        Category(context, Cart.Category, codec, fold, initial, sliding20m)
+        |> Equinox.Decider.forStream log
         |> Cart.create
 
     #if STORE_MESSAGEDB
     let createServiceWithSnapshottingAndCaching log context cache =
             let sliding20m = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-            Category(context, codec, fold, initial, sliding20m, AccessStrategy.AdjacentSnapshots snapshot)
-            |> Equinox.Decider.resolve log
+            Category(context, Cart.Category, codec, fold, initial, sliding20m, AccessStrategy.AdjacentSnapshots snapshot)
+            |> Equinox.Decider.forStream log
             |> Cart.create
     #else
     let createServiceWithCompactionAndCaching log context cache =
         let sliding20m = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        Category(context, codec, fold, initial, sliding20m, AccessStrategy.RollingSnapshots snapshot)
-        |> Equinox.Decider.resolve log
+        Category(context, Cart.Category, codec, fold, initial, sliding20m, AccessStrategy.RollingSnapshots snapshot)
+        |> Equinox.Decider.forStream log
         |> Cart.create
     #endif
 
@@ -153,13 +154,13 @@ module ContactPreferences =
     let codec = ContactPreferences.Events.codec
     let createServiceWithoutOptimization log connection =
         let context = createContext connection defaultBatchSize
-        Category(context, codec, fold, initial)
-        |> Equinox.Decider.resolve log
+        Category(context, ContactPreferences.Category, codec, fold, initial)
+        |> Equinox.Decider.forStream log
         |> ContactPreferences.create
 
     let createService log connection =
-        Category(createContext connection 1, codec, fold, initial, access = AccessStrategy.LatestKnownEvent)
-        |> Equinox.Decider.resolve log
+        Category(createContext connection 1, ContactPreferences.Category, codec, fold, initial, access = AccessStrategy.LatestKnownEvent)
+        |> Equinox.Decider.forStream log
         |> ContactPreferences.create
 
 let addAndThenRemoveItems optimistic exceptTheLastOne context cartId skuId (service: Cart.Service) count =
@@ -429,8 +430,7 @@ type GeneralTests(testOutputHelper) =
         let batchSize = 3
         let context = createContext connection batchSize
         let id = Guid.NewGuid()
-        let toStreamId (x: Guid) = x.ToString "N"
-        let decider = SimplestThing.resolve log context SimplestThing.Category (Equinox.StreamId.gen toStreamId id)
+        let decider = SimplestThing.decider log context id
 
         let! before, after = decider.TransactEx(
             (fun state -> state.Version, [SimplestThing.StuffHappened]),

--- a/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
+++ b/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
@@ -16,8 +16,8 @@ type AutoDataAttribute() =
 let createMemoryStore () = VolatileStore<_>()
 
 let createServiceMemory log store =
-    let cat = MemoryStoreCategory(store, FsCodec.Box.Codec.Create(), Cart.Fold.fold, Cart.Fold.initial)
-    cat |> Equinox.Decider.resolve log |> Cart.create
+    let cat = MemoryStoreCategory(store, Cart.Category, FsCodec.Box.Codec.Create(), Cart.Fold.fold, Cart.Fold.initial)
+    cat |> Equinox.Decider.forStream log |> Cart.create
 
 type Tests(testOutputHelper) =
     let log = TestOutput(testOutputHelper).CreateLogger()
@@ -57,8 +57,8 @@ type Tests(testOutputHelper) =
     }
 
 let createFavoritesServiceMemory store log : Favorites.Service =
-    let cat = MemoryStoreCategory(store, FsCodec.Box.Codec.Create(), Favorites.Fold.fold, Favorites.Fold.initial)
-    cat |> Equinox.Decider.resolve log |> Favorites.create
+    let cat = MemoryStoreCategory(store, Favorites.Category, FsCodec.Box.Codec.Create(), Favorites.Fold.fold, Favorites.Fold.initial)
+    cat |> Equinox.Decider.forStream log |> Favorites.create
 
 type ChangeFeed(testOutputHelper) =
     let log = TestOutput(testOutputHelper).CreateLogger()

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -44,14 +44,14 @@ type Arguments =
             | Dump _ ->                     "Load and show events in a specified stream (supports all stores)."
 and [<NoComparison; NoEquality>] InitParameters =
     | [<AltCommandLine "-ru"; Unique>]      Rus of int
-    | [<AltCommandLine "-A"; Unique>]       AutoScale
+    | [<AltCommandLine "-A"; Unique>]       Autoscale
     | [<AltCommandLine "-m"; Unique>]       Mode of CosmosModeType
     | [<AltCommandLine "-P"; Unique>]       SkipStoredProc
     | [<CliPrefix(CliPrefix.None)>]         Cosmos of ParseResults<Store.Cosmos.Parameters>
     interface IArgParserTemplate with
         member a.Usage = a |> function
             | Rus _ ->                      "Specify RU/s level to provision (Not applicable for Serverless Mode; Default: 400 RU/s for Container/Database; Default: Max 4000 RU/s for Container/Database when Autoscale specified)."
-            | AutoScale ->                  "Autoscale provisioned throughput. Use --rus to specify the maximum RU/s."
+            | Autoscale ->                  "Autoscale provisioned throughput. Use --rus to specify the maximum RU/s."
             | Mode _ ->                     "Configure RU mode to use Container-level RU, Database-level RU, or Serverless allocations (Default: Use Container-level allocation)."
             | SkipStoredProc ->             "Inhibit creation of stored procedure in specified Container."
             | Cosmos _ ->                   "Cosmos Connection parameters."
@@ -60,7 +60,7 @@ and CosmosInitArguments(p : ParseResults<InitParameters>) =
     let rusOrDefault value = p.GetResult(Rus, value)
     let throughput auto = if auto then CosmosInit.Throughput.Autoscale (rusOrDefault 4000) else CosmosInit.Throughput.Manual (rusOrDefault 400)
     member val ProvisioningMode =
-        match p.GetResult(Mode, CosmosModeType.Container), p.Contains AutoScale with
+        match p.GetResult(Mode, CosmosModeType.Container), p.Contains Autoscale with
         | CosmosModeType.Container, auto -> CosmosInit.Provisioning.Container (throughput auto)
         | CosmosModeType.Db, auto ->        CosmosInit.Provisioning.Database (throughput auto)
         | CosmosModeType.Serverless, auto when auto || p.Contains Rus -> Store.missingArg "Cannot specify RU/s or Autoscale in Serverless mode"


### PR DESCRIPTION
Following @nordfjord and @everzet's leadership in https://github.com/nordfjord/equinox-js/pull/6

- all `*StoreCategory` types now have a `Name` as a second argument rather than having it littering the `Decider.resolve` partial application chain.
- the `caching` argument moves to the end of the constructor argument list, to reflect that Caching, which was once a store-specific integration, is now a fairly separable decorator (one can imagine adjusting it so that it gets applied independent of the `Category` construction at some point)

IME This has made factory wiring in apps much more terse, with less juggling of compiler errors, and also removes the ugly temporary `Equinox.Factory` name, so I trust that on balance this is a good change