### PR TITLE
feat(Batcher): Add Limiter option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Equinox.DeciderCore`: C# friendly equivalent of `Decider` (i.e. `Func` and `Task`) [#338](https://github.com/jet/equinox/pull/338)
 - `Equinox.ISyncContext.StreamEventBytes`: Exposes stored size of events in the stream (initial impl provides it for `DynamoStore` only) [#326](https://github.com/jet/equinox/pull/326)
 - `Equinox.Core.Batching`: `BatcherDictionary`, `BatcherCache` to host concurrent `Batchers` [#390](https://github.com/jet/equinox/pull/390)
+- `Equinox.Core.Batching`: Add `limiter: SemaphoreSlim` argument to extend linger phase [#427](https://github.com/jet/equinox/pull/427)
 - `CosmosStore`: `CosmosStoreConnector.Connect`, `CosmosStoreClient.Connect`, `CosmosStoreContext.Connect` [#421](https://github.com/jet/equinox/pull/421)
 - `CosmosStore.Exceptions`: Active patterns to simplify classification in the context of Propulsion handlers [#416](https://github.com/jet/equinox/pull/416)
 - `CosmosStore.Prometheus`: Add `rut` tag to enable filtering/grouping by Read vs Write activity as per `DynamoStore` [#321](https://github.com/jet/equinox/pull/321)


### PR DESCRIPTION
Adds a facility to the Batcher that (optionally) extends the Linger period to include a phase during which a `SemaphoreSlim` is acquired:
- the semaphore is `Release`d when the processing has finished
- further items can join the lingering batch during the acquisition period