### PR TITLE
feat(Stores): Make caching and access mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - Stores: `*Category.Resolve`: Replace `Resolve(sn, ?ResolveOption)` with `?load = LoadOption` parameter on all `Transact` and `Query` methods [#308](https://github.com/jet/equinox/pull/308)
 - Stores: `*Category` ctor: Add mandatory `name` argument, and `Name` property [#410](https://github.com/jet/equinox/pull/410)
 - Stores: `*Category` ctor: Change `caching` to be last argument, to reflect that it is applied over the top [#410](https://github.com/jet/equinox/pull/410)
+- Stores: `*Category` ctor: Change `caching` and `access` to be mandatory, adding `NoCaching` and `Unoptimized` modes to represent the former defaults [#417](https://github.com/jet/equinox/pull/417)
 - `CosmosStore`: Require `Microsoft.Azure.Cosmos` v `3.27.0` [#310](https://github.com/jet/equinox/pull/310)
 - `CosmosStore`: Switch to natively using `JsonElement` event bodies [#305](https://github.com/jet/equinox/pull/305) :pray: [@ylibrach](https://github.com/ylibrach)
 - `CosmosStore`: Switch to natively using `System.Text.Json` for serialization of all `Microsoft.Azure.Cosmos` round-trips [#305](https://github.com/jet/equinox/pull/305) :pray: [@ylibrach](https://github.com/ylibrach)

--- a/samples/Infrastructure/Services.fs
+++ b/samples/Infrastructure/Services.fs
@@ -17,13 +17,13 @@ type Store(store) =
         | Store.Context.Memory store ->
             MemoryStore.MemoryStoreCategory(store, name, codec, fold, initial)
         | Store.Context.Cosmos (store, caching, unfolds) ->
-            let accessStrategy = if unfolds then CosmosStore.AccessStrategy.Snapshot snapshot else Equinox.CosmosStore.AccessStrategy.Unoptimized
+            let accessStrategy = if unfolds then CosmosStore.AccessStrategy.Snapshot snapshot else CosmosStore.AccessStrategy.Unoptimized
             CosmosStore.CosmosStoreCategory<'event,'state,_>(store, name, codec.ToJsonElementCodec(), fold, initial, accessStrategy, caching)
         | Store.Context.Dynamo (store, caching, unfolds) ->
-            let accessStrategy = if unfolds then DynamoStore.AccessStrategy.Snapshot snapshot else Equinox.DynamoStore.AccessStrategy.Unoptimized
+            let accessStrategy = if unfolds then DynamoStore.AccessStrategy.Snapshot snapshot else DynamoStore.AccessStrategy.Unoptimized
             DynamoStore.DynamoStoreCategory<'event,'state,_>(store, name, FsCodec.Deflate.EncodeTryDeflate codec, fold, initial, accessStrategy, caching)
         | Store.Context.Es (context, caching, unfolds) ->
-            let accessStrategy = if unfolds then EventStoreDb.AccessStrategy.RollingSnapshots snapshot else Equinox.EventStoreDb.AccessStrategy.Unoptimized
+            let accessStrategy = if unfolds then EventStoreDb.AccessStrategy.RollingSnapshots snapshot else EventStoreDb.AccessStrategy.Unoptimized
             EventStoreDb.EventStoreCategory<'event,'state,_>(context, name, codec, fold, initial, accessStrategy, caching)
         | Store.Context.Sql (context, caching, unfolds) ->
             let accessStrategy = if unfolds then SqlStreamStore.AccessStrategy.RollingSnapshots snapshot else SqlStreamStore.AccessStrategy.Unoptimized

--- a/samples/Infrastructure/Services.fs
+++ b/samples/Infrastructure/Services.fs
@@ -15,21 +15,21 @@ type Store(store) =
             snapshot: ('event -> bool) * ('state -> 'event)): Category<'event, 'state, unit> =
         match store with
         | Store.Context.Memory store ->
-            Equinox.MemoryStore.MemoryStoreCategory(store, name, codec, fold, initial)
+            MemoryStore.MemoryStoreCategory(store, name, codec, fold, initial)
         | Store.Context.Cosmos (store, caching, unfolds) ->
-            let accessStrategy = if unfolds then Equinox.CosmosStore.AccessStrategy.Snapshot snapshot else Equinox.CosmosStore.AccessStrategy.Unoptimized
-            Equinox.CosmosStore.CosmosStoreCategory<'event,'state,_>(store, name, codec.ToJsonElementCodec(), fold, initial, accessStrategy, caching)
+            let accessStrategy = if unfolds then CosmosStore.AccessStrategy.Snapshot snapshot else Equinox.CosmosStore.AccessStrategy.Unoptimized
+            CosmosStore.CosmosStoreCategory<'event,'state,_>(store, name, codec.ToJsonElementCodec(), fold, initial, accessStrategy, caching)
         | Store.Context.Dynamo (store, caching, unfolds) ->
-            let accessStrategy = if unfolds then Equinox.DynamoStore.AccessStrategy.Snapshot snapshot else Equinox.DynamoStore.AccessStrategy.Unoptimized
-            Equinox.DynamoStore.DynamoStoreCategory<'event,'state,_>(store, name, FsCodec.Deflate.EncodeTryDeflate codec, fold, initial, accessStrategy, caching)
+            let accessStrategy = if unfolds then DynamoStore.AccessStrategy.Snapshot snapshot else Equinox.DynamoStore.AccessStrategy.Unoptimized
+            DynamoStore.DynamoStoreCategory<'event,'state,_>(store, name, FsCodec.Deflate.EncodeTryDeflate codec, fold, initial, accessStrategy, caching)
         | Store.Context.Es (context, caching, unfolds) ->
-            let accessStrategy = if unfolds then Equinox.EventStoreDb.AccessStrategy.RollingSnapshots snapshot |> Some else None
-            Equinox.EventStoreDb.EventStoreCategory<'event,'state,_>(context, name, codec, fold, initial, ?access = accessStrategy, ?caching = caching)
+            let accessStrategy = if unfolds then EventStoreDb.AccessStrategy.RollingSnapshots snapshot else Equinox.EventStoreDb.AccessStrategy.Unoptimized
+            EventStoreDb.EventStoreCategory<'event,'state,_>(context, name, codec, fold, initial, accessStrategy, caching)
         | Store.Context.Sql (context, caching, unfolds) ->
-            let accessStrategy = if unfolds then Equinox.SqlStreamStore.AccessStrategy.RollingSnapshots snapshot |> Some else None
-            Equinox.SqlStreamStore.SqlStreamStoreCategory<'event,'state,_>(context, name, codec, fold, initial, ?access = accessStrategy, ?caching = caching)
+            let accessStrategy = if unfolds then SqlStreamStore.AccessStrategy.RollingSnapshots snapshot else SqlStreamStore.AccessStrategy.Unoptimized
+            SqlStreamStore.SqlStreamStoreCategory<'event,'state,_>(context, name, codec, fold, initial, accessStrategy, caching)
         | Store.Context.Mdb (context, caching) ->
-            Equinox.MessageDb.MessageDbCategory<'event,'state,_>(context, name, codec, fold, initial, ?caching = caching)
+            MessageDb.MessageDbCategory<'event,'state,_>(context, name, codec, fold, initial, MessageDb.AccessStrategy.Unoptimized, caching)
 
 type ServiceBuilder(storageConfig, handlerLog) =
      let store = Store storageConfig

--- a/samples/Infrastructure/Store.fs
+++ b/samples/Infrastructure/Store.fs
@@ -8,11 +8,11 @@ open System
 type Context =
     // For MemoryStore, we keep the events as UTF8 arrays - we could use FsCodec.Codec.Box to remove the JSON encoding, which would improve perf but can conceal problems
     | Memory of Equinox.MemoryStore.VolatileStore<ReadOnlyMemory<byte>>
-    | Cosmos of Equinox.CosmosStore.CosmosStoreContext * Equinox.CosmosStore.CachingStrategy * unfolds: bool
-    | Dynamo of Equinox.DynamoStore.DynamoStoreContext * Equinox.DynamoStore.CachingStrategy * unfolds: bool
-    | Es     of Equinox.EventStoreDb.EventStoreContext * Equinox.CachingStrategy option * unfolds: bool
-    | Mdb    of Equinox.MessageDb.MessageDbContext * Equinox.CachingStrategy option
-    | Sql    of Equinox.SqlStreamStore.SqlStreamStoreContext * Equinox.CachingStrategy option * unfolds: bool
+    | Cosmos of Equinox.CosmosStore.CosmosStoreContext * Equinox.CachingStrategy * unfolds: bool
+    | Dynamo of Equinox.DynamoStore.DynamoStoreContext * Equinox.CachingStrategy * unfolds: bool
+    | Es     of Equinox.EventStoreDb.EventStoreContext * Equinox.CachingStrategy * unfolds: bool
+    | Mdb    of Equinox.MessageDb.MessageDbContext * Equinox.CachingStrategy
+    | Sql    of Equinox.SqlStreamStore.SqlStreamStoreContext * Equinox.CachingStrategy * unfolds: bool
 
 module MemoryStore =
     type [<NoEquality; NoComparison>] Parameters =
@@ -127,7 +127,7 @@ module Cosmos =
         log.Information("CosmosStore Max Events in Tip: {maxTipEvents}e {maxTipJsonLength}b Items in Query: {queryMaxItems}",
                         a.TipMaxEvents, a.TipMaxJsonLength, a.QueryMaxItems)
         let context = CosmosStoreContext(connection, a.TipMaxEvents, queryMaxItems = a.QueryMaxItems, tipMaxJsonLength = a.TipMaxJsonLength)
-        let cacheStrategy = match cache with Some c -> CachingStrategy.SlidingWindow (c, TimeSpan.FromMinutes 20.) | None -> CachingStrategy.NoCaching
+        let cacheStrategy = match cache with Some c -> Equinox.CachingStrategy.SlidingWindow (c, TimeSpan.FromMinutes 20.) | None -> Equinox.CachingStrategy.NoCaching
         Context.Cosmos (context, cacheStrategy, unfolds)
 
 module Dynamo =
@@ -216,7 +216,7 @@ module Dynamo =
         storeClient.LogConfiguration("Main", log)
         let context = DynamoStoreContext(storeClient, maxBytes = a.TipMaxBytes, queryMaxItems = a.QueryMaxItems, ?tipMaxEvents = a.TipMaxEvents)
         context.LogConfiguration(log)
-        let cacheStrategy = match cache with Some c -> CachingStrategy.SlidingWindow (c, TimeSpan.FromMinutes 20.) | None -> CachingStrategy.NoCaching
+        let cacheStrategy = match cache with Some c -> Equinox.CachingStrategy.SlidingWindow (c, TimeSpan.FromMinutes 20.) | None -> Equinox.CachingStrategy.NoCaching
         Context.Dynamo (context, cacheStrategy, unfolds)
 
 /// To establish a local node to run the tests against, follow https://developers.eventstore.com/server/v21.10/installation.html#use-docker-compose
@@ -258,7 +258,7 @@ module EventStore =
         let timeout = a.Timeout
         log.Information("EventStoreDB {connectionString} {timeout}s", a.ConnectionString, timeout.TotalSeconds)
         let connection = connect a.ConnectionString a.Credentials timeout
-        let cacheStrategy = cache |> Option.map (fun c -> Equinox.CachingStrategy.SlidingWindow (c, TimeSpan.FromMinutes 20.))
+        let cacheStrategy = match cache with Some c -> Equinox.CachingStrategy.SlidingWindow (c, TimeSpan.FromMinutes 20.) | None -> Equinox.CachingStrategy.NoCaching
         Context.Es (EventStoreContext(connection, batchSize = a.BatchSize), cacheStrategy, unfolds)
 
 // see https://github.com/jet/equinox#provisioning-mssql
@@ -266,7 +266,7 @@ module Sql =
 
     open Equinox.SqlStreamStore
 
-    let cacheStrategy cache = cache |> Option.map (fun c -> Equinox.CachingStrategy.SlidingWindow (c, TimeSpan.FromMinutes 20.))
+    let cacheStrategy = function Some c -> Equinox.CachingStrategy.SlidingWindow (c, TimeSpan.FromMinutes 20.) | None -> Equinox.CachingStrategy.NoCaching
     module Ms =
         type [<NoEquality; NoComparison>] Parameters =
             | [<AltCommandLine "-c"; Mandatory>] ConnectionString of string
@@ -366,5 +366,5 @@ module MessageDb =
     let config (log : ILogger) cache (p : ParseResults<Parameters>) =
         let a = Arguments(p)
         let connection = connect log a.ConnectionString
-        let cache = cache |> Option.map (fun c -> Equinox.CachingStrategy.SlidingWindow(c, TimeSpan.FromMinutes 20.))
+        let cache = match cache with Some c -> Equinox.CachingStrategy.SlidingWindow(c, TimeSpan.FromMinutes 20.) | None -> Equinox.CachingStrategy.NoCaching
         Context.Mdb (MessageDbContext(connection, batchSize = a.BatchSize), cache)

--- a/samples/Store/Integration/CartIntegration.fs
+++ b/samples/Store/Integration/CartIntegration.fs
@@ -19,14 +19,14 @@ let codec = Cart.Events.codec
 let codecJe = Cart.Events.codecJe
 
 let categoryGesStreamWithRollingSnapshots context =
-    EventStoreDb.EventStoreCategory(context, Cart.Category, codec, fold, initial, access = EventStoreDb.AccessStrategy.RollingSnapshots snapshot)
+    EventStoreDb.EventStoreCategory(context, Cart.Category, codec, fold, initial, EventStoreDb.AccessStrategy.RollingSnapshots snapshot, CachingStrategy.NoCaching)
 let categoryGesStreamWithoutCustomAccessStrategy context =
-    EventStoreDb.EventStoreCategory(context, Cart.Category, codec, fold, initial)
+    EventStoreDb.EventStoreCategory(context, Cart.Category, codec, fold, initial, EventStoreDb.AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
 
 let categoryCosmosStreamWithSnapshotStrategy context =
-    CosmosStore.CosmosStoreCategory(context, Cart.Category, codecJe, fold, initial, CosmosStore.AccessStrategy.Snapshot snapshot, CosmosStore.CachingStrategy.NoCaching)
+    CosmosStore.CosmosStoreCategory(context, Cart.Category, codecJe, fold, initial, CosmosStore.AccessStrategy.Snapshot snapshot, CachingStrategy.NoCaching)
 let categoryCosmosStreamWithoutCustomAccessStrategy context =
-    CosmosStore.CosmosStoreCategory(context, Cart.Category, codecJe, fold, initial, CosmosStore.AccessStrategy.Unoptimized, CosmosStore.CachingStrategy.NoCaching)
+    CosmosStore.CosmosStoreCategory(context, Cart.Category, codecJe, fold, initial, CosmosStore.AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
 
 let addAndThenRemoveItemsManyTimesExceptTheLastOne context cartId skuId (service: Cart.Service) count =
     service.ExecuteManyAsync(cartId, false, seq {

--- a/samples/Store/Integration/ContactPreferencesIntegration.fs
+++ b/samples/Store/Integration/ContactPreferencesIntegration.fs
@@ -17,17 +17,17 @@ let Category = ContactPreferences.Category
 let codec = ContactPreferences.Events.codec
 let codecJe = ContactPreferences.Events.codecJe
 let categoryGesWithOptimizedStorageSemantics context =
-    EventStoreDb.EventStoreCategory(context 1, Category, codec, fold, initial, access = EventStoreDb.AccessStrategy.LatestKnownEvent)
+    EventStoreDb.EventStoreCategory(context 1, Category, codec, fold, initial, EventStoreDb.AccessStrategy.LatestKnownEvent, CachingStrategy.NoCaching)
 let categoryGesWithoutAccessStrategy context =
-    EventStoreDb.EventStoreCategory(context defaultBatchSize, Category, codec, fold, initial)
+    EventStoreDb.EventStoreCategory(context defaultBatchSize, Category, codec, fold, initial, EventStoreDb.AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
 
 let categoryCosmosWithLatestKnownEventSemantics context =
-    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.AccessStrategy.LatestKnownEvent, CosmosStore.CachingStrategy.NoCaching)
+    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.AccessStrategy.LatestKnownEvent, CachingStrategy.NoCaching)
 let categoryCosmosUnoptimized context =
-    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.AccessStrategy.Unoptimized, CosmosStore.CachingStrategy.NoCaching)
+    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
 let categoryCosmosRollingUnfolds context =
     let access = CosmosStore.AccessStrategy.Custom(ContactPreferences.Fold.isOrigin, ContactPreferences.Fold.transmute)
-    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, access, CosmosStore.CachingStrategy.NoCaching)
+    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, access, CachingStrategy.NoCaching)
 
 type Tests(testOutputHelper) =
     let testOutput = TestOutput testOutputHelper

--- a/samples/Store/Integration/FavoritesIntegration.fs
+++ b/samples/Store/Integration/FavoritesIntegration.fs
@@ -18,18 +18,18 @@ let createServiceMemory log store =
 let codec = Favorites.Events.codec
 let codecJe = Favorites.Events.codecJe
 let createServiceGes log context =
-    EventStoreDb.EventStoreCategory(context, Category, codec, fold, initial, access = EventStoreDb.AccessStrategy.RollingSnapshots snapshot)
+    EventStoreDb.EventStoreCategory(context, Category, codec, fold, initial, EventStoreDb.AccessStrategy.RollingSnapshots snapshot, CachingStrategy.NoCaching)
     |> Decider.forStream log
     |> Favorites.create
 
 let createServiceCosmosSnapshotsUncached log context =
-    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.AccessStrategy.Snapshot snapshot, CosmosStore.CachingStrategy.NoCaching)
+    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.AccessStrategy.Snapshot snapshot, CachingStrategy.NoCaching)
     |> Decider.forStream log
     |> Favorites.create
 
 let createServiceCosmosRollingStateUncached log context =
     let access = CosmosStore.AccessStrategy.RollingState Favorites.Fold.snapshot
-    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, access, CosmosStore.CachingStrategy.NoCaching)
+    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, access, CachingStrategy.NoCaching)
     |> Decider.forStream log
     |> Favorites.create
 
@@ -37,7 +37,7 @@ let createServiceCosmosUnoptimizedButCached log context =
     let access = CosmosStore.AccessStrategy.Unoptimized
     let caching =
         let cache = Cache ("name", 10)
-        CosmosStore.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
+        CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
     CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, access, caching)
     |> Decider.forStream log
     |> Favorites.create

--- a/samples/Tutorial/AsAt.fsx
+++ b/samples/Tutorial/AsAt.fsx
@@ -168,7 +168,7 @@ module Cosmos =
     let connector = CosmosStoreConnector(discovery, TimeSpan.FromSeconds 5., 2, TimeSpan.FromSeconds 5., Microsoft.Azure.Cosmos.ConnectionMode.Gateway)
     let storeClient = CosmosStoreClient.Connect(connector.CreateAndInitialize, read "EQUINOX_COSMOS_DATABASE", read "EQUINOX_COSMOS_CONTAINER") |> Async.RunSynchronously
     let context = CosmosStoreContext(storeClient, tipMaxEvents = 10)
-    let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
+    let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
     let accessStrategy = AccessStrategy.Snapshot (Fold.isValid,Fold.snapshot)
     let cat = CosmosStoreCategory(context, Category, Events.codecJe, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
     let resolve = Equinox.Decider.forStream Log.log cat

--- a/samples/Tutorial/Cosmos.fsx
+++ b/samples/Tutorial/Cosmos.fsx
@@ -87,7 +87,7 @@ module Favorites =
         open Equinox.CosmosStore // Everything outside of this module is completely storage agnostic so can be unit tested simply and/or bound to any store
         let accessStrategy = AccessStrategy.Unoptimized // Or Snapshot etc https://github.com/jet/equinox/blob/master/DOCUMENTATION.md#access-strategies
         let category (context, cache) =
-            let cacheStrategy = CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
+            let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
             CosmosStoreCategory(context, Category, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
 
 let [<Literal>] appName = "equinox-tutorial"

--- a/samples/Tutorial/FulfilmentCenter.fsx
+++ b/samples/Tutorial/FulfilmentCenter.fsx
@@ -140,7 +140,7 @@ module Store =
     let storeClient = CosmosStoreClient.Connect(connector.CreateAndInitialize, read "EQUINOX_COSMOS_DATABASE", read "EQUINOX_COSMOS_CONTAINER") |> Async.RunSynchronously
     let context = CosmosStoreContext(storeClient, tipMaxEvents = 256)
     let cache = Equinox.Cache(appName, 20)
-    let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
+    let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
 
 open FulfilmentCenter
 

--- a/samples/Tutorial/Gapless.fs
+++ b/samples/Tutorial/Gapless.fs
@@ -80,7 +80,7 @@ module Cosmos =
 
     open Equinox.CosmosStore
     let private category (context, cache, accessStrategy) =
-        let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
+        let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
         CosmosStoreCategory(context, Category, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
 
     module Snapshot =

--- a/samples/Tutorial/Index.fs
+++ b/samples/Tutorial/Index.fs
@@ -52,7 +52,7 @@ module Cosmos =
 
     open Equinox.CosmosStore
     let category (context,cache) =
-        let cacheStrategy = CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
+        let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
         let accessStrategy = AccessStrategy.RollingState Fold.snapshot
         CosmosStoreCategory(context, Category, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
 

--- a/samples/Tutorial/Sequence.fs
+++ b/samples/Tutorial/Sequence.fs
@@ -42,7 +42,7 @@ module Cosmos =
 
     open Equinox.CosmosStore
     let private create (context, cache, accessStrategy) =
-        let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
+        let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
         CosmosStoreCategory(context, Category, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
 
     module LatestKnownEvent =

--- a/samples/Tutorial/Set.fs
+++ b/samples/Tutorial/Set.fs
@@ -53,7 +53,7 @@ module Cosmos =
 
     open Equinox.CosmosStore
     let category (context, cache) =
-        let cacheStrategy = CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
+        let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
         let accessStrategy = AccessStrategy.RollingState Fold.snapshot
         CosmosStoreCategory(context, Category, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
 

--- a/samples/Tutorial/Todo.fsx
+++ b/samples/Tutorial/Todo.fsx
@@ -130,7 +130,7 @@ module Store =
     let connector = CosmosStoreConnector(discovery, TimeSpan.FromSeconds 5., 2, TimeSpan.FromSeconds 5.)
     let storeClient = CosmosStoreClient.Connect(connector.CreateAndInitialize, read "EQUINOX_COSMOS_DATABASE", read "EQUINOX_COSMOS_CONTAINER") |> Async.RunSynchronously
     let context = CosmosStoreContext(storeClient, tipMaxEvents = 100) // Keep up to 100 events in tip before moving events to a new document
-    let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
+    let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
 
     let access = AccessStrategy.Snapshot (isOrigin,snapshot)
     let category = CosmosStoreCategory(context, Category, codec, fold, initial, access, cacheStrategy)

--- a/samples/Tutorial/Upload.fs
+++ b/samples/Tutorial/Upload.fs
@@ -58,10 +58,10 @@ module Cosmos =
 
     open Equinox.CosmosStore
     let category (context, cache) =
-        let cacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
+        let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
         CosmosStoreCategory(context, Category, Events.codecJe, Fold.fold, Fold.initial, AccessStrategy.LatestKnownEvent, cacheStrategy)
 
 module EventStore =
     open Equinox.EventStoreDb
     let category context =
-        EventStoreCategory(context, Category, Events.codec, Fold.fold, Fold.initial, access = AccessStrategy.LatestKnownEvent)
+        EventStoreCategory(context, Category, Events.codec, Fold.fold, Fold.initial, AccessStrategy.LatestKnownEvent, Equinox.CachingStrategy.NoCaching)

--- a/src/Equinox.Core/Cache.fs
+++ b/src/Equinox.Core/Cache.fs
@@ -101,7 +101,7 @@ type Cache private (inner: System.Runtime.Caching.MemoryCache) =
     member val Inner = inner
 
 type [<NoComparison; NoEquality; RequireQualifiedAccess>] CachingStrategy =
-    /// Do not apply any caching strategy for this Stream.
+    /// Do not apply any caching strategy for this Category.
     | NoCaching
     /// Retain a single 'state per streamName.
     /// Each cache hit for a stream renews the retention period for the defined <c>window</c>.
@@ -114,5 +114,6 @@ type [<NoComparison; NoEquality; RequireQualifiedAccess>] CachingStrategy =
     | FixedTimeSpan of Cache * period: TimeSpan
     /// Prefix is used to segregate multiple folded states per stream when they are stored in the cache.
     /// Semantics are otherwise identical to <c>SlidingWindow</c>.
-    /// NOTE In general, its much preferred to ensure that the snapshot includes all relevant state or use AccessStrategy.MultiSnapshot where possible
+    /// NOTE In general, its much preferred to ensure that the snapshot includes all relevant state
+    ///      or use an AccessStrategy such as MultiSnapshot where available
     | SlidingWindowPrefixed of Cache * window: TimeSpan * prefix: string

--- a/src/Equinox.Core/Cache.fs
+++ b/src/Equinox.Core/Cache.fs
@@ -101,6 +101,8 @@ type Cache private (inner: System.Runtime.Caching.MemoryCache) =
     member val Inner = inner
 
 type [<NoComparison; NoEquality; RequireQualifiedAccess>] CachingStrategy =
+    /// Do not apply any caching strategy for this Stream.
+    | NoCaching
     /// Retain a single 'state per streamName.
     /// Each cache hit for a stream renews the retention period for the defined <c>window</c>.
     /// Upon expiration of the defined <c>window</c> from the point at which the cache was entry was last used, a full reload is triggered.
@@ -112,4 +114,5 @@ type [<NoComparison; NoEquality; RequireQualifiedAccess>] CachingStrategy =
     | FixedTimeSpan of Cache * period: TimeSpan
     /// Prefix is used to segregate multiple folded states per stream when they are stored in the cache.
     /// Semantics are otherwise identical to <c>SlidingWindow</c>.
+    /// NOTE In general, its much preferred to ensure that the snapshot includes all relevant state or use AccessStrategy.MultiSnapshot where possible
     | SlidingWindowPrefixed of Cache * window: TimeSpan * prefix: string

--- a/src/Equinox.Core/Caching.fs
+++ b/src/Equinox.Core/Caching.fs
@@ -35,13 +35,13 @@ let private mkKey prefix streamName =
 
 let internal policySlidingExpiration (slidingExpiration: System.TimeSpan) () =
     System.Runtime.Caching.CacheItemPolicy(SlidingExpiration = slidingExpiration)
-let internal policyFixedTimeSpan (period: System.TimeSpan) () =
+let private policyFixedTimeSpan (period: System.TimeSpan) () =
     let expirationPoint = let creationDate = System.DateTimeOffset.UtcNow in creationDate.Add period
     System.Runtime.Caching.CacheItemPolicy(AbsoluteExpiration = expirationPoint)
 
 let apply isStale x (cat: 'cat when 'cat :> ICategory<'event, 'state, 'context> and 'cat :> IReloadable<'state>) =
     match x with
     | Equinox.CachingStrategy.NoCaching ->                                     (cat : ICategory<_, _, _>)
-    | Equinox.CachingStrategy.FixedTimeSpan (cache, period) ->                 Decorator(cat, cache, isStale, mkKey null, policyFixedTimeSpan period)
-    | Equinox.CachingStrategy.SlidingWindow (cache, window) ->                 Decorator(cat, cache, isStale, mkKey null, policySlidingExpiration window)
+    | Equinox.CachingStrategy.FixedTimeSpan (cache, period) ->                 Decorator(cat, cache, isStale, mkKey null,   policyFixedTimeSpan period)
+    | Equinox.CachingStrategy.SlidingWindow (cache, window) ->                 Decorator(cat, cache, isStale, mkKey null,   policySlidingExpiration window)
     | Equinox.CachingStrategy.SlidingWindowPrefixed (cache, window, prefix) -> Decorator(cat, cache, isStale, mkKey prefix, policySlidingExpiration window)

--- a/src/Equinox.EventStore/EventStore.fs
+++ b/src/Equinox.EventStore/EventStore.fs
@@ -422,6 +422,8 @@ type EventStoreContext(connection: EventStoreConnection, batchOptions: BatchOpti
 
 [<NoComparison; NoEquality; RequireQualifiedAccess>]
 type AccessStrategy<'event, 'state> =
+    /// Read events forward, in batches.
+    | Unoptimized
     /// Load only the single most recent event defined in <c>'event</c> and trust that doing a <c>fold</c> from any such event
     /// will yield a correct and complete state
     /// In other words, the <c>fold</c> function should not need to consider either the preceding <c>'state</state> or <c>'event</c>s.
@@ -440,18 +442,18 @@ type private Category<'event, 'state, 'context>(context: EventStoreContext, code
     let tryDecode (e: ResolvedEvent) = e |> UnionEncoderAdapters.encodedEventOfResolvedEvent |> codec.TryDecode
     let isOrigin =
         match access with
-        | None | Some AccessStrategy.LatestKnownEvent -> fun _ -> true
-        | Some (AccessStrategy.RollingSnapshots (isValid, _)) -> isValid
+        | AccessStrategy.Unoptimized | AccessStrategy.LatestKnownEvent -> fun _ -> true
+        | AccessStrategy.RollingSnapshots (isValid, _) -> isValid
     let loadAlgorithm log streamName requireLeader =
         match access with
-        | None -> context.LoadBatched(log, streamName, requireLeader, tryDecode, None)
-        | Some AccessStrategy.LatestKnownEvent
-        | Some (AccessStrategy.RollingSnapshots _) -> context.LoadBackwardsStoppingAtCompactionEvent(log, streamName, requireLeader, tryDecode, isOrigin)
+        | AccessStrategy.Unoptimized -> context.LoadBatched(log, streamName, requireLeader, tryDecode, None)
+        | AccessStrategy.LatestKnownEvent
+        | AccessStrategy.RollingSnapshots _ -> context.LoadBackwardsStoppingAtCompactionEvent(log, streamName, requireLeader, tryDecode, isOrigin)
     let compactionPredicate =
         match access with
-        | None -> None
-        | Some AccessStrategy.LatestKnownEvent -> Some (fun _ -> true)
-        | Some (AccessStrategy.RollingSnapshots (isValid, _)) -> Some isValid
+        | AccessStrategy.Unoptimized -> None
+        | AccessStrategy.LatestKnownEvent -> Some (fun _ -> true)
+        | AccessStrategy.RollingSnapshots (isValid, _) -> Some isValid
     let fetch state f = task { let! token', events = f in return struct (token', fold state events) }
     let reload (log, sn, leader, token, state) = fetch state (context.Reload(log, sn, leader, token, tryDecode, compactionPredicate))
     interface ICategory<'event, 'state, 'context> with
@@ -461,8 +463,8 @@ type private Category<'event, 'state, 'context>(context: EventStoreContext, code
         member _.Sync(log, _categoryName, _streamId, streamName, ctx, (Token.Unpack token as streamToken), state, events, _ct) = task {
             let events =
                 match access with
-                | None | Some AccessStrategy.LatestKnownEvent -> events
-                | Some (AccessStrategy.RollingSnapshots (_, compact)) ->
+                | AccessStrategy.Unoptimized | AccessStrategy.LatestKnownEvent -> events
+                | AccessStrategy.RollingSnapshots (_, compact) ->
                     let cc = CompactionContext(Array.length events, token.batchCapacityLimit.Value)
                     if cc.IsCompactionDue then Array.append events (fold state events |> compact |> Array.singleton) else events
             let encode e = codec.Encode(ctx, e)
@@ -474,16 +476,15 @@ type private Category<'event, 'state, 'context>(context: EventStoreContext, code
 
 type EventStoreCategory<'event, 'state, 'context> internal (name, inner) =
     inherit Equinox.Category<'event, 'state, 'context>(name, inner = inner)
-    new(context: EventStoreContext, name, codec: FsCodec.IEventCodec<_, _, 'context>, fold, initial, [<O; D(null)>] ?access,
+    new(context: EventStoreContext, name, codec: FsCodec.IEventCodec<_, _, 'context>, fold, initial, access,
         // Caching can be overkill for EventStore esp considering the degree to which its intrinsic caching is a first class feature
-        // e.g., A key benefit is that reads of streams more than a few pages long get completed in constant time after the initial load
-        [<O; D(null)>] ?caching) =
-        do  match access with
-            | Some AccessStrategy.LatestKnownEvent when Option.isSome caching ->
-                "Equinox.EventStore does not support (and it would make things _less_ efficient even if it did)"
-                + "mixing AccessStrategy.LatestKnownEvent with Caching at present."
-                |> invalidOp
-            | _ -> ()
+        // e.g., a key benefit is that reads of streams more than a few pages long get completed in constant time after the initial load
+        caching) =
+        match access, caching with
+        | AccessStrategy.LatestKnownEvent, Equinox.CachingStrategy.NoCaching -> ()
+        | AccessStrategy.LatestKnownEvent, _ ->
+            invalidOp "Equinox.EventStore does not support mixing AccessStrategy.LatestKnownEvent with Caching at present."
+        | _ -> ()
         let cat = Category<'event, 'state, 'context>(context, codec, fold, initial, access) |> Caching.apply Token.isStale caching
         EventStoreCategory(name, inner = cat)
 

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -413,7 +413,10 @@ type private Category<'event, 'state, 'context>(context: MessageDbContext, codec
         context.StoreSnapshot(log, category, streamId, encodedWithMeta, ct)
 
 type MessageDbCategory<'event, 'state, 'context>(context: MessageDbContext, name, codec, fold, initial, access,
-        // For MessageDb, caching is less critical than it is for e.g. CosmosDB
-        // As such, it can sometimes be omitted, particularly if streams are short, or events are small and/or database latency aligns with request latency requirements
+        // For MessageDb, caching is less critical than it is for e.g. CosmosDB.
+        // However, while not necessary to control costs, caching can improve the throughput of your application a few times over,
+        //   as such you should only skip it if you know what you're doing
+        //   e.g. if streams are always short, events are always small, you are absolutely certain there will be no cache hits
+        //        (and you have a cheerful but bored DBA)
         caching) =
     inherit Equinox.Category<'event, 'state, 'context>(name, Category(context, codec, fold, initial, access) |> Caching.apply Token.isStale caching)

--- a/src/Equinox.SqlStreamStore/SqlStreamStore.fs
+++ b/src/Equinox.SqlStreamStore/SqlStreamStore.fs
@@ -1,5 +1,6 @@
 ﻿namespace Equinox.SqlStreamStore
 
+open Equinox
 open Equinox.Core
 open Serilog
 open SqlStreamStore
@@ -398,6 +399,8 @@ type SqlStreamStoreContext(connection: SqlStreamStoreConnection, batchOptions: B
 
 [<NoComparison; NoEquality; RequireQualifiedAccess>]
 type AccessStrategy<'event, 'state> =
+    /// Read events forward, in batches.
+    | Unoptimized
     /// Load only the single most recent event defined in <c>'event</c> and trust that doing a <c>fold</c> from any such event
     /// will yield a correct and complete state
     /// In other words, the <c>fold</c> function should not need to consider either the preceding <c>'state</state> or <c>'event</c>s.
@@ -416,18 +419,18 @@ type private Category<'event, 'state, 'context>(context: SqlStreamStoreContext, 
     let tryDecode (e: ResolvedEvent) = e |> UnionEncoderAdapters.encodedEventOfResolvedEvent |> codec.TryDecode
     let isOrigin =
         match access with
-        | None | Some AccessStrategy.LatestKnownEvent -> fun _ -> true
-        | Some (AccessStrategy.RollingSnapshots (isValid, _)) -> isValid
+        | AccessStrategy.Unoptimized | AccessStrategy.LatestKnownEvent -> fun _ -> true
+        | AccessStrategy.RollingSnapshots (isValid, _) -> isValid
     let loadAlgorithm log streamName requireLeader ct =
         match access with
-        | None -> context.LoadBatched(log, streamName, requireLeader, tryDecode, None, ct)
-        | Some AccessStrategy.LatestKnownEvent
-        | Some (AccessStrategy.RollingSnapshots _) -> context.LoadBackwardsStoppingAtCompactionEvent(log, streamName, requireLeader, tryDecode, isOrigin, ct)
+        | AccessStrategy.Unoptimized -> context.LoadBatched(log, streamName, requireLeader, tryDecode, None, ct)
+        | AccessStrategy.LatestKnownEvent
+        | AccessStrategy.RollingSnapshots _ -> context.LoadBackwardsStoppingAtCompactionEvent(log, streamName, requireLeader, tryDecode, isOrigin, ct)
     let compactionPredicate =
         match access with
-        | None -> None
-        | Some AccessStrategy.LatestKnownEvent -> Some (fun _ -> true)
-        | Some (AccessStrategy.RollingSnapshots (isValid, _)) -> Some isValid
+        | AccessStrategy.Unoptimized -> None
+        | AccessStrategy.LatestKnownEvent -> Some (fun _ -> true)
+        | AccessStrategy.RollingSnapshots (isValid, _) -> Some isValid
     let fetch state f = task { let! token', events = f in return struct (token', fold state events) }
     let reload (log, sn, leader, token, state) ct = fetch state (context.Reload(log, sn, leader, token, tryDecode, compactionPredicate, ct))
     interface ICategory<'event, 'state, 'context> with
@@ -437,8 +440,8 @@ type private Category<'event, 'state, 'context>(context: SqlStreamStoreContext, 
         member _.Sync(log, _categoryName, _streamId, streamName, ctx, (Token.Unpack token as streamToken), state, events, ct) = task {
             let events =
                 match access with
-                | None | Some AccessStrategy.LatestKnownEvent -> events
-                | Some (AccessStrategy.RollingSnapshots (_, compact)) ->
+                | AccessStrategy.Unoptimized | AccessStrategy.LatestKnownEvent -> events
+                | AccessStrategy.RollingSnapshots (_, compact) ->
                     let cc = CompactionContext(Array.length events, token.batchCapacityLimit.Value)
                     if cc.IsCompactionDue then Array.append events (fold state events |> compact |> Array.singleton) else events
             let encode e = codec.Encode(ctx, e)
@@ -450,16 +453,15 @@ type private Category<'event, 'state, 'context>(context: SqlStreamStoreContext, 
 
 type SqlStreamStoreCategory<'event, 'state, 'context> internal (name, inner) =
     inherit Equinox.Category<'event, 'state, 'context>(name, inner = inner)
-    new(context: SqlStreamStoreContext, name, codec: FsCodec.IEventCodec<_, _, 'context>, fold, initial, [<O; D(null)>]?access,
+    new(context: SqlStreamStoreContext, name, codec: FsCodec.IEventCodec<_, _, 'context>, fold, initial, access,
         // For SqlStreamStore, caching is less critical than it is for e.g. CosmosDB
-        // As such, it can often be omitted, particularly if streams are short, or events are small and/or database latency aligns with request latency requirements
-        [<O; D(null)>]?caching) =
-        do  match access with
-            | Some AccessStrategy.LatestKnownEvent when Option.isSome caching ->
-                "Equinox.SqlStreamStore does not support (and it would make things _less_ efficient even if it did)"
-                + "mixing AccessStrategy.LatestKnownEvent with Caching at present."
-                |> invalidOp
-            | _ -> ()
+        // As such, it can sometimes be omitted, particularly if streams are short, or events are small and/or database latency aligns with request latency requirements
+        caching) =
+        match access, caching with
+        | AccessStrategy.LatestKnownEvent, CachingStrategy.NoCaching -> ()
+        | AccessStrategy.LatestKnownEvent, _ ->
+            invalidOp "Equinox.SqlStreamStore does not support mixing AccessStrategy.LatestKnownEvent with Caching at present."
+        | _ -> ()
         let cat = Category<'event, 'state, 'context>(context, codec, fold, initial, access) |> Caching.apply Token.isStale caching
         SqlStreamStoreCategory(name, cat)
 

--- a/src/Equinox.SqlStreamStore/SqlStreamStore.fs
+++ b/src/Equinox.SqlStreamStore/SqlStreamStore.fs
@@ -1,6 +1,5 @@
 ﻿namespace Equinox.SqlStreamStore
 
-open Equinox
 open Equinox.Core
 open Serilog
 open SqlStreamStore
@@ -458,7 +457,7 @@ type SqlStreamStoreCategory<'event, 'state, 'context> internal (name, inner) =
         // As such, it can sometimes be omitted, particularly if streams are short, or events are small and/or database latency aligns with request latency requirements
         caching) =
         match access, caching with
-        | AccessStrategy.LatestKnownEvent, CachingStrategy.NoCaching -> ()
+        | AccessStrategy.LatestKnownEvent, Equinox.CachingStrategy.NoCaching -> ()
         | AccessStrategy.LatestKnownEvent, _ ->
             invalidOp "Equinox.SqlStreamStore does not support mixing AccessStrategy.LatestKnownEvent with Caching at present."
         | _ -> ()

--- a/tests/Equinox.Core.Tests/CachingTests.fs
+++ b/tests/Equinox.Core.Tests/CachingTests.fs
@@ -61,7 +61,7 @@ let [<Fact>] ``AsyncLazy.Empty is a true singleton, does not allocate`` () =
 
 let [<Fact>] ``No strategy, no wrapping`` () =
     let cat = SpyCategory()
-    let sut = Equinox.Core.Caching.apply isStale None cat
+    let sut = Equinox.Core.Caching.apply isStale Equinox.CachingStrategy.NoCaching cat
     test <@ obj.ReferenceEquals(cat, sut) @>
 
 type Tests() =
@@ -69,7 +69,7 @@ type Tests() =
     let cache = Equinox.Cache("tests", 1)
     let strategy = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 10)
     let cat = SpyCategory()
-    let sut = Equinox.Core.Caching.apply isStale (Some strategy) cat
+    let sut = Equinox.Core.Caching.apply isStale strategy cat
     let sn = Guid.NewGuid |> string
 
     let write () = write sn sut

--- a/tests/Equinox.Core.Tests/CachingTests.fs
+++ b/tests/Equinox.Core.Tests/CachingTests.fs
@@ -59,7 +59,7 @@ let [<Fact>] ``AsyncLazy.Empty is a true singleton, does not allocate`` () =
     let i2 = Equinox.Core.AsyncLazy<int>.Empty
     test <@ obj.ReferenceEquals(i1, i2) @>
 
-let [<Fact>] ``No strategy, no wrapping`` () =
+let [<Fact>] ``NoCaching strategy does no wrapping`` () =
     let cat = SpyCategory()
     let sut = Equinox.Core.Caching.apply isStale Equinox.CachingStrategy.NoCaching cat
     test <@ obj.ReferenceEquals(cat, sut) @>

--- a/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
+++ b/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
@@ -15,10 +15,10 @@ open Xunit
 module WiringHelpers =
 
     let private createCategoryUncached name codec initial fold accessStrategy context =
-        let noCachingCacheStrategy = CachingStrategy.NoCaching
+        let noCachingCacheStrategy = Equinox.CachingStrategy.NoCaching
         StoreCategory(context, name, codec, fold, initial, accessStrategy, noCachingCacheStrategy)
     let private createCategory name codec initial fold accessStrategy (context, cache) =
-        let sliding20mCacheStrategy = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
+        let sliding20mCacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
         StoreCategory(context, name, codec, fold, initial, accessStrategy, sliding20mCacheStrategy)
 
     let createCategoryUnoptimizedUncached name codec initial fold context =

--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -23,27 +23,27 @@ module Cart =
     let codec = Cart.Events.codecJe
 #endif
     let createServiceWithoutOptimization log context =
-        StoreCategory(context, Cart.Category, codec, fold, initial, AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
+        StoreCategory(context, Cart.Category, codec, fold, initial, AccessStrategy.Unoptimized, Equinox.CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> Cart.create
     /// Trigger looking in Tip (we want those calls to occur, but without leaning on snapshots, which would reduce the paths covered)
     let createServiceWithEmptyUnfolds log context =
         let unfArgs = Cart.Fold.isOrigin, fun _ -> Array.empty
-        StoreCategory(context, Cart.Category, codec, fold, initial, AccessStrategy.MultiSnapshot unfArgs, CachingStrategy.NoCaching)
+        StoreCategory(context, Cart.Category, codec, fold, initial, AccessStrategy.MultiSnapshot unfArgs, Equinox.CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> Cart.create
     let createServiceWithSnapshotStrategy log context =
-        StoreCategory(context, Cart.Category, codec, fold, initial, AccessStrategy.Snapshot snapshot, CachingStrategy.NoCaching)
+        StoreCategory(context, Cart.Category, codec, fold, initial, AccessStrategy.Snapshot snapshot, Equinox.CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> Cart.create
     let createServiceWithSnapshotStrategyAndCaching log context cache =
-        let sliding20m = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
+        let sliding20m = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
         StoreCategory(context, Cart.Category, codec, fold, initial, AccessStrategy.Snapshot snapshot, sliding20m)
         |> Equinox.Decider.forStream log
         |> Cart.create
     let createServiceWithRollingState log context =
         let access = AccessStrategy.RollingState Cart.Fold.snapshot
-        StoreCategory(context, Cart.Category, codec, fold, initial, access, CachingStrategy.NoCaching)
+        StoreCategory(context, Cart.Category, codec, fold, initial, access, Equinox.CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> Cart.create
     let streamName = Cart.streamId >> StreamName.render Cart.Category
@@ -60,9 +60,9 @@ module ContactPreferences =
         |> Equinox.Decider.forStream log
         |> ContactPreferences.create
     let createServiceWithoutCaching log context =
-        createServiceWithLatestKnownEvent context log CachingStrategy.NoCaching
+        createServiceWithLatestKnownEvent context log Equinox.CachingStrategy.NoCaching
     let createServiceWithCaching log context cache =
-        let sliding20m = CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
+        let sliding20m = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
         createServiceWithLatestKnownEvent context log sliding20m
     let streamName = ContactPreferences.streamId >> StreamName.render ContactPreferences.Category
 


### PR DESCRIPTION
While the value of caching is most debatable for ESDB, in general forcing people to be explicit about their caching strategy is a nudge that's too important to give up

- It also makes the Cosmos and Dynamo implementations cleaner to follow
- Obviates the need for #399 (as Cosmos and Dynamo no longer need specific mapping of available strategies)

Following the logic to its conclusion, considering the Access Strategy should also not be considered a luxury for a non-top system.
- Adds an `Unoptimized` case for EventStore, EventStoreDb, MessageDb and SqlStreamStore 

HT @nordfjord for driving the suggestion