### PR TITLE
feat(Tool): eqx stats -A

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `EventStoreDb`: As per `EventStore` module, but using the modern `EventStore.Client.Grpc.Streams` client [#196](https://github.com/jet/equinox/pull/196)
 - `MessageDb`: Implements a [message-db](http://docs.eventide-project.org/user-guide/message-db/) storage backend [#339](https://github.com/jet/equinox/pull/339) with OpenTelemetry tracing and snapshotting support [#348](https://github.com/jet/equinox/pull/348) :pray: [@nordfjord](https://github.com/nordfjord)
 - `eqx dump`: `-s` flag is now optional
+- `eqx stats`: `-A` flag to request all stats (equivalent to requesting `-ESD`) [#424](https://github.com/jet/equinox/pull/424)
 
 ### Changed
 

--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -84,7 +84,7 @@ type Tests(testOutputHelper) =
         let tripRequestCharges = [ for e, c in capture.RequestCharges -> sprintf "%A" e, c ]
         test <@ float rus >= Seq.sum (Seq.map snd tripRequestCharges) @>
 
-    // There's currently a discrepancy between real DynamoDb and the similar wrt whether a continuation token is returned
+    // There's currently a discrepancy between real DynamoDB and the dynamodb-local simulator wrt whether a continuation token is returned
     // when you hit the max count as you read the final item in a stream. Leaving it ugly in the hope we get to delete it.
     let expectFinalExtraPage () =
 #if STORE_DYNAMO

--- a/tools/Equinox.Tool/Infrastructure/Infrastructure.fs
+++ b/tools/Equinox.Tool/Infrastructure/Infrastructure.fs
@@ -9,7 +9,7 @@ open System.Text
 type Exception with
     // https://github.com/fsharp/fslang-suggestions/issues/660
     member this.Reraise() =
-        (System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture this).Throw ()
+        System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(this).Throw()
         Unchecked.defaultof<_>
 
 type Async with


### PR DESCRIPTION
Adds a `stats -A cosmos` option so nobody has to remember `-ESD` again