### PR TITLE
 refactor!: Label contexts unambiguously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Equinox.Core.AsyncBatchingGate`: renamed to `Batching.Batcher` [#390](https://github.com/jet/equinox/pull/390)
 - `Equinox.Core`: Now a free-standing library that a) does not depend on `Equinox` b) is not depended on by the Stores (though `CosmosStore` inlines `AsyncCacheCell`) [#420](https://github.com/jet/equinox/pull/420)
 - Stores: Change Event Body types, requiring `FsCodec` v `3.0.0`, with [`EventBody` types switching from `byte[]` to `ReadOnlyMemory<byte>` and/or `JsonElement` see FsCodec#75](https://github.com/jet/FsCodec/pull/75) [#323](https://github.com/jet/equinox/pull/323)
-- Stores: `*Category.Resolve`: Replace `Resolve(sn, ?ResolveOption, ?requestContext)` with `?load = LoadOption` parameter on all `Transact` and `Query` methods, and `Decider.forStream`/`Decider.forContext` to convey request context [#308](https://github.com/jet/equinox/pull/308)
+- Stores: `*Category.Resolve`: Replace `Resolve(sn, ?ResolveOption, ?requestContext)` with `?load = LoadOption` parameter on all `Transact` and `Query` methods, and `Decider.forStream`/`Decider.forRequest` to convey request context [#308](https://github.com/jet/equinox/pull/308)
 - Stores: `*Category` ctor: Add mandatory `name` argument, and `Name` property [#410](https://github.com/jet/equinox/pull/410)
 - Stores: `*Category` ctor: Change `fold` to be a `Func` (no changes to F# code required) [#421](https://github.com/jet/equinox/pull/421)
 - Stores: `*Category` ctor: Change `caching` to be last argument, to reflect that it is applied over the top [#410](https://github.com/jet/equinox/pull/410)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Equinox.Core.AsyncBatchingGate`: renamed to `Batching.Batcher` [#390](https://github.com/jet/equinox/pull/390)
 - `Equinox.Core`: Now a free-standing library that a) does not depend on `Equinox` b) is not depended on by the Stores (though `CosmosStore` inlines `AsyncCacheCell`) [#420](https://github.com/jet/equinox/pull/420)
 - Stores: Change Event Body types, requiring `FsCodec` v `3.0.0`, with [`EventBody` types switching from `byte[]` to `ReadOnlyMemory<byte>` and/or `JsonElement` see FsCodec#75](https://github.com/jet/FsCodec/pull/75) [#323](https://github.com/jet/equinox/pull/323)
-- Stores: `*Category.Resolve`: Replace `Resolve(sn, ?ResolveOption, ?context)` with `?load = LoadOption` parameter on all `Transact` and `Query` methods, and `Decider.forStream`/`Decider.forContext` to convey context [#308](https://github.com/jet/equinox/pull/308)
+- Stores: `*Category.Resolve`: Replace `Resolve(sn, ?ResolveOption, ?requestContext)` with `?load = LoadOption` parameter on all `Transact` and `Query` methods, and `Decider.forStream`/`Decider.forContext` to convey request context [#308](https://github.com/jet/equinox/pull/308)
 - Stores: `*Category` ctor: Add mandatory `name` argument, and `Name` property [#410](https://github.com/jet/equinox/pull/410)
 - Stores: `*Category` ctor: Change `fold` to be a `Func` (no changes to F# code required) [#421](https://github.com/jet/equinox/pull/421)
 - Stores: `*Category` ctor: Change `caching` to be last argument, to reflect that it is applied over the top [#410](https://github.com/jet/equinox/pull/410)
@@ -457,7 +457,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `.Cosmos`: ability to inhibit server certificate validation via `Connector`'s `bypassCertificateValidation` option [#170](https://github.com/jet/equinox/pull/170) :pray: [@Kelvin4702](https://github.com/Kelvin4702)
 - store-neutral `ICache`; centralized implementation in `Equinox.Core` [#161](https://github.com/jet/equinox/pull/161) :pray: [@DSilence](https://github.com/DSilence)
 - `ResolveOption.AllowStale`, maximizing use of OCC for `Stream.Transact`, enabling stale reads (in the face of multiple writers) for `Stream.Query` [#167](https://github.com/jet/equinox/pull/167)
-- Ability to (optionally) pass a `'Context` when creating a `Stream`, in order to be able to interop with FsCodec's `CorrelationId` and `CausationId` fields (as added in [FsCodec#22](https://github.com/jet/FsCodec/pulls/22)) [#169](https://github.com/jet/equinox/pull/169)
+- Ability to (optionally) pass a `'req` when creating a `Stream`, in order to be able to interop with FsCodec's `CorrelationId` and `CausationId` fields (as added in [FsCodec#22](https://github.com/jet/FsCodec/pulls/22)) [#169](https://github.com/jet/equinox/pull/169)
 
 ### Changed
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1833,9 +1833,9 @@ let connector: Equinox.CosmosStore.CosmosStoreConnector =
         maxRetryAttemptsOnRateLimitedRequests = 1,
         maxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds 3.)
 
-let! storeClient = CosmosStoreContext.Connect(connector, "databaseName", "containerName")
+let! context = CosmosStoreContext.Connect(connector, "databaseName", "containerName")
 
-let ctx = EventsContext(storeClient, gatewayLog)
+let ctx = EventsContext(context, gatewayLog)
 
 //
 // Write an event

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1833,9 +1833,7 @@ let connector: Equinox.CosmosStore.CosmosStoreConnector =
         maxRetryAttemptsOnRateLimitedRequests = 1,
         maxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds 3.)
 
-// If storing in a single collection, one specifies the db and collection when using Connect()
-// alternately use factory.CreateUnitialized, which defers that until the stream one is writing to becomes clear
-let! storeClient = CosmosStoreClient.Connect(connector.CreateAndInitialize, "databaseName", "containerName")
+let! storeClient = CosmosStoreContext.Connect(connector, "databaseName", "containerName")
 
 let ctx = EventsContext(storeClient, gatewayLog)
 

--- a/samples/Infrastructure/Services.fs
+++ b/samples/Infrastructure/Services.fs
@@ -14,21 +14,21 @@ type Store(store) =
             initial: 'state,
             snapshot: ('event -> bool) * ('state -> 'event)): Category<'event, 'state, unit> =
         match store with
-        | Store.Context.Memory store ->
+        | Store.Config.Memory store ->
             MemoryStore.MemoryStoreCategory(store, name, codec, fold, initial)
-        | Store.Context.Cosmos (store, caching, unfolds) ->
+        | Store.Config.Cosmos (store, caching, unfolds) ->
             let accessStrategy = if unfolds then CosmosStore.AccessStrategy.Snapshot snapshot else CosmosStore.AccessStrategy.Unoptimized
             CosmosStore.CosmosStoreCategory<'event,'state,_>(store, name, codec.ToJsonElementCodec(), fold, initial, accessStrategy, caching)
-        | Store.Context.Dynamo (store, caching, unfolds) ->
+        | Store.Config.Dynamo (store, caching, unfolds) ->
             let accessStrategy = if unfolds then DynamoStore.AccessStrategy.Snapshot snapshot else DynamoStore.AccessStrategy.Unoptimized
             DynamoStore.DynamoStoreCategory<'event,'state,_>(store, name, FsCodec.Deflate.EncodeTryDeflate codec, fold, initial, accessStrategy, caching)
-        | Store.Context.Es (context, caching, unfolds) ->
+        | Store.Config.Es (context, caching, unfolds) ->
             let accessStrategy = if unfolds then EventStoreDb.AccessStrategy.RollingSnapshots snapshot else EventStoreDb.AccessStrategy.Unoptimized
             EventStoreDb.EventStoreCategory<'event,'state,_>(context, name, codec, fold, initial, accessStrategy, caching)
-        | Store.Context.Sql (context, caching, unfolds) ->
+        | Store.Config.Sql (context, caching, unfolds) ->
             let accessStrategy = if unfolds then SqlStreamStore.AccessStrategy.RollingSnapshots snapshot else SqlStreamStore.AccessStrategy.Unoptimized
             SqlStreamStore.SqlStreamStoreCategory<'event,'state,_>(context, name, codec, fold, initial, accessStrategy, caching)
-        | Store.Context.Mdb (context, caching) ->
+        | Store.Config.Mdb (context, caching) ->
             MessageDb.MessageDbCategory<'event,'state,_>(context, name, codec, fold, initial, MessageDb.AccessStrategy.Unoptimized, caching)
 
 type ServiceBuilder(storageConfig, handlerLog) =

--- a/samples/Infrastructure/Store.fs
+++ b/samples/Infrastructure/Store.fs
@@ -104,9 +104,9 @@ module Cosmos =
     // NOTE: this is a big song and dance, don't blindly copy!
     // - In normal usage, you typically connect to a single container only.
     // - In hot-warm scenarios, the Archive Container will frequently be within the same account and hence can share a CosmosClient
-    // For these typical purposes, CosmosStoreClient.Connect should be used to establish the Client and Connection, not custom wiring as we have here
+    // For these typical purposes, CosmosStoreClient.Connect should be used to establish the Client, not custom wiring as we have here
     let createConnector (a: Arguments) connectionString =
-        CosmosStoreConnector(Discovery.ConnectionString connectionString, a.Timeout, a.Retries, a.MaxRetryWaitTime, ?mode=a.Mode)
+        CosmosStoreConnector(Discovery.ConnectionString connectionString, a.Timeout, a.Retries, a.MaxRetryWaitTime, ?mode = a.Mode)
     let connect (log: ILogger) (a: Arguments) =
         let primaryConnector, primaryDatabase, primaryContainer as primary = createConnector a a.Connection, a.Database, a.Container
         logContainer log "Primary" (a.Mode, primaryConnector.Endpoint, primaryDatabase, primaryContainer)

--- a/samples/Tutorial/AsAt.fsx
+++ b/samples/Tutorial/AsAt.fsx
@@ -19,7 +19,6 @@
 #r "Serilog.dll"
 #r "Serilog.Sinks.Console.dll"
 #r "Serilog.Sinks.Seq.dll"
-#r "Equinox.Core.dll"
 #r "Newtonsoft.Json.dll"
 #r "FSharp.UMX.dll"
 #r "FsCodec.dll"
@@ -168,8 +167,7 @@ module Cosmos =
     let discovery = Discovery.ConnectionString (read "EQUINOX_COSMOS_CONNECTION")
     let connector = CosmosStoreConnector(discovery, TimeSpan.FromSeconds 5., 2, TimeSpan.FromSeconds 5., Microsoft.Azure.Cosmos.ConnectionMode.Gateway)
     let databaseId, containerId = read "EQUINOX_COSMOS_DATABASE", read "EQUINOX_COSMOS_CONTAINER"
-    let storeClient = CosmosStoreClient.Connect(connector.CreateAndInitialize, databaseId, containerId) |> Async.RunSynchronously
-    let context = CosmosStoreContext(storeClient, databaseId, containerId, tipMaxEvents = 10)
+    let context = CosmosStoreContext.Connect(connector, databaseId, containerId, tipMaxEvents = 10) |> Async.RunSynchronously
     let accessStrategy = AccessStrategy.Snapshot (Fold.isValid,Fold.snapshot)
     let cat = CosmosStoreCategory(context, Stream.Category, Events.codecJe, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
     let resolve = Equinox.Decider.forStream Log.log cat

--- a/samples/Tutorial/Cosmos.fsx
+++ b/samples/Tutorial/Cosmos.fsx
@@ -9,7 +9,6 @@
 #r "Newtonsoft.Json.dll"
 #r "TypeShape.dll"
 #r "Equinox.dll"
-#r "Equinox.Core.dll"
 #r "FSharp.UMX.dll"
 #r "FsCodec.dll"
 #r "FsCodec.SystemTextJson.dll"
@@ -103,8 +102,7 @@ module Store =
     let connector = CosmosStoreConnector(discovery, System.TimeSpan.FromSeconds 5., 2, System.TimeSpan.FromSeconds 5., Microsoft.Azure.Cosmos.ConnectionMode.Gateway)
 
     let databaseId, containerId = read "EQUINOX_COSMOS_DATABASE", read "EQUINOX_COSMOS_CONTAINER"
-    let storeClient = CosmosStoreClient.Connect(connector.CreateAndInitialize, databaseId, containerId) |> Async.RunSynchronously
-    let context = CosmosStoreContext(storeClient, databaseId, containerId, tipMaxEvents = 10)
+    let context = CosmosStoreContext.Connect(connector, databaseId, containerId, tipMaxEvents = 10) |> Async.RunSynchronously
     let cache = Equinox.Cache(appName, 20)
 
 let service = Favorites.Cosmos.category (Store.context, Store.cache) |> Favorites.create

--- a/samples/Tutorial/Counter.fsx
+++ b/samples/Tutorial/Counter.fsx
@@ -6,7 +6,6 @@
 #r "Serilog.dll"
 #r "Serilog.Sinks.Console.dll"
 #r "Equinox.dll"
-#r "Equinox.Core.dll"
 #r "Equinox.MemoryStore.dll"
 #r "TypeShape.dll"
 #r "FSharp.UMX.dll"

--- a/samples/Tutorial/Favorites.fsx
+++ b/samples/Tutorial/Favorites.fsx
@@ -5,7 +5,6 @@
 #r "Serilog.dll"
 #r "Serilog.Sinks.Console.dll"
 #r "Equinox.dll"
-#r "Equinox.Core.dll"
 #r "Equinox.MemoryStore.dll"
 #r "FSharp.UMX.dll"
 #r "FSCodec.dll"

--- a/samples/Tutorial/FulfilmentCenter.fsx
+++ b/samples/Tutorial/FulfilmentCenter.fsx
@@ -6,7 +6,6 @@
 #r "Serilog.Sinks.Console.dll"
 #r "Newtonsoft.Json.dll"
 #r "Equinox.dll"
-#r "Equinox.Core.dll"
 #r "FSharp.UMX.dll"
 #r "FsCodec.dll"
 #r "TypeShape.dll"
@@ -138,8 +137,7 @@ module Store =
     let appName = "equinox-tutorial"
     let connector = CosmosStoreConnector(Discovery.ConnectionString (read "EQUINOX_COSMOS_CONNECTION"), TimeSpan.FromSeconds 5., 2, TimeSpan.FromSeconds 5.)
     let databaseId, containerId = read "EQUINOX_COSMOS_DATABASE", read "EQUINOX_COSMOS_CONTAINER"
-    let storeClient = CosmosStoreClient.Connect(connector.CreateAndInitialize, databaseId, containerId) |> Async.RunSynchronously
-    let context = CosmosStoreContext(storeClient, databaseId, containerId, tipMaxEvents = 256)
+    let context = CosmosStoreContext.Connect(connector, databaseId, containerId, tipMaxEvents = 256) |> Async.RunSynchronously
     let cache = Equinox.Cache(appName, 20)
     let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
 

--- a/samples/Tutorial/Todo.fsx
+++ b/samples/Tutorial/Todo.fsx
@@ -15,10 +15,10 @@
 #r "Microsoft.Azure.Cosmos.Client.dll"
 #r "Equinox.CosmosStore.dll"
 #else
-#r "nuget: Equinox.CosmosStore, *-*"
-#r "nuget: FsCodec.SystemTextJson, *-*"
-#r "nuget: Serilog.Sinks.Console"
-#r "nuget: Serilog.Sinks.Seq"
+#r "nuget:Equinox.CosmosStore, *-*"
+#r "nuget:FsCodec.SystemTextJson, *-*"
+#r "nuget:Serilog.Sinks.Console"
+#r "nuget:Serilog.Sinks.Seq"
 #endif
 
 open System

--- a/samples/Tutorial/Todo.fsx
+++ b/samples/Tutorial/Todo.fsx
@@ -7,7 +7,6 @@
 #r "Serilog.Sinks.Console.dll"
 #r "Newtonsoft.Json.dll"
 #r "TypeShape.dll"
-#r "Equinox.Core.dll"
 #r "Equinox.dll"
 #r "FSharp.UMX.dll"
 #r "FsCodec.dll"
@@ -134,8 +133,7 @@ module Store =
     let discovery = Discovery.ConnectionString (read "EQUINOX_COSMOS_CONNECTION")
     let connector = CosmosStoreConnector(discovery, TimeSpan.FromSeconds 5., 2, TimeSpan.FromSeconds 5.)
     let databaseId, containerId = read "EQUINOX_COSMOS_DATABASE", read "EQUINOX_COSMOS_CONTAINER"
-    let storeClient = CosmosStoreClient.Connect(connector.CreateAndInitialize, databaseId, containerId) |> Async.RunSynchronously
-    let context = CosmosStoreContext(storeClient, databaseId, containerId, tipMaxEvents = 100) // Keep up to 100 events in tip before moving events to a new document
+    let context = CosmosStoreContext.Connect(connector, databaseId, containerId, tipMaxEvents = 100) |> Async.RunSynchronously // Keep up to 100 events in tip before moving events to a new document
     let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
 
     let access = AccessStrategy.Snapshot Snapshot.config

--- a/samples/Web/Startup.fs
+++ b/samples/Web/Startup.fs
@@ -65,7 +65,7 @@ type Startup() =
             let c = match maybeSeq with None -> c | Some endpoint -> c.WriteTo.Seq(endpoint)
             c.CreateLogger() :> ILogger
 
-        let storeConfig, storeLog : Store.Context * ILogger =
+        let storeConfig, storeLog : Store.Config * ILogger =
             let options = p.GetResults Cached @ p.GetResults Unfolds
             let unfolds = options |> List.exists (function Unfolds -> true | _ -> false)
             let log = Log.ForContext<App>()

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -1079,10 +1079,10 @@ type internal StoreCategory<'event, 'state, 'req>
         member _.Load(log, _categoryName, _streamId, stream, _maxAge, _requireLeader, ct): Task<struct (StreamToken * 'state)> = task {
             let! token, events = store.Load(log, (stream, None), (codec.TryDecode, isOrigin), checkUnfolds, ct)
             return struct (token, fold initial events) }
-        member _.Sync(log, _categoryName, _streamId, streamName, ctx, (Token.Unpack pos as streamToken), state, events, ct) = task {
+        member _.Sync(log, _categoryName, _streamId, streamName, req, (Token.Unpack pos as streamToken), state, events, ct) = task {
             let state' = fold state events
             let exp, events, eventsEncoded, projectionsEncoded =
-                let encode e = codec.Encode(ctx, e)
+                let encode e = codec.Encode(req, e)
                 match mapUnfolds with
                 | Choice1Of3 () ->        SyncExp.Version pos.index, events, Array.map encode events, Seq.empty
                 | Choice2Of3 unfold ->    SyncExp.Version pos.index, events, Array.map encode events, Array.map encode (unfold events state')

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -1,8 +1,8 @@
 namespace Equinox.CosmosStore.Core
 
 open Equinox.Core
-open FsCodec
 open FSharp.Control
+open FsCodec
 open Microsoft.Azure.Cosmos
 open Serilog
 open System
@@ -1167,7 +1167,7 @@ type CosmosClientFactory
         co
 
     /// Creates an instance of CosmosClient without actually validating or establishing the connection
-    /// It's recommended to use <c>Connect()</c> and/or <c>CosmosStoreClient.Connect()</c> in preference to this API
+    /// It's recommended to use <c>CosmosStoreClient.Connect()</c> in preference to this API
     ///   in order to avoid latency spikes, and/or deferring discovery of connectivity or permission issues.
     member x.CreateUninitialized(discovery: Discovery) = discovery |> function
         | Discovery.AccountUriAndKey (accountUri = uri; key = key) -> new CosmosClient(string uri, key, x.Options)
@@ -1211,7 +1211,7 @@ type CosmosStoreConnector
     member _.Endpoint = discovery.Endpoint
 
     /// Creates an instance of CosmosClient without actually validating or establishing the connection
-    /// It's recommended to use <c>Connect()</c> and/or <c>CosmosStoreClient.Connect()</c> in preference to this API
+    /// It's recommended to use <c>Connect</c> and/or <c>CosmosStoreClient.Connect()</c> in preference to this API
     ///   in order to avoid latency spikes, and/or deferring discovery of connectivity or permission issues.
     member _.CreateUninitialized() = factory.CreateUninitialized(discovery)
 

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -1065,16 +1065,16 @@ type StoreClient(container: Container, fallback: Container option, query: QueryO
     member _.Prune(log, stream, index, ct) =
         Prune.until log (container, stream) query.MaxItems index ct
 
-type internal StoreCategory<'event, 'state, 'context>
+type internal StoreCategory<'event, 'state, 'req>
     (   store: StoreClient, createStoredProcIfNotExistsExactlyOnce: CancellationToken -> System.Threading.Tasks.ValueTask,
-        codec: IEventCodec<'event, EventBody, 'context>, fold, initial: 'state, isOrigin: 'event -> bool,
+        codec: IEventCodec<'event, EventBody, 'req>, fold, initial: 'state, isOrigin: 'event -> bool,
         checkUnfolds, compressUnfolds, mapUnfolds: Choice<unit, 'event[] -> 'state -> 'event[], 'event[] -> 'state -> 'event[] * 'event[]>) =
     let fold s xs = (fold : Func<'state, 'event[], 'state>).Invoke(s, xs)
     let reload (log, streamName, (Token.Unpack pos as streamToken), state) preloaded ct: Task<struct (StreamToken * 'state)> = task {
         match! store.Reload(log, (streamName, pos), (codec.TryDecode, isOrigin), ct, ?preview = preloaded) with
         | LoadFromTokenResult.Unchanged -> return struct (streamToken, state)
         | LoadFromTokenResult.Found (token', events) -> return token', fold state events }
-    interface ICategory<'event, 'state, 'context> with
+    interface ICategory<'event, 'state, 'req> with
         member _.Empty = Token.create Position.fromKnownEmpty, initial
         member _.Load(log, _categoryName, _streamId, stream, _maxAge, _requireLeader, ct): Task<struct (StreamToken * 'state)> = task {
             let! token, events = store.Load(log, (stream, None), (codec.TryDecode, isOrigin), checkUnfolds, ct)
@@ -1338,8 +1338,8 @@ type AccessStrategy<'event, 'state> =
     /// </remarks>
     | Custom of isOrigin: ('event -> bool) * transmute: ('event[] -> 'state -> 'event[] * 'event[])
 
-type CosmosStoreCategory<'event, 'state, 'context> =
-    inherit Equinox.Category<'event, 'state, 'context>
+type CosmosStoreCategory<'event, 'state, 'req> =
+    inherit Equinox.Category<'event, 'state, 'req>
     new(context: CosmosStoreContext, name, codec, fold, initial, access,
         // For CosmosDB, caching is typically a central aspect of managing RU consumption to maintain performance and capacity.
         // The cache holds the Tip document's etag, which enables use of etag-contingent Reads (which cost only 1RU in the case where the document is unchanged)
@@ -1363,9 +1363,9 @@ type CosmosStoreCategory<'event, 'state, 'context> =
             | AccessStrategy.MultiSnapshot (isOrigin, unfold) -> isOrigin,         true,  Choice2Of3 (fun _ state  -> unfold state)
             | AccessStrategy.RollingState toSnapshot ->          (fun _ -> true),  true,  Choice3Of3 (fun _ state  -> Array.empty, toSnapshot state |> Array.singleton)
             | AccessStrategy.Custom (isOrigin, transmute) ->     isOrigin,         true,  Choice3Of3 transmute
-        { inherit Equinox.Category<'event, 'state, 'context>(name,
-            StoreCategory<'event, 'state, 'context>(context.StoreClient, context.EnsureStoredProcedureInitialized, codec, fold, initial, isOrigin, checkUnfolds, compressUnfolds, mapUnfolds)
-            |> Caching.apply Token.isStale caching); __ = 0 }; val private __: int // __ can be removed after Rider 2023.2
+        { inherit Equinox.Category<'event, 'state, 'req>(name,
+            StoreCategory<'event, 'state, 'req>(context.StoreClient, context.EnsureStoredProcedureInitialized, codec, fold, initial, isOrigin, checkUnfolds, compressUnfolds, mapUnfolds)
+            |> Caching.apply Token.isStale caching); __ = () }; val private __: unit // __ can be removed after Rider 2023.2
 
 module Exceptions =
 

--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -1112,9 +1112,9 @@ type internal StoreClient(table: StoreTable, fallback: StoreTable option, query:
     member _.Prune(log, stream, index, ct) =
         Prune.until log (table, stream) query.MaxItems index ct
 
-type internal StoreCategory<'event, 'state, 'context>
+type internal StoreCategory<'event, 'state, 'req>
     (   store: StoreClient,
-        codec: IEventCodec<'event, EncodedBody, 'context>, fold, initial: 'state, isOrigin: 'event -> bool,
+        codec: IEventCodec<'event, EncodedBody, 'req>, fold, initial: 'state, isOrigin: 'event -> bool,
         checkUnfolds, mapUnfolds: Choice<unit, 'event[] -> 'state -> 'event[], 'event[] -> 'state -> 'event[] * 'event[]>) =
     let fold s xs = (fold : Func<'state, 'event[], 'state>).Invoke(s, xs)
     let fetch state f = task { let! token', events = f in return struct (token', fold state events) }
@@ -1122,7 +1122,7 @@ type internal StoreCategory<'event, 'state, 'context>
         match! store.Reload(log, (streamNam, pos), requireLeader, (codec.TryDecode, isOrigin), ct) with
         | LoadFromTokenResult.Unchanged -> return struct (streamToken, state)
         | LoadFromTokenResult.Found (token', events) -> return token', fold state events }
-    interface ICategory<'event, 'state, 'context> with
+    interface ICategory<'event, 'state, 'req> with
         member _.Empty = Token.empty, initial
         member _.Load(log, _categoryName, _streamId, streamName, _maxAge, requireLeader, ct) =
             fetch initial (store.Load(log, (streamName, None), requireLeader, (codec.TryDecode, isOrigin), checkUnfolds, ct))
@@ -1282,8 +1282,8 @@ type AccessStrategy<'event, 'state> =
     /// </remarks>
     | Custom of isOrigin: ('event -> bool) * transmute: ('event[] -> 'state -> 'event[] * 'event[])
 
-type DynamoStoreCategory<'event, 'state, 'context> =
-    inherit Equinox.Category<'event, 'state, 'context>
+type DynamoStoreCategory<'event, 'state, 'req> =
+    inherit Equinox.Category<'event, 'state, 'req>
     new(context: DynamoStoreContext, name, codec, fold, initial, access,
         // For DynamoDB, caching is typically a central aspect of managing RU consumption to maintain performance and capacity.
         // Omitting can make sense in specific cases; if streams are short, or there's always a usable snapshot in the Tip
@@ -1302,9 +1302,9 @@ type DynamoStoreCategory<'event, 'state, 'context> =
             | AccessStrategy.MultiSnapshot (isOrigin, unfold) -> isOrigin,         true,  Choice2Of3 (fun _ (state: 'state) -> unfold state)
             | AccessStrategy.RollingState toSnapshot ->          (fun _ -> true),  true,  Choice3Of3 (fun _ state  -> Array.empty, toSnapshot state |> Array.singleton)
             | AccessStrategy.Custom (isOrigin, transmute) ->     isOrigin,         true,  Choice3Of3 transmute
-        { inherit Equinox.Category<'event, 'state, 'context>(name,
-            StoreCategory<'event, 'state, 'context>(context.StoreClient, codec, fold, initial, isOrigin, checkUnfolds, mapUnfolds)
-            |> Caching.apply Token.isStale caching) }
+        { inherit Equinox.Category<'event, 'state, 'req>(name,
+            StoreCategory<'event, 'state, 'req>(context.StoreClient, codec, fold, initial, isOrigin, checkUnfolds, mapUnfolds)
+            |> Caching.apply Token.isStale caching); __ = () }; val private __: unit // __ can be removed after Rider 2023.2
 
 module Exceptions =
 

--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -1,9 +1,9 @@
 namespace Equinox.DynamoStore.Core
 
 open Equinox.Core
-open FsCodec
 open FSharp.AWS.DynamoDB
 open FSharp.Control
+open FsCodec
 open Serilog
 open System
 open System.IO
@@ -1240,7 +1240,7 @@ type DynamoStoreContext(client: DynamoStoreClient, tableName, tipOptions, queryO
             [<O; D null>] ?queryMaxItems, [<O; D null>] ?queryMaxRequests,
             [<O; D null>] ?ignoreMissingEvents, [<O; D null>] ?archiveTableName,
             [<O; D null>] ?mode: ConnectMode): Async<DynamoStoreContext> = async {
-        do! client.Establish(tableName, ?archiveTableName = archiveTableName)
+        do! client.Establish(tableName, ?archiveTableName = archiveTableName, ?mode = mode)
         return DynamoStoreContext(client, tableName,
             ?maxBytes = maxBytes, ?tipMaxEvents = tipMaxEvents,
             ?queryMaxItems = queryMaxItems, ?queryMaxRequests = queryMaxRequests,

--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -1126,10 +1126,10 @@ type internal StoreCategory<'event, 'state, 'req>
         member _.Empty = Token.empty, initial
         member _.Load(log, _categoryName, _streamId, streamName, _maxAge, requireLeader, ct) =
             fetch initial (store.Load(log, (streamName, None), requireLeader, (codec.TryDecode, isOrigin), checkUnfolds, ct))
-        member _.Sync(log, _categoryName, _streamId, streamName, ctx, (Token.Unpack pos as streamToken), state, events, ct) = task {
+        member _.Sync(log, _categoryName, _streamId, streamName, req, (Token.Unpack pos as streamToken), state, events, ct) = task {
             let state' = fold state events
             let exp, events, eventsEncoded, unfoldsEncoded =
-                let encode e = codec.Encode(ctx, e)
+                let encode e = codec.Encode(req, e)
                 let expVer = Position.toIndex >> Sync.Exp.Version
                 match mapUnfolds with
                 | Choice1Of3 () ->        expVer, events, Array.map encode events, Array.empty

--- a/src/Equinox.EventStoreDb/EventStoreDb.fs
+++ b/src/Equinox.EventStoreDb/EventStoreDb.fs
@@ -380,7 +380,7 @@ type private CompactionContext(eventsLen: int, capacityBeforeCompaction: int) =
     /// Determines whether writing a Compaction event is warranted (based on the existing state and the current accumulated changes)
     member _.IsCompactionDue = eventsLen > capacityBeforeCompaction
 
-type private StoreCategory<'event, 'state, 'context>(context: EventStoreContext, codec: FsCodec.IEventCodec<_, _, 'context>, fold, initial, access) =
+type private StoreCategory<'event, 'state, 'req>(context: EventStoreContext, codec: FsCodec.IEventCodec<_, _, 'req>, fold, initial, access) =
     let fold s xs = (fold : System.Func<'state, 'event[], 'state>).Invoke(s, xs)
     let tryDecode (e: ResolvedEvent) = e.Event |> ClientCodec.timelineEvent |> codec.TryDecode
     let isOrigin =
@@ -401,7 +401,7 @@ type private StoreCategory<'event, 'state, 'context>(context: EventStoreContext,
     let fetch state f = task { let! struct (token', events) = f in return struct (token', fold state events) }
     let reload (log, sn, leader, token, state) ct = fetch state (context.Reload(log, sn, leader, token, tryDecode, compactionPredicate, ct))
     interface Caching.IReloadable<'state> with member _.Reload(log, sn, leader, token, state, ct) = reload (log, sn, leader, token, state) ct
-    interface ICategory<'event, 'state, 'context> with
+    interface ICategory<'event, 'state, 'req> with
         member _.Empty = context.TokenEmpty, initial
         member _.Load(log, _categoryName, _streamId, streamName, _maxAge, requireLeader, ct) =
             fetch initial (loadAlgorithm log streamName requireLeader ct)
@@ -418,9 +418,9 @@ type private StoreCategory<'event, 'state, 'context>(context: EventStoreContext,
             | GatewaySyncResult.Written token' ->    return SyncResult.Written  (token', fold state events)
             | GatewaySyncResult.ConflictUnknown _ -> return SyncResult.Conflict (reload (log, streamName, (*requireLeader*)true, streamToken, state)) }
 
-type EventStoreCategory<'event, 'state, 'context> =
-    inherit Equinox.Category<'event, 'state, 'context>
-    new(context: EventStoreContext, name, codec: FsCodec.IEventCodec<_, _, 'context>, fold, initial, access,
+type EventStoreCategory<'event, 'state, 'req> =
+    inherit Equinox.Category<'event, 'state, 'req>
+    new(context: EventStoreContext, name, codec: FsCodec.IEventCodec<_, _, 'req>, fold, initial, access,
         // Caching can be overkill for EventStore esp considering the degree to which its intrinsic caching is a first class feature
         // e.g., a key benefit is that reads of streams more than a few pages long get completed in constant time after the initial load
         caching) =
@@ -429,9 +429,9 @@ type EventStoreCategory<'event, 'state, 'context> =
         | AccessStrategy.LatestKnownEvent, _ ->
             invalidOp "Equinox.EventStoreDb does not support mixing AccessStrategy.LatestKnownEvent with Caching at present."
         | _ -> ()
-        { inherit Equinox.Category<'event, 'state, 'context>(name,
-            StoreCategory<'event, 'state, 'context>(context, codec, fold, initial, access)
-            |> Caching.apply Token.isStale caching) }
+        { inherit Equinox.Category<'event, 'state, 'req>(name,
+            StoreCategory<'event, 'state, 'req>(context, codec, fold, initial, access)
+            |> Caching.apply Token.isStale caching); __ = () }; val private __: unit // __ can be removed after Rider 2023.2
 
 [<RequireQualifiedAccess; NoComparison>]
 type Discovery =

--- a/src/Equinox.EventStoreDb/EventStoreDb.fs
+++ b/src/Equinox.EventStoreDb/EventStoreDb.fs
@@ -405,14 +405,14 @@ type private StoreCategory<'event, 'state, 'req>(context: EventStoreContext, cod
         member _.Empty = context.TokenEmpty, initial
         member _.Load(log, _categoryName, _streamId, streamName, _maxAge, requireLeader, ct) =
             fetch initial (loadAlgorithm log streamName requireLeader ct)
-        member _.Sync(log, _categoryName, _streamId, streamName, ctx, (Token.Unpack token as streamToken), state, events, ct) = task {
+        member _.Sync(log, _categoryName, _streamId, streamName, req, (Token.Unpack token as streamToken), state, events, ct) = task {
             let events =
                 match access with
                 | AccessStrategy.Unoptimized | AccessStrategy.LatestKnownEvent -> events
                 | AccessStrategy.RollingSnapshots (_, compact) ->
                     let cc = CompactionContext(Array.length events, token.batchCapacityLimit.Value)
                     if cc.IsCompactionDue then Array.append events (fold state events |> compact |> Array.singleton) else events
-            let encode e = codec.Encode(ctx, e)
+            let encode e = codec.Encode(req, e)
             let encodedEvents: EventData[] = events |> Array.map (encode >> ClientCodec.eventData)
             match! context.Sync(log, streamName, streamToken, events, encodedEvents, compactionPredicate, ct) with
             | GatewaySyncResult.Written token' ->    return SyncResult.Written  (token', fold state events)

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -373,7 +373,7 @@ type AccessStrategy<'event, 'state> =
     /// </summary>
     | AdjacentSnapshots of snapshotEventCaseName: string * toSnapshot: ('state -> 'event)
 
-type private StoreCategory<'event, 'state, 'context>(context: MessageDbContext, codec: IEventCodec<_, _, 'context>, fold, initial, access) =
+type private StoreCategory<'event, 'state, 'req>(context: MessageDbContext, codec: IEventCodec<_, _, 'req>, fold, initial, access) =
     let fold s xs = (fold : System.Func<'state, 'event[], 'state>).Invoke(s, xs)
     let loadAlgorithm log category streamId streamName requireLeader ct =
         match access with
@@ -387,7 +387,7 @@ type private StoreCategory<'event, 'state, 'context>(context: MessageDbContext, 
                 return struct(token, state)
             | ValueNone -> return! context.LoadBatched(log, streamName, requireLeader, codec.TryDecode, fold, initial, ct) }
     let reload (log, sn, leader, token, state) ct = context.Reload(log, sn, leader, token, codec.TryDecode, fold, state, ct)
-    interface ICategory<'event, 'state, 'context> with
+    interface ICategory<'event, 'state, 'req> with
         member _.Empty = context.TokenEmpty, initial
         member _.Load(log, categoryName, streamId, streamName, _maxAge, requireLeader, ct) =
             loadAlgorithm log categoryName streamId streamName requireLeader ct
@@ -413,11 +413,11 @@ type private StoreCategory<'event, 'state, 'context>(context: MessageDbContext, 
             FsCodec.Core.EventData.Create(rawEvent.EventType, rawEvent.Data, meta = Snapshot.meta token)
         context.StoreSnapshot(log, category, streamId, encodedWithMeta, ct)
 
-type MessageDbCategory<'event, 'state, 'context>(context: MessageDbContext, name, codec, fold, initial, access,
+type MessageDbCategory<'event, 'state, 'req>(context: MessageDbContext, name, codec, fold, initial, access,
         // For MessageDb, caching is less critical than it is for e.g. CosmosDB.
         // However, while not necessary to control costs, caching can improve the throughput of your application a few times over,
         //   as such you should only skip it if you know what you're doing
         //   e.g. if streams are always short, events are always small, you are absolutely certain there will be no cache hits
         //        (and you have a cheerful but bored DBA)
         caching) =
-    inherit Equinox.Category<'event, 'state, 'context>(name, StoreCategory(context, codec, fold, initial, access) |> Caching.apply Token.isStale caching)
+    inherit Equinox.Category<'event, 'state, 'req>(name, StoreCategory(context, codec, fold, initial, access) |> Caching.apply Token.isStale caching)

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -407,9 +407,9 @@ type private StoreCategory<'event, 'state, 'req>(context: MessageDbContext, code
                 return SyncResult.Conflict (reload (log, streamName, (*requireLeader*)true, token, state)) }
     interface Caching.IReloadable<'state> with member _.Reload(log, sn, leader, token, state, ct) = reload (log, sn, leader, token, state) ct
 
-    member _.StoreSnapshot(log, category, streamId, ctx, token, snapshotEvent, ct) =
+    member _.StoreSnapshot(log, category, streamId, req, token, snapshotEvent, ct) =
         let encodedWithMeta =
-            let rawEvent = codec.Encode(ctx, snapshotEvent)
+            let rawEvent = codec.Encode(req, snapshotEvent)
             FsCodec.Core.EventData.Create(rawEvent.EventType, rawEvent.Data, meta = Snapshot.meta token)
         context.StoreSnapshot(log, category, streamId, encodedWithMeta, ct)
 

--- a/src/Equinox.SqlStreamStore/SqlStreamStore.fs
+++ b/src/Equinox.SqlStreamStore/SqlStreamStore.fs
@@ -437,14 +437,14 @@ type private StoreCategory<'event, 'state, 'req>(context: SqlStreamStoreContext,
         member _.Empty = context.TokenEmpty, initial
         member _.Load(log, _categoryName, _streamId, streamName, _maxAge, requireLeader, ct) =
             fetch initial (loadAlgorithm log streamName requireLeader ct)
-        member _.Sync(log, _categoryName, _streamId, streamName, ctx, (Token.Unpack token as streamToken), state, events, ct) = task {
+        member _.Sync(log, _categoryName, _streamId, streamName, req, (Token.Unpack token as streamToken), state, events, ct) = task {
             let events =
                 match access with
                 | AccessStrategy.Unoptimized | AccessStrategy.LatestKnownEvent -> events
                 | AccessStrategy.RollingSnapshots (_, compact) ->
                     let cc = CompactionContext(Array.length events, token.batchCapacityLimit.Value)
                     if cc.IsCompactionDue then Array.append events (fold state events |> compact |> Array.singleton) else events
-            let encode e = codec.Encode(ctx, e)
+            let encode e = codec.Encode(req, e)
             let encodedEvents: EventData[] = events |> Array.map (encode >> UnionEncoderAdapters.eventDataOfEncodedEvent)
             match! context.Sync(log, streamName, streamToken, events, encodedEvents, compactionPredicate, ct) with
             | GatewaySyncResult.Written token' ->  return SyncResult.Written  (token', fold state events)

--- a/src/Equinox.Tests/CachingTests.fs
+++ b/src/Equinox.Tests/CachingTests.fs
@@ -33,7 +33,7 @@ type SpyCategory() =
             Interlocked.Increment &loads |> ignore
             do! Task.Delay(x.Delay, ct)
             return struct (mkToken(), Interlocked.Increment &state) }
-        member _.Sync(_log, _cat, _sid, _sn, _ctx, _originToken, originState, events, _ct) = task {
+        member _.Sync(_log, _cat, _sid, _sn, _req, _originToken, originState, events, _ct) = task {
             return Equinox.Core.SyncResult.Written (mkToken(), originState + events.Length) }
 
     interface Equinox.Core.Caching.IReloadable<State> with

--- a/src/Equinox/Caching.fs
+++ b/src/Equinox/Caching.fs
@@ -9,9 +9,9 @@ let private tee f (inner: CancellationToken -> Task<struct (StreamToken * 'state
     f tokenAndState
     return tokenAndState }
 
-type private Decorator<'event, 'state, 'context, 'cat when 'cat :> ICategory<'event, 'state, 'context> and 'cat :> IReloadable<'state> >
+type private Decorator<'event, 'state, 'req, 'cat when 'cat :> ICategory<'event, 'state, 'req> and 'cat :> IReloadable<'state> >
     (category: 'cat, cache: Equinox.Cache, isStale, createKey, createOptions) =
-    interface ICategory<'event, 'state, 'context> with
+    interface ICategory<'event, 'state, 'req> with
         member _.Empty = category.Empty
         member _.Load(log, categoryName, streamId, streamName, maxAge, requireLeader, ct) = task {
             let loadOrReload ct = function
@@ -37,7 +37,7 @@ let private policyFixedTimeSpan (period: System.TimeSpan) () =
     let expirationPoint = let creationDate = System.DateTimeOffset.UtcNow in creationDate.Add period
     System.Runtime.Caching.CacheItemPolicy(AbsoluteExpiration = expirationPoint)
 
-let apply isStale x (cat: 'cat when 'cat :> ICategory<'event, 'state, 'context> and 'cat :> IReloadable<'state>) =
+let apply isStale x (cat: 'cat when 'cat :> ICategory<'event, 'state, 'req> and 'cat :> IReloadable<'state>) =
     match x with
     | Equinox.CachingStrategy.NoCaching ->                                     (cat : ICategory<_, _, _>)
     | Equinox.CachingStrategy.FixedTimeSpan (cache, period) ->                 Decorator(cat, cache, isStale, mkKey null,   policyFixedTimeSpan period)

--- a/src/Equinox/Caching.fs
+++ b/src/Equinox/Caching.fs
@@ -18,10 +18,10 @@ type private Decorator<'event, 'state, 'req, 'cat when 'cat :> ICategory<'event,
                 | ValueNone -> category.Load(log, categoryName, streamId, streamName, maxAge, requireLeader, ct)
                 | ValueSome (struct (token, state)) -> category.Reload(log, streamName, requireLeader, token, state, ct)
             return! cache.Load(createKey streamName, maxAge, isStale, createOptions (), loadOrReload, ct) }
-        member _.Sync(log, categoryName, streamId, streamName, context, streamToken, state, events, ct) = task {
+        member _.Sync(log, categoryName, streamId, streamName, req, streamToken, state, events, ct) = task {
             let timestamp = System.Diagnostics.Stopwatch.GetTimestamp() // NB take the timestamp before any potential write takes place
             let save struct (token, state) = cache.Save(createKey streamName, isStale, createOptions (), timestamp, token, state)
-            match! category.Sync(log, categoryName, streamId, streamName, context, streamToken, state, events, ct) with
+            match! category.Sync(log, categoryName, streamId, streamName, req, streamToken, state, events, ct) with
             | SyncResult.Written tokenAndState' ->
                 save tokenAndState'
                 return SyncResult.Written tokenAndState'

--- a/src/Equinox/Category.fs
+++ b/src/Equinox/Category.fs
@@ -45,8 +45,8 @@ type Category<'event, 'state, 'req>(categoryName, inner: Core.ICategory<'event, 
 [<AbstractClass; Sealed; System.Runtime.CompilerServices.Extension>]
 type Stream private () =
     [<System.Runtime.CompilerServices.Extension>]
-    static member Resolve(cat: Category<'event, 'state, 'req>, log, context): System.Func<FsCodec.StreamId, DeciderCore<'event, 'state>> =
-         System.Func<_, _>(fun sid -> cat.Stream(log, context, sid) |> DeciderCore<'event, 'state>)
+    static member Resolve(cat: Category<'event, 'state, 'req>, log, req): System.Func<FsCodec.StreamId, DeciderCore<'event, 'state>> =
+         System.Func<_, _>(fun sid -> cat.Stream(log, req, sid) |> DeciderCore<'event, 'state>)
     [<System.Runtime.CompilerServices.Extension>]
     static member Resolve(cat: Category<'event, 'state, unit>, log): System.Func<FsCodec.StreamId, DeciderCore<'event, 'state>> =
         Stream.Resolve(cat, log, ())

--- a/src/Equinox/Category.fs
+++ b/src/Equinox/Category.fs
@@ -52,7 +52,7 @@ type Stream private () =
         Stream.Resolve(cat, log, ())
 
 module Decider =
-    let forContext log (cat: Category<'event, 'state, 'req>) context streamId =
+    let forRequest log (cat: Category<'event, 'state, 'req>) context streamId =
         Stream.Resolve(cat, log, context).Invoke(streamId) |> Decider<'event, 'state>
     let forStream log (cat: Category<'event, 'state, unit>) streamId =
-        forContext log cat () streamId
+        forRequest log cat () streamId

--- a/src/Equinox/Category.fs
+++ b/src/Equinox/Category.fs
@@ -2,7 +2,7 @@
 namespace Equinox.Core
 
 /// Store-agnostic interface representing interactions a Decider can have with a set of streams with a given pair of Event and State types
-type ICategory<'event, 'state, 'context> =
+type ICategory<'event, 'state, 'req> =
     /// Obtain a Null state for optimistic processing
     abstract Empty: struct (StreamToken * 'state)
     /// Obtain the state from the target stream
@@ -14,7 +14,7 @@ type ICategory<'event, 'state, 'context> =
     /// - Conflict: signifies the sync failed, and the proposed decision hence needs to be reconsidered in light of the supplied conflicting Stream State
     /// NB the central precondition upon which the sync is predicated is that the stream has not diverged from the `originState` represented by `token`
     ///    where the precondition is not met, the SyncResult.Conflict bears a [lazy] async result (in a specific manner optimal for the store)
-    abstract Sync: log: Serilog.ILogger * categoryName: string * streamId: string * streamName: string * 'context
+    abstract Sync: log: Serilog.ILogger * categoryName: string * streamId: string * streamName: string * 'req
                    * originToken: StreamToken * originState: 'state * events: 'event[]
                    * CancellationToken -> Task<SyncResult<'state>>
 
@@ -26,8 +26,8 @@ open Equinox.Core.Tracing
 /// Provides access to the low level store operations used for Loading and/or Syncing updates via the Decider
 /// (Normal usage is via the adjacent `module Decider` / `Stream.Resolve` helpers)
 [<NoComparison; NoEquality>]
-type Category<'event, 'state, 'context>(categoryName, inner: Core.ICategory<'event, 'state, 'context>) =
-    member _.Stream(log: Serilog.ILogger, context: 'context, streamId: FsCodec.StreamId) =
+type Category<'event, 'state, 'req>(categoryName, inner: Core.ICategory<'event, 'state, 'req>) =
+    member _.Stream(log: Serilog.ILogger, req: 'req, streamId: FsCodec.StreamId) =
         let streamName = FsCodec.StreamName.create categoryName streamId |> FsCodec.StreamName.toString
         let streamId = FsCodec.StreamId.toString streamId
         { new Core.IStream<'event, 'state> with
@@ -40,19 +40,19 @@ type Category<'event, 'state, 'context>(categoryName, inner: Core.ICategory<'eve
                 use act = source.StartActivity("Sync", System.Diagnostics.ActivityKind.Client)
                 if act <> null then act.AddStream(categoryName, streamId, streamName).AddSyncAttempt(attempt) |> ignore
                 let log = if attempt = 1 then log else log.ForContext("attempts", attempt)
-                return! inner.Sync(log, categoryName, streamId, streamName, context, token, originState, events, ct) } }
+                return! inner.Sync(log, categoryName, streamId, streamName, req, token, originState, events, ct) } }
 
 [<AbstractClass; Sealed; System.Runtime.CompilerServices.Extension>]
 type Stream private () =
     [<System.Runtime.CompilerServices.Extension>]
-    static member Resolve(cat: Category<'event, 'state, 'context>, log, context): System.Func<FsCodec.StreamId, DeciderCore<'event, 'state>> =
+    static member Resolve(cat: Category<'event, 'state, 'req>, log, context): System.Func<FsCodec.StreamId, DeciderCore<'event, 'state>> =
          System.Func<_, _>(fun sid -> cat.Stream(log, context, sid) |> DeciderCore<'event, 'state>)
     [<System.Runtime.CompilerServices.Extension>]
     static member Resolve(cat: Category<'event, 'state, unit>, log): System.Func<FsCodec.StreamId, DeciderCore<'event, 'state>> =
         Stream.Resolve(cat, log, ())
 
 module Decider =
-    let forContext log (cat: Category<'event, 'state, 'context>) context streamId =
+    let forContext log (cat: Category<'event, 'state, 'req>) context streamId =
         Stream.Resolve(cat, log, context).Invoke(streamId) |> Decider<'event, 'state>
     let forStream log (cat: Category<'event, 'state, unit>) streamId =
         forContext log cat () streamId

--- a/tests/Equinox.EventStoreDb.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStoreDb.Integration/StoreIntegration.fs
@@ -17,7 +17,7 @@ let connectToLocalStore (_: Serilog.ILogger) =
     Connector("Host=localhost;Username=postgres;password=postgres;database=postgres",autoCreate=true).Establish()
 
 type Context = SqlStreamStoreContext
-type Category<'event, 'state, 'context> = SqlStreamStoreCategory<'event, 'state, 'context>
+type Category<'event, 'state, 'req> = SqlStreamStoreCategory<'event, 'state, 'req>
 #endif
 #if STORE_MSSQL
 open Equinox.SqlStreamStore
@@ -27,7 +27,7 @@ let connectToLocalStore (_: Serilog.ILogger) =
     Connector("Server=localhost,1433;User=sa;Password=mssql1Ipw;Database=EQUINOX_TEST_DB", autoCreate = true).Establish()
 
 type Context = SqlStreamStoreContext
-type Category<'event, 'state, 'context> = SqlStreamStoreCategory<'event, 'state, 'context>
+type Category<'event, 'state, 'req> = SqlStreamStoreCategory<'event, 'state, 'req>
 #endif
 #if STORE_MYSQL
 open Equinox.SqlStreamStore
@@ -37,7 +37,7 @@ let connectToLocalStore (_: Serilog.ILogger) =
     Connector("Server=localhost;User=root;Database=EQUINOX_TEST_DB", autoCreate = true).Establish()
 
 type Context = SqlStreamStoreContext
-type Category<'event, 'state, 'context> = SqlStreamStoreCategory<'event, 'state, 'context>
+type Category<'event, 'state, 'req> = SqlStreamStoreCategory<'event, 'state, 'req>
 #endif
 #if STORE_MESSAGEDB
 open Equinox.MessageDb
@@ -50,7 +50,7 @@ let connectToLocalStore _ = async {
   return MessageDbClient(connectionString)
 }
 type Context = MessageDbContext
-type Category<'event, 'state, 'context> = MessageDbCategory<'event, 'state, 'context>
+type Category<'event, 'state, 'req> = MessageDbCategory<'event, 'state, 'req>
 #endif
 #if STORE_EVENTSTOREDB
 open Equinox.EventStoreDb
@@ -79,7 +79,7 @@ let connectToLocalStore log =
 #endif
 #if STORE_EVENTSTORE_LEGACY || STORE_EVENTSTOREDB
 type Context = EventStoreContext
-type Category<'event, 'state, 'context> = EventStoreCategory<'event, 'state, 'context>
+type Category<'event, 'state, 'req> = EventStoreCategory<'event, 'state, 'req>
 #endif
 
 let createContext connection batchSize = Context(connection, batchSize = batchSize)

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -291,12 +291,12 @@ let resetStats () =
     let _ = Equinox.SqlStreamStore.Log.InternalMetrics.Stats.LogSink.Restart() in ()
 
 let dumpStats log = function
-    | Store.Context.Cosmos _ -> Equinox.CosmosStore.Core.Log.InternalMetrics.dump log
-    | Store.Context.Dynamo _ -> Equinox.DynamoStore.Core.Log.InternalMetrics.dump log
-    | Store.Context.Es _ ->     Equinox.EventStoreDb.Log.InternalMetrics.dump log
-    | Store.Context.Sql _ ->    Equinox.SqlStreamStore.Log.InternalMetrics.dump log
-    | Store.Context.Mdb _ ->    Equinox.MessageDb.Log.InternalMetrics.dump log
-    | Store.Context.Memory _ -> ()
+    | Store.Config.Cosmos _ -> Equinox.CosmosStore.Core.Log.InternalMetrics.dump log
+    | Store.Config.Dynamo _ -> Equinox.DynamoStore.Core.Log.InternalMetrics.dump log
+    | Store.Config.Es _ ->     Equinox.EventStoreDb.Log.InternalMetrics.dump log
+    | Store.Config.Sql _ ->    Equinox.SqlStreamStore.Log.InternalMetrics.dump log
+    | Store.Config.Mdb _ ->    Equinox.MessageDb.Log.InternalMetrics.dump log
+    | Store.Config.Memory _ -> ()
 
 module LoadTest =
 
@@ -321,7 +321,7 @@ module LoadTest =
     let run (log : ILogger) (verbose, verboseConsole, maybeSeq) reportFilename (p : ParseResults<TestParameters>) =
         let createStoreLog storeVerbose = createStoreLog storeVerbose verboseConsole maybeSeq
         let a = TestArguments p
-        let storeLog, storeConfig, httpClient: ILogger * Store.Context option * HttpClient option =
+        let storeLog, storeConfig, httpClient: ILogger * Store.Config option * HttpClient option =
             match p.TryGetSubCommand() with
             | Some (Web p) ->
                 let uri = p.GetResult(WebParameters.Endpoint,"https://localhost:5001") |> Uri


### PR DESCRIPTION
Resolves #423
- `'context` -> `'req`
- 'Decider.forContext` -> `forRequest`
- `Store.Context` -> `Store.Config`