### PR TITLE
fix!: Remove Async from TransactAsync, TransactExAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
-- `Equinox`: `Decider.Transact`, `TransactAsync`, `TransactExAsync` overloads [#325](https://github.com/jet/equinox/pull/325)
+- `Equinox`: `Decider.Transact`, `TransactEx` overloads [#325](https://github.com/jet/equinox/pull/325)
 - `Equinox.LoadOption.RequireLeader`: support for requesting a consistent read of a stream [#341](https://github.com/jet/equinox/pull/341)
 - `Equinox.LoadOption.AllowStale`: Read mode that limits reads to a maximum of one retrieval per the defined time window [#386](https://github.com/jet/equinox/pull/386)
 - `Equinox.Category` base class, with `Decider` and `Stream` helper `module`s [#337](https://github.com/jet/equinox/pull/337)
@@ -40,6 +40,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Equinox.LoadOption`: Rename `AllowStale` to `AnyCachedValue` [#386](https://github.com/jet/equinox/pull/386)
 - `Equinox.Decider`: Replace `'event list` with `'event[]` [#411](https://github.com/jet/equinox/pull/411)
 - `Equinox.Decider`: Replace `maxAttempts` with a default policy and an optional argument on `Transact*` APIs [#337](https://github.com/jet/equinox/pull/337)
+- `Equinox.Decider`: rename `Decider.TransactAsync`, `Decider.TransactExAsync` to `Transact` [#314](https://github.com/jet/equinox/pull/314)
 - `Equinox.Core.AsyncBatchingGate`: renamed to `Batching.Batcher` [#390](https://github.com/jet/equinox/pull/390)
 - `Equinox.Core`: Now a free-standing library that a) does not depend on `Equinox` b) is not depended on by the Stores (though `CosmosStore` inlines `AsyncCacheCell`) [#420](https://github.com/jet/equinox/pull/420)
 - Stores: Change Event Body types, requiring `FsCodec` v `3.0.0`, with [`EventBody` types switching from `byte[]` to `ReadOnlyMemory<byte>` and/or `JsonElement` see FsCodec#75](https://github.com/jet/FsCodec/pull/75) [#323](https://github.com/jet/equinox/pull/323)

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1318,7 +1318,7 @@ type Service internal (resolve: CartId -> Equinox.Decider<Events.Event, Fold.Sta
     member _.Run(cartId, optimistic, commands: Command seq, ?prepare): Async<Fold.State> =
         let decider = resolve cartId
         let opt = if optimistic then Equinox.AnyCachedValue else Equinox.RequireLoad
-        decider.TransactAsync(fun state -> async {
+        decider.Transact(fun state -> async {
             match prepare with None -> () | Some prep -> do! prep
             return interpretMany Fold.fold (Seq.map interpret commands) state }, opt)
 ```

--- a/samples/Store/Domain/Cart.fs
+++ b/samples/Store/Domain/Cart.fs
@@ -162,7 +162,7 @@ type Service internal (resolve: CartId -> Equinox.Decider<Events.Event, Fold.Sta
 #endif
         let decider = resolve cartId
         let opt = if optimistic then Equinox.LoadOption.AnyCachedValue else Equinox.LoadOption.RequireLoad
-        decider.TransactAsync(interpret, opt)
+        decider.Transact(interpret, opt)
 
     member x.ExecuteManyAsync(cartId, optimistic, commands: Command seq, ?prepare): Async<unit> =
         x.Run(cartId, optimistic, commands, ?prepare = prepare) |> Async.Ignore

--- a/samples/Store/Domain/Favorites.fs
+++ b/samples/Store/Domain/Favorites.fs
@@ -82,7 +82,8 @@ type Service internal (resolve: ClientId -> Equinox.Decider<Events.Event, Fold.S
     // NOTE not a real world example - used for an integration test; TODO get a better example where it's actually relevant
     member _.UnfavoriteWithPostVersion(clientId, sku) =
         let decider = resolve clientId
-        decider.TransactEx((fun c -> (), decideUnfavorite sku c.State), fun () c -> c.Version)
+        let mapResult () (c: Equinox.ISyncContext<_>) = c.Version
+        decider.TransactEx((fun c -> (), decideUnfavorite sku c.State), mapResult)
 
 let create resolve =
     Service(Stream.id >> resolve)

--- a/samples/Store/Domain/SavedForLater.fs
+++ b/samples/Store/Domain/SavedForLater.fs
@@ -126,7 +126,7 @@ type Service internal (resolve: ClientId -> Equinox.Decider<Events.Event, Fold.S
 
     let remove clientId (resolveCommand: (SkuId->bool) -> Async<Command>): Async<unit> =
         let decider = resolve clientId
-        decider.TransactAsync(fun (state: Fold.State) -> async {
+        decider.Transact(fun (state: Fold.State) -> async {
             let contents = seq { for item in state -> item.skuId } |> set
             let! cmd = resolveCommand contents.Contains
             let _, events = decide maxSavedItems cmd state

--- a/src/Equinox/Decider.fs
+++ b/src/Equinox/Decider.fs
@@ -67,33 +67,33 @@ type Decider<'event, 'state>(inner: DeciderCore<'event, 'state>) =
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Uses <c>render</c> to generate a 'view from the persisted final state
-    member _.TransactAsync(interpret: 'state -> Async<'event[]>, render: 'state -> 'view, ?load, ?attempts): Async<'view> = Async.call <| fun ct ->
-        inner.TransactAsync((fun s ct -> Async.StartImmediateAsTask(interpret s, ct)), render, ?load = load, ?attempts = attempts, ct = ct)
+    member _.Transact(interpret: 'state -> Async<'event[]>, render: 'state -> 'view, ?load, ?attempts): Async<'view> = Async.call <| fun ct ->
+        inner.Transact((fun s ct -> Async.StartImmediateAsTask(interpret s, ct)), render, ?load = load, ?attempts = attempts, ct = ct)
 
     /// 1. Invoke the supplied <c>Async</c> <c>decide</c> function with the present state, holding the <c>'result</c>
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yield result
-    member _.TransactAsync(decide: 'state -> Async<'result * 'event[]>, ?load, ?attempts): Async<'result> = Async.call <| fun ct ->
+    member _.Transact(decide: 'state -> Async<'result * 'event[]>, ?load, ?attempts): Async<'result> = Async.call <| fun ct ->
         let inline decide' s ct = task { let! r, es = Async.StartImmediateAsTask(decide s, ct) in return struct (r, es) }
-        inner.TransactAsync(decide', ?load = load, ?attempts = attempts, ct = ct)
+        inner.Transact(decide', ?load = load, ?attempts = attempts, ct = ct)
 
     /// 1. Invoke the supplied <c>Async</c> <c>decide</c> function with the current complete context, holding the <c>'result</c>
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yield result
-    member _.TransactExAsync(decide: ISyncContext<'state> -> Async<'result * 'event[]>, ?load, ?attempts): Async<'result> = Async.call <| fun ct ->
+    member _.TransactEx(decide: ISyncContext<'state> -> Async<'result * 'event[]>, ?load, ?attempts): Async<'result> = Async.call <| fun ct ->
         let decide' c ct = task { let! r, es = Async.StartImmediateAsTask(decide c, ct) in return struct (r, es) }
-        inner.TransactExAsync(decide', ?load = load, ?attempts = attempts, ct = ct)
+        inner.TransactEx(decide', ?load = load, ?attempts = attempts, ct = ct)
 
     /// 1. Invoke the supplied <c>Async</c> <c>decide</c> function with the current complete context, holding the <c>'result</c>
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yields a final 'view produced by <c>mapResult</c> from the <c>'result</c> and/or the final persisted <c>ISyncContext</c>
-    member _.TransactExAsync(decide: ISyncContext<'state> -> Async<'result * 'event[]>, mapResult: 'result -> ISyncContext<'state> -> 'view,
-                             ?load, ?attempts): Async<'view> = Async.call <| fun ct ->
+    member _.TransactEx(decide: ISyncContext<'state> -> Async<'result * 'event[]>, mapResult: 'result -> ISyncContext<'state> -> 'view,
+                       ?load, ?attempts): Async<'view> = Async.call <| fun ct ->
         let inline decide' c ct = task { let! r, es = Async.StartImmediateAsTask(decide c, ct) in return struct (r, es) }
-        inner.TransactExAsync(decide', mapResult, ?load = load, ?attempts = attempts, ct = ct)
+        inner.TransactEx(decide', mapResult, ?load = load, ?attempts = attempts, ct = ct)
 
 /// Central Application-facing API. Wraps the handling of decision or query flows in a manner that is store agnostic
 /// For F#, the async and FSharpFunc signatures in Decider tend to work better, but the API set is equivalent
@@ -175,8 +175,8 @@ and [<NoComparison; NoEquality>]
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Uses <c>render</c> to generate a 'view from the persisted final state
-    member _.TransactAsync(interpret: Func<'state, CancellationToken, Task<'event[]>>, render: Func<'state, 'view>,
-                           [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct): Task<'view> =
+    member _.Transact(interpret: Func<'state, CancellationToken, Task<'event[]>>, render: Func<'state, 'view>,
+                      [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct): Task<'view> =
         let inline decide struct (_token, state) ct = task { let! es = interpret.Invoke(state, ct) in return struct ((), es) }
         let inline mapRes () struct (_token, state) = render.Invoke state
         Stream.transact (stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
@@ -185,8 +185,8 @@ and [<NoComparison; NoEquality>]
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yield result
-    member _.TransactAsync(decide: Func<'state, CancellationToken, Task<struct ('result * 'event[])>>,
-                           [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct): Task<'result> =
+    member _.Transact(decide: Func<'state, CancellationToken, Task<struct ('result * 'event[])>>,
+                      [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct): Task<'result> =
         let inline decide struct (_token, state) ct = decide.Invoke(state, ct)
         let inline mapRes r _ = r
         Stream.transact (stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
@@ -195,8 +195,8 @@ and [<NoComparison; NoEquality>]
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yield result
-    member _.TransactExAsync(decide: Func<ISyncContext<'state>, CancellationToken, Task<struct ('result * 'event[])>>,
-                             [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct): Task<'result> =
+    member _.TransactEx(decide: Func<ISyncContext<'state>, CancellationToken, Task<struct ('result * 'event[])>>,
+                        [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct): Task<'result> =
         let inline decide (Context c) ct = decide.Invoke(c, ct)
         let inline mapRes r _ = r
         Stream.transact (stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)
@@ -205,8 +205,8 @@ and [<NoComparison; NoEquality>]
     /// 2. (if events yielded) Attempt to sync the yielded events to the stream.
     ///    (Restarts up to <c>maxAttempts</c> times with updated state per attempt, throwing <c>MaxResyncsExhaustedException</c> on failure of final attempt.)
     /// 3. Yields a final 'view produced by <c>mapResult</c> from the <c>'result</c> and/or the final persisted <c>ISyncContext</c>
-    member _.TransactExAsync(decide: Func<ISyncContext<'state>, CancellationToken, Task<struct ('result * 'event[])>>, mapResult: Func<'result, ISyncContext<'state>, 'view>,
-                             [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct): Task<'view> =
+    member _.TransactEx(decide: Func<ISyncContext<'state>, CancellationToken, Task<struct ('result * 'event[])>>, mapResult: Func<'result, ISyncContext<'state>, 'view>,
+                        [<O; D null>] ?load, [<O; D null>] ?attempts, [<O; D null>] ?ct): Task<'view> =
         let inline decide (Context c) ct = decide.Invoke(c, ct)
         let inline mapRes r (Context c) = mapResult.Invoke(r, c)
         Stream.transact (stream, LoadPolicy.Fetch load, decide, AttemptsPolicy.Validate attempts, mapRes, defaultArg ct CancellationToken.None)

--- a/tests/Equinox.EventStoreDb.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStoreDb.Integration/StoreIntegration.fs
@@ -424,9 +424,9 @@ type GeneralTests(testOutputHelper) =
         let id = Guid.NewGuid()
         let decider = SimplestThing.decider log context id
 
-        let! before, after = decider.TransactEx(
-            (fun state -> state.Version, [| SimplestThing.StuffHappened |]),
-            mapResult = (fun result ctx-> result, ctx.Version))
+        let! before, after =
+            let mapResult result (ctx: Equinox.ISyncContext<_>) = result, ctx.Version
+            decider.TransactEx((fun state -> state.Version, [| SimplestThing.StuffHappened |]), mapResult)
         test <@ [before; after] = [0L; 1L] @> }
 
 #if STORE_MESSAGEDB


### PR DESCRIPTION
Another run at #314
Having >10 overloads of transact has pros and cons; the seriousness of the cons is largely dependent on the IDE

While the single change I had to make to the consumption in this repo seems innocuous, IME it can be excruciating to resolve when you're just trying to make something work.

So I'm still not sure if it should actually be done...