### PR TITLE
fix(Cosmos): add missing CosmosStoreContext.Connect wiring

### DIFF
--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -84,7 +84,7 @@ type Tests(testOutputHelper) =
         let tripRequestCharges = [ for e, c in capture.RequestCharges -> sprintf "%A" e, c ]
         test <@ float rus >= Seq.sum (Seq.map snd tripRequestCharges) @>
 
-    // There's currently a discrepancy between real DynamoDb and the similar wrt whether a continuation token is returned
+    // There's currently a discrepancy between real DynamoDB and the dynamodb-local simulator wrt whether a continuation token is returned
     // when you hit the max count as you read the final item in a stream. Leaving it ugly in the hope we get to delete it.
     let expectFinalExtraPage () =
 #if STORE_DYNAMO

--- a/tools/Equinox.Tool/Infrastructure/Infrastructure.fs
+++ b/tools/Equinox.Tool/Infrastructure/Infrastructure.fs
@@ -9,7 +9,7 @@ open System.Text
 type Exception with
     // https://github.com/fsharp/fslang-suggestions/issues/660
     member this.Reraise() =
-        (System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture this).Throw ()
+        System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(this).Throw()
         Unchecked.defaultof<_>
 
 type Async with


### PR DESCRIPTION
Includes minor cleanup work making logging consistent and/or aligning with equivalent in `dotnet-templates`