### PR TITLE
refactor(Cosmos): SyncExp

### DIFF
--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -124,19 +124,18 @@ type Tip = // TODO for STJ v5: All fields required unless explicitly optional
 [<NoComparison; NoEquality>]
 type Position = { index: int64; etag: string option }
 module internal Position =
-    /// NB very inefficient compared to FromDocument or using one already returned to you
+    /// NB very inefficient compared to FromEtagAndNext or using one already returned to you
     let fromI (i: int64) = { index = i; etag = None }
     /// If we have strong reason to suspect a stream is empty, we won't have an etag (and Writer Stored Procedure special cases this)
     let fromKnownEmpty = fromI 0L
-    /// Just Do It mode
-    let fromAppendAtEnd = fromI -1L // sic - needs to yield -1
-    let fromEtag (value: string) = { fromI -2L with etag = Some value }
-    /// Create Position from Tip record context (facilitating 1 RU reads)
-    let fromTip (x: Tip) = { index = x.n; etag = match x._etag with null -> None | x -> Some x }
+    /// Blind append mode
+    let fromAppendAtEnd = fromI -1L // sic - needs to yield value -1 to trigger stored proc logic
+    let fromEtagOnly (value: string) = { index = -2; etag = Some value }
+    let fromEtagAndNext (etag, n) = { index = n; etag = Some etag }
     /// If we encounter the tip (id=-1) item/document, we're interested in its etag so we can re-sync for 1 RU
     let tryFromBatch (x: Batch) =
         if x.id <> Tip.WellKnownDocumentId then None
-        else Some { index = x.n; etag = match x._etag with null -> None | x -> Some x }
+        else Some { index = x.n; etag = Option.ofObj x._etag }
 
 [<RequireQualifiedAccess>]
 type Direction = Forward | Backward override this.ToString() = match this with Forward -> "Forward" | Backward -> "Backward"
@@ -439,7 +438,15 @@ function sync(req, expIndex, expEtag, maxEventsInTip, maxStringifyLen) {
 }"""
 
 [<RequireQualifiedAccess>]
-type internal SyncExp = Version of int64 | Etag of string | Any
+type internal SyncExp private = Version of int64 | Etag of string | Any
+module internal SyncExp =
+    let fromVersion i =
+        if i < 0L then raise <| ArgumentOutOfRangeException(nameof i, i, "must be >= 0")
+        SyncExp.Version i
+    let fromVersionOrMagicAny = function -1L -> SyncExp.Any | i -> fromVersion i
+    let fromEtag etag =
+        if isNull etag then invalidArg (nameof etag) "must be non-null"
+        SyncExp.Etag etag
 
 module internal Sync =
 
@@ -455,7 +462,7 @@ module internal Sync =
         let ep =
             match exp with
             | SyncExp.Version ev -> Position.fromI ev
-            | SyncExp.Etag et -> Position.fromEtag et
+            | SyncExp.Etag et -> Position.fromEtagOnly et
             | SyncExp.Any -> Position.fromAppendAtEnd
         let args = [| box req; box ep.index; box (Option.toObj ep.etag); box maxEventsInTip; box maxStringifyLen |]
         let! (res: Scripts.StoredProcedureExecuteResponse<SyncResponse>) =
@@ -615,7 +622,18 @@ module internal Tip =
         | ReadResult.NotFound -> return Result.NotFound
         | ReadResult.Found tip ->
             let minIndex = maybePos |> Option.map (fun x -> x.index)
-            return Result.Found (Position.fromTip tip, tip.i, Enum.EventsAndUnfolds(tip, ?maxIndex = maxIndex, ?minIndex = minIndex) |> Array.ofSeq) }
+            return Result.Found (Position.fromEtagAndNext (tip._etag, tip.n), tip.i, Enum.EventsAndUnfolds(tip, ?maxIndex = maxIndex, ?minIndex = minIndex) |> Array.ofSeq) }
+    let tryFindOrigin (tryDecode: ITimelineEvent<EventBody> -> 'event voption, isOrigin: 'event -> bool) xs =
+        let stack = ResizeArray()
+        let isOrigin' (u: ITimelineEvent<EventBody>) =
+            match tryDecode u with
+            | ValueNone -> false
+            | ValueSome e ->
+                stack.Insert(0, e) // WalkResult always renders events ordered correctly - here we're aiming to align with Enum.EventsAndUnfolds
+                isOrigin e
+        match xs |> Seq.tryFindBack isOrigin' with
+        | Some x -> ValueSome (x, stack.ToArray())
+        | None -> ValueNone
 
 module internal Query =
 
@@ -695,16 +713,11 @@ module internal Query =
     [<RequireQualifiedAccess; NoComparison; NoEquality>]
     type ScanResult<'event> = { found: bool; minIndex: int64; next: int64; maybeTipPos: Position option; events: 'event[] }
 
-    let scanTip (tryDecode: #IEventData<EventBody> -> 'event voption, isOrigin: 'event -> bool) (pos: Position, i: int64, xs: #ITimelineEvent<EventBody>[]): ScanResult<'event> =
-        let items = ResizeArray()
-        let isOrigin' e =
-            match tryDecode e with
-            | ValueNone -> false
-            | ValueSome e ->
-                items.Insert(0, e) // WalkResult always renders events ordered correctly - here we're aiming to align with Enum.EventsAndUnfolds
-                isOrigin e
-        let f, e = xs |> Seq.tryFindBack isOrigin' |> Option.isSome, items.ToArray()
-        { found = f; maybeTipPos = Some pos; minIndex = i; next = pos.index + 1L; events = e }
+    let scanTip (tryDecode, isOrigin) (pos: Position, i: int64, xs: #ITimelineEvent<EventBody>[]): ScanResult<'event> =
+        let ok, e = xs |> Tip.tryFindOrigin (tryDecode, isOrigin) |> function
+            | ValueSome (_, events) -> true, events
+            | ValueNone -> false, Array.empty
+        { found = ok; maybeTipPos = Some pos; minIndex = i; next = pos.index + 1L; events = e }
 
     // Yields events in ascending Index order
     let scan<'event> (log: ILogger) (container, stream) includeTip (maxItems: int) maxRequests direction
@@ -1083,10 +1096,10 @@ type internal StoreCategory<'event, 'state, 'req>
                 let encode e = codec.Encode(req, e)
                 let encodeU e = (if shouldCompress.Invoke e then JsonElement.undefinedToNull >> JsonElement.deflate else JsonElement.undefinedToNull), encode e
                 match mapUnfolds with
-                | Choice1Of3 () ->        SyncExp.Version pos.index, events, Array.map encode events, Seq.empty
-                | Choice2Of3 unfold ->    SyncExp.Version pos.index, events, Array.map encode events, Seq.map encodeU (unfold events state')
+                | Choice1Of3 () ->        SyncExp.fromVersion pos.index, events, Array.map encode events, Seq.empty
+                | Choice2Of3 unfold ->    SyncExp.fromVersion pos.index, events, Array.map encode events, Seq.map encodeU (unfold events state')
                 | Choice3Of3 transmute -> let events', unfolds = transmute events state'
-                                          SyncExp.Etag (defaultArg pos.etag null), events', Array.map encode events', Seq.map encodeU unfolds
+                                          SyncExp.fromEtag (defaultArg pos.etag null), events', Array.map encode events', Seq.map encodeU unfolds
             let baseIndex = pos.index + int64 (Array.length events)
             let projections = projectionsEncoded |> Seq.map (Sync.mkUnfold baseIndex) |> Array.ofSeq
             let batch = Sync.mkBatch streamName eventsEncoded projections
@@ -1304,8 +1317,8 @@ type AccessStrategy<'event, 'state> =
     /// </remarks>
     | Custom of isOrigin: ('event -> bool) * transmute: ('event[] -> 'state -> 'event[] * 'event[])
 
-type CosmosStoreCategory<'event, 'state, 'req> =
-    inherit Equinox.Category<'event, 'state, 'req>
+type CosmosStoreCategory<'event, 'state, 'req> private (name, inner) =
+    inherit Equinox.Category<'event, 'state, 'req>(name, inner)
     new(context: CosmosStoreContext, name, codec, fold, initial, access,
         // For CosmosDB, caching is typically a central aspect of managing RU consumption to maintain performance and capacity.
         // The cache holds the Tip document's etag, which enables use of etag-contingent Reads (which cost only 1RU in the case where the document is unchanged)
@@ -1328,9 +1341,8 @@ type CosmosStoreCategory<'event, 'state, 'req> =
             | AccessStrategy.MultiSnapshot (isOrigin, unfold) -> isOrigin,         true,  Choice2Of3 (fun _ -> unfold)
             | AccessStrategy.RollingState toSnapshot ->          (fun _ -> true),  true,  Choice3Of3 (fun _ state  -> Array.empty, toSnapshot state |> Array.singleton)
             | AccessStrategy.Custom (isOrigin, transmute) ->     isOrigin,         true,  Choice3Of3 transmute
-        { inherit Equinox.Category<'event, 'state, 'req>(name,
-            StoreCategory<'event, 'state, 'req>(context.StoreClient, context.EnsureStoredProcedureInitialized, codec, fold, initial, isOrigin, checkUnfolds, shouldCompress, mapUnfolds)
-            |> Caching.apply Token.isStale caching) }
+        let sc = StoreCategory<'event, 'state, 'req>(context.StoreClient, context.EnsureStoredProcedureInitialized, codec, fold, initial, isOrigin, checkUnfolds, shouldCompress, mapUnfolds)
+        CosmosStoreCategory<'event, 'state, 'req>(name, sc |> Caching.apply Token.isStale caching)
 
 module Exceptions =
 
@@ -1424,7 +1436,7 @@ type EventsContext
         do! context.EnsureStoredProcedureInitialized ct
         let store, stream = resolve streamName
         let batch = Sync.mkBatch stream events Array.empty
-        match! store.Sync(log, stream, SyncExp.Version position.index, batch, ct) with
+        match! store.Sync(log, stream, SyncExp.fromVersionOrMagicAny position.index, batch, ct) with
         | InternalSyncResult.Written (Token.Unpack pos) -> return AppendResult.Ok pos
         | InternalSyncResult.Conflict (pos, events) -> return AppendResult.Conflict (pos, events)
         | InternalSyncResult.ConflictUnknown (Token.Unpack pos) -> return AppendResult.ConflictUnknown pos }

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -531,9 +531,7 @@ module Dump =
                 else log.Information("{i,4}@{t:u}+{d,9} Corr {corr} Cause {cause} {u:l} {e:l} {data:l} {meta:l}",
                          x.Index, x.Timestamp, interval, x.CorrelationId, x.CausationId, ty, x.EventType, render x.Data, render x.Meta)
             match streamBytes with ValueNone -> () | ValueSome x -> log.Information("ISyncContext.StreamEventBytes {kib:n1}KiB", float x / 1024.) }
-
         resetStats ()
-
         let streams = p.GetResults DumpParameters.Stream
         log.ForContext("streams",streams).Information("Reading...")
         streams


### PR DESCRIPTION
Preparatory refactoring in advance of #434
- `FromI` was always badly named
- `SyncExp` came later; there's definitely room to do more but the main goal here is to do 434 without inducing risk