### PR TITLE
refactor(CosmosStore): Cleanup stored proc initialization

### DIFF
--- a/src/Equinox.Core/Caching.fs
+++ b/src/Equinox.Core/Caching.fs
@@ -20,10 +20,10 @@ type private Decorator<'event, 'state, 'context, 'cat when 'cat :> ICategory<'ev
                 | ValueNone -> category.Load(log, categoryName, streamId, streamName, maxAge, requireLeader, ct)
                 | ValueSome (struct (token, state)) -> category.Reload(log, streamName, requireLeader, token, state, ct)
             return! cache.Load(createKey streamName, maxAge, isStale, createOptions (), loadOrReload, ct) }
-        member _.Sync(log, categoryName, streamId, streamName, context, maybeInit, streamToken, state, events, ct) = task {
+        member _.Sync(log, categoryName, streamId, streamName, context, streamToken, state, events, ct) = task {
             let timestamp = System.Diagnostics.Stopwatch.GetTimestamp() // NB take the timestamp before any potential write takes place
             let save struct (token, state) = cache.Save(createKey streamName, isStale, createOptions (), timestamp, token, state)
-            match! category.Sync(log, categoryName, streamId, streamName, context, maybeInit, streamToken, state, events, ct) with
+            match! category.Sync(log, categoryName, streamId, streamName, context, streamToken, state, events, ct) with
             | SyncResult.Written tokenAndState' ->
                 save tokenAndState'
                 return SyncResult.Written tokenAndState'

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -580,8 +580,10 @@ module Initialization =
         let initGuard = initContainer |> Option.map (fun init -> AsyncCacheCell<unit>(init container))
         member _.Container = container
         member _.Fallback = fallback
-        member internal _.Initialize(ct): ValueTask =
-            match initGuard with Some g when not (g.IsValid()) -> g.Await(ct) |> ValueTask.ofTask |> ValueTask.ignore | _ -> ValueTask.CompletedTask
+        member internal _.Initialize(ct): System.Threading.Tasks.ValueTask =
+            match initGuard with
+            | Some g when not (g.IsValid()) -> g.Await(ct) |> ValueTask.ofTask |> ValueTask.ignore
+            | _ -> System.Threading.Tasks.ValueTask.CompletedTask
 
 module internal Tip =
 

--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -1113,8 +1113,8 @@ type internal StoreClient(container: Container, fallback: Container option, quer
         Prune.until log (container, stream) query.MaxItems index ct
 
 type internal Category<'event, 'state, 'context>
-    (   store: StoreClient, codec: IEventCodec<'event, EncodedBody, 'context>,
-        fold: 'state -> 'event[] -> 'state, initial: 'state, isOrigin: 'event -> bool,
+    (   store: StoreClient,
+        codec: IEventCodec<'event, EncodedBody, 'context>, fold: 'state -> 'event[] -> 'state, initial: 'state, isOrigin: 'event -> bool,
         checkUnfolds, mapUnfolds: Choice<unit, 'event[] -> 'state -> 'event[], 'event[] -> 'state -> 'event[] * 'event[]>) =
     let fetch state f = task { let! token', events = f in return struct (token', fold state events) }
     let reload (log, streamNam, requireLeader, (Token.Unpack pos as streamToken), state) ct: Task<struct (StreamToken * 'state)> = task {

--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -1125,7 +1125,7 @@ type internal Category<'event, 'state, 'context>
         member _.Empty = Token.empty, initial
         member _.Load(log, _categoryName, _streamId, streamName, _maxAge, requireLeader, ct) =
             fetch initial (store.Load(log, (streamName, None), requireLeader, (codec.TryDecode, isOrigin), checkUnfolds, ct))
-        member _.Sync(log, _categoryName, _streamId, streamName, ctx, _maybeInit, (Token.Unpack pos as streamToken), state, events, ct) = task {
+        member _.Sync(log, _categoryName, _streamId, streamName, ctx, (Token.Unpack pos as streamToken), state, events, ct) = task {
             let state' = fold state events
             let exp, events, eventsEncoded, unfoldsEncoded =
                 let encode e = codec.Encode(ctx, e)
@@ -1340,7 +1340,7 @@ type DynamoStoreCategory<'event, 'state, 'context>(name, resolveStream) =
             categories.GetOrAdd(categoryName, createCategory)
         let resolveStream streamId =
             let struct (container, streamName) = context.ResolveContainerClientAndStreamName(name, streamId)
-            struct (resolveInner (name, container), streamName, ValueNone)
+            struct (resolveInner (name, container), streamName)
         DynamoStoreCategory(name, resolveStream)
 
 module Exceptions =

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -458,7 +458,7 @@ type private Category<'event, 'state, 'context>(context: EventStoreContext, code
         member _.Empty = context.TokenEmpty, initial
         member _.Load(log, _categoryName, _streamId, streamName, _maxAge, requireLeader, _ct) =
             fetch initial (loadAlgorithm log streamName requireLeader)
-        member _.Sync(log, _categoryName, _streamId, streamName, ctx, _maybeInit, (Token.Unpack token as streamToken), state, events, _ct) = task {
+        member _.Sync(log, _categoryName, _streamId, streamName, ctx, (Token.Unpack token as streamToken), state, events, _ct) = task {
             let events =
                 match access with
                 | None | Some AccessStrategy.LatestKnownEvent -> events

--- a/src/Equinox.EventStoreDb/EventStoreDb.fs
+++ b/src/Equinox.EventStoreDb/EventStoreDb.fs
@@ -402,7 +402,7 @@ type private Category<'event, 'state, 'context>(context: EventStoreContext, code
         member _.Empty = context.TokenEmpty, initial
         member _.Load(log, _categoryName, _streamId, streamName, _maxAge, requireLeader, ct) =
             fetch initial (loadAlgorithm log streamName requireLeader ct)
-        member _.Sync(log, _categoryName, _streamId, streamName, ctx, _maybeInit, (Token.Unpack token as streamToken), state, events, ct) = task {
+        member _.Sync(log, _categoryName, _streamId, streamName, ctx, (Token.Unpack token as streamToken), state, events, ct) = task {
             let events =
                 match access with
                 | None | Some AccessStrategy.LatestKnownEvent -> events

--- a/src/Equinox.MemoryStore/MemoryStore.fs
+++ b/src/Equinox.MemoryStore/MemoryStore.fs
@@ -69,7 +69,7 @@ type private Category<'event, 'state, 'context, 'Format>(store: VolatileStore<'F
             match store.Load(streamName) with
             | null -> return (Token.ofEmpty, initial)
             | xs -> return (Token.ofValue xs, fold initial (Array.chooseV codec.TryDecode xs)) }
-        member _.Sync(_log, categoryName, streamId, streamName, context, _init, Token.Unpack eventCount, state, events, _ct) = task {
+        member _.Sync(_log, categoryName, streamId, streamName, context, Token.Unpack eventCount, state, events, _ct) = task {
             let inline map i (e: FsCodec.IEventData<'Format>) = FsCodec.Core.TimelineEvent.Create(int64 i, e)
             let encoded = Array.ofSeq events |> Array.mapi (fun i e -> map (eventCount + i) (codec.Encode(context, e)))
             match store.TrySync(streamName, categoryName, streamId, eventCount, encoded) with

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -388,7 +388,7 @@ type private Category<'event, 'state, 'context>(context: MessageDbContext, codec
         member _.Empty = context.TokenEmpty, initial
         member _.Load(log, categoryName, streamId, streamName, _maxAge, requireLeader, ct) =
             loadAlgorithm log categoryName streamId streamName requireLeader ct
-        member x.Sync(log, categoryName, streamId, streamName, ctx, _maybeInit, token, state, events, ct) = task {
+        member x.Sync(log, categoryName, streamId, streamName, ctx, token, state, events, ct) = task {
             let encode e = codec.Encode(ctx, e)
             let encodedEvents: IEventData<EventBody>[] = events |> Array.map encode
             match! context.TrySync(log, categoryName, streamId, streamName, token, encodedEvents, ct) with

--- a/src/Equinox.SqlStreamStore/SqlStreamStore.fs
+++ b/src/Equinox.SqlStreamStore/SqlStreamStore.fs
@@ -434,7 +434,7 @@ type private Category<'event, 'state, 'context>(context: SqlStreamStoreContext, 
         member _.Empty = context.TokenEmpty, initial
         member _.Load(log, _categoryName, _streamId, streamName, _maxAge, requireLeader, ct) =
             fetch initial (loadAlgorithm log streamName requireLeader ct)
-        member _.Sync(log, _categoryName, _streamId, streamName, ctx, _maybeInit, (Token.Unpack token as streamToken), state, events, ct) = task {
+        member _.Sync(log, _categoryName, _streamId, streamName, ctx, (Token.Unpack token as streamToken), state, events, ct) = task {
             let events =
                 match access with
                 | None | Some AccessStrategy.LatestKnownEvent -> events

--- a/tests/Equinox.Core.Tests/CachingTests.fs
+++ b/tests/Equinox.Core.Tests/CachingTests.fs
@@ -33,7 +33,7 @@ type SpyCategory() =
             Interlocked.Increment &loads |> ignore
             do! Task.Delay(x.Delay, ct)
             return struct (mkToken(), Interlocked.Increment &state) }
-        member _.Sync(_log, _cat, _sid, _sn, _ctx, _maybeInit, _originToken, originState, events, _ct) = task {
+        member _.Sync(_log, _cat, _sid, _sn, _ctx, _originToken, originState, events, _ct) = task {
             return Equinox.Core.SyncResult.Written (mkToken(), originState + events.Length) }
 
     interface Equinox.Core.Caching.IReloadable<State> with
@@ -49,7 +49,7 @@ let writeOriginState = 99
 let expectedWriteState = 99 + 2 // events written
 
 let write sn (sut: Equinox.Core.ICategory<_, _, _>) = task {
-    let! wr = sut.Sync(Serilog.Log.Logger, null, null, sn, (), ValueNone, Unchecked.defaultof<_>, writeOriginState, Array.replicate 2 (), CancellationToken.None)
+    let! wr = sut.Sync(Serilog.Log.Logger, null, null, sn, (), Unchecked.defaultof<_>, writeOriginState, Array.replicate 2 (), CancellationToken.None)
     let wState' = trap <@ match wr with Equinox.Core.SyncResult.Written (_token, state') -> state' | _ -> failwith "unexpected" @>
     test <@ expectedWriteState = wState' @> }
 


### PR DESCRIPTION
Cleans up how the library guarantees that the edition of the Sync stored proc required by a given version of the library has been provisioned into the CosmosDB container in question

By @nordfjord 