### PR TITLE
refactor(Cosmos)!: Cleanup CosmosClientFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `CosmosStore`: Only log `bytes` when log level is `Debug` [#305](https://github.com/jet/equinox/pull/305)
 - `CosmosStore.AccessStrategy.MultiSnapshot`,`Custom`: Change `list` and `seq` types to `array` [#338](https://github.com/jet/equinox/pull/338)
 - `CosmosStore.Core.Initialization.initAux`: Replace hard-coded manual 400 RU with `mode` parameter [#328](https://github.com/jet/equinox/pull/328) :pray: [@brihadish](https://github.com/brihadish)
+- `CosmosStore.CosmosClientFactory`: Moved to Core [#430](https://github.com/jet/equinox/pull/430)
 - `EventStore`: Target `EventStore.Client` v `22.0.0-preview`; rename `Connector` -> `EventStoreConnector` [#317](https://github.com/jet/equinox/pull/317)
 - `Tool`/`samples/`: switched to use `Equinox.EventStoreDb` [#196](https://github.com/jet/equinox/pull/196)
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1840,7 +1840,6 @@ following key benefits:
 ### Example Code
 
 ```fsharp
-
 open Equinox.CosmosStore.Core
 // open MyCodecs.Json // example of using specific codec which can yield UTF-8
                       // byte arrays from a type using `Json.toBytes` via Fleece
@@ -1852,22 +1851,20 @@ type EventData with
 
 // Load connection string from your Key Vault (example here is the CosmosDB
 // simulator's well known key)
-// see https://github.com/jet/equinox-provisioning-cosmosdb
+// see https://github.com/jet/equinox#provisioning-cosmosdb
 let connectionString: string =
     "AccountEndpoint=https://localhost:8081;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==;"
 
-// Forward to Log (you can use `Log.Logger` and/or `Log.ForContext` if your app
-// uses Serilog already)
-let outputLog = LoggerConfiguration().WriteTo.NLog().CreateLogger()
+// Forward to Log (use `Log.Logger` if your app already uses Serilog)
+let outputLog = LoggerConfiguration().WriteTo.Console().CreateLogger()
 // Serilog has a `ForContext<T>()`, but if you are using a `module` for the
 // wiring, you might create a tagged logger like this:
 let gatewayLog =
     outputLog.ForContext(Serilog.Core.Constants.SourceContextPropertyName, "Equinox")
 
-let discovery = Discovery.ConnectionString (read "EQUINOX_COSMOS_CONNECTION")
 let connector: Equinox.CosmosStore.CosmosStoreConnector =
     CosmosStoreConnector(
-        discovery,
+        Equinox.CosmosStore.Discovery.ConnectionString connectionString,
         requestTimeout = TimeSpan.FromSeconds 5.,
         maxRetryAttemptsOnRateLimitedRequests = 1,
         maxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds 3.)

--- a/README.md
+++ b/README.md
@@ -665,12 +665,14 @@ For more complete instructions, follow https://developers.eventstore.com/server/
 
 #### Using Azure Cosmos DB Service
 
-    dotnet run --project tools/Equinox.Tool -- init -ru 400 `
-        cosmos -s $env:EQUINOX_COSMOS_CONNECTION -d $env:EQUINOX_COSMOS_DATABASE -c $env:EQUINOX_COSMOS_CONTAINER
-    # Same for a Archive Container for integration testing of the archive store fallback mechanism
-    $env:EQUINOX_COSMOS_CONTAINER_ARCHIVE="equinox-test-archive"
-    dotnet run --project tools/Equinox.Tool -- init -ru 400 `
-        cosmos -s $env:EQUINOX_COSMOS_CONNECTION -d $env:EQUINOX_COSMOS_DATABASE -c $env:EQUINOX_COSMOS_CONTAINER_ARCHIVE
+```bash
+dotnet run --project tools/Equinox.Tool -- init -ru 400 `
+    cosmos -s $env:EQUINOX_COSMOS_CONNECTION -d $env:EQUINOX_COSMOS_DATABASE -c $env:EQUINOX_COSMOS_CONTAINER
+# Same for a Archive Container for integration testing of the archive store fallback mechanism
+$env:EQUINOX_COSMOS_CONTAINER_ARCHIVE="equinox-test-archive"
+dotnet run --project tools/Equinox.Tool -- init -ru 400 `
+    cosmos -s $env:EQUINOX_COSMOS_CONNECTION -d $env:EQUINOX_COSMOS_DATABASE -c $env:EQUINOX_COSMOS_CONTAINER_ARCHIVE
+```
 
 #### Using Cosmos Emulator on an Intel Mac 
 
@@ -678,8 +680,10 @@ NOTE There's [no Apple Silicon emulator available as yet](https://github.com/Azu
 
 NOTE Have not tested with the Windows Emulator, but it should work with analogous steps.
 
-    docker compose up equinox-cosmos -d
-    bash docker-compose-cosmos.sh
+```bash
+docker compose up equinox-cosmos -d
+bash docker-compose-cosmos.sh
+```
 
 ### Provisioning SqlStreamStore
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - AZURE_COSMOS_EMULATOR_IP_ADDRESS_OVERRIDE=127.0.0.1
     ports:
       - "8081:8081" # so docker-cosmos-init.sh can get the cert and/or humans can use https://localhost:8081/_explorer/index.html
-      - "10250-10256:10250-10256" # tests connect using Direct mode
+      - "10250-10255:10250-10255" # tests connect using Direct mode
 
   equinox-mssql:
     container_name: equinox-mssql

--- a/tests/Equinox.CosmosStore.Integration/CosmosFixtures.fs
+++ b/tests/Equinox.CosmosStore.Integration/CosmosFixtures.fs
@@ -80,7 +80,7 @@ let private databaseId = tryRead "EQUINOX_COSMOS_DATABASE" |> Option.defaultValu
 let private containerId = tryRead "EQUINOX_COSMOS_CONTAINER" |> Option.defaultValue "equinox-test"
 let private archiveContainerId = tryRead "EQUINOX_COSMOS_CONTAINER_ARCHIVE" |> Option.defaultValue "equinox-test-archive"
 
-// see https://github.com/jet/equinox-provisioning-cosmosdb for details of what's expected in terms of provisioned containers etc
+// see https://github.com/jet/equinox#provisioning-cosmosdb for details of what's expected in terms of provisioned containers etc
 let discoverConnection () =
     match tryRead "EQUINOX_COSMOS_CONNECTION" with
     | None -> "localDocDbSim", Discovery.AccountUriAndKey(Uri "https://localhost:8081", "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==")
@@ -90,7 +90,7 @@ let createConnector (log: Serilog.ILogger) =
     let name, discovery = discoverConnection ()
     let connector = CosmosStoreConnector(discovery, requestTimeout = TimeSpan.FromSeconds 3.,
                                          maxRetryAttemptsOnRateLimitedRequests = 2, maxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromMinutes 1.)
-    log.Information("CosmosStore {name} {endpoint}", name, discovery.Endpoint)
+    log.Information("CosmosStore {name} {endpoint}", name, connector.Endpoint)
     connector
 
 [<Xunit.CollectionDefinition "DocStore">]

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -384,13 +384,13 @@ module CosmosInit =
             match a.ProvisioningMode with
             | CosmosInit.Provisioning.Container throughput ->
                 let modeStr = "Container"
-                log.Information("Provisioning `Equinox.CosmosStore` Store at {mode:l} level for {rus:n0} RU/s", modeStr, throughput)
+                log.Information("CosmosStore provisioning at {mode:l} level for {rus:n0} RU/s", modeStr, throughput)
             | CosmosInit.Provisioning.Database throughput ->
                 let modeStr = "Database"
-                log.Information("Provisioning `Equinox.CosmosStore` Store at {mode:l} level for {rus:n0} RU/s", modeStr, throughput)
+                log.Information("CosmosStore provisioning at {mode:l} level for {rus:n0} RU/s", modeStr, throughput)
             | CosmosInit.Provisioning.Serverless ->
                 let modeStr = "Serverless"
-                log.Information("Provisioning `Equinox.CosmosStore` Store in {mode:l} mode with automatic RU/s as configured in account", modeStr)
+                log.Information("CosmosStore provisioning in {mode:l} mode with automatic RU/s as configured in account", modeStr)
             CosmosInit.init log (connector.CreateUninitialized()) (dName, cName) a.ProvisioningMode a.SkipStoredProc
         | x -> Store.missingArg $"unexpected subcommand %A{x}"
 


### PR DESCRIPTION
`CosmosClientFactory` was hidden in `3.0.1` - this moves it to `Core` and removes a lot of redundancy

Prepares for a future implementation of [`TrustLocalEmulator=true` connection string value](#431 )