### PR TITLE
docs: Remove Command/Handler

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -316,7 +316,7 @@ highly recommended to use the following canonical skeleton layout:
 module Aggregate
 
 module private Stream =
-    let [<Literal>] Category = "category"
+    let [<Literal>] CategoryName = "category"
     let id = FsCodec.StreamId.gen Id.toString
 
 (* Optionally (rarely) Helpers/Types *)
@@ -342,18 +342,6 @@ Some notes about the intents being satisfied here:
   sibling code in adjacent `module`s should not be using them directly (in
   general interaction should be via the `type Service`)
 
-✅ DO keep `module Stream` visibility `private`, present via `module Reactions`
-
-If the composition of stream names is relevant for Reactions processing, expose relevant helpers in a `module Reactions` facade.
-For instance, rather than having external reaction logic refer to `Aggregate.Stream.Category`, expose a facade such as:
-
-```fsharp
-module Reactions =
-
-    let streamName = Stream.name
-    let deletionNamePrefix tenantIdStr = $"%s{Stream.Category}-%s{tenantIdStr}"
-```
-
 ✅ DO use tupled arguments for the `Stream.id` function
 
 All the inputs of which the `StreamId` is composed should be represented as one argument:
@@ -367,13 +355,13 @@ All the inputs of which the `StreamId` is composed should be represented as one 
 ✅ DO keep `module Stream` visibility `private`, present via `module Reactions`
 
 If the composition of stream names is relevant for Reactions processing, expose relevant helpers in a `module Reactions` facade.
-For instance, rather than having external reaction logic refer to `Aggregate.Stream.Category`, expose a facade such as:
+For instance, rather than having external reaction logic refer to `Aggregate.Stream.CategoryName`, expose a facade such as:
 
 ```fsharp
 module Reactions =
 
     let streamName = Stream.name
-    let deletionNamePrefix tenantIdStr = $"%s{Stream.Category}-%s{tenantIdStr}"
+    let deletionNamePrefix tenantIdStr = $"%s{Stream.CategoryName}-%s{tenantIdStr}"
     let [<return: Struct>] (|For|_|) = Stream.tryDecode
     let [<return: Struct>] (|Decode|_|) = function
         | struct (For id, _) & Streams.Decode dec events -> ValueSome struct (id, events)
@@ -477,12 +465,12 @@ let cacheStrategy cache = Equinox.CosmosStore.CachingStrategy.SlidingWindow (cac
 module EventStore =
     let accessStrategy = Equinox.EventStoreDb.AccessStrategy.RollingSnapshots Fold.Snapshot.config
     let category (context, cache) =
-        Equinox.EventStore.EventStoreCategory(context, Stream.Category, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy cache)
+        Equinox.EventStore.EventStoreCategory(context, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy cache)
 
 module Cosmos =
     let accessStrategy = Equinox.CosmosStore.AccessStrategy.Snapshot Fold.Snapshot.config
     let category (context, cache) =
-        Equinox.CosmosStore.CosmosStoreCategory(context, Stream.Category, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy cache)
+        Equinox.CosmosStore.CosmosStoreCategory(context, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy cache)
 ```
 
 ### `MemoryStore` Storage Binding Module
@@ -494,7 +482,7 @@ can use the `MemoryStore` in the context of your tests:
 ```fsharp
 module MemoryStore =
     let category (store: Equinox.MemoryStore.VolatileStore) =
-        Equinox.MemoryStore.MemoryStoreCategory(store, Stream.Category, Events.codec, Fold.fold, Fold.initial)
+        Equinox.MemoryStore.MemoryStoreCategory(store, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial)
 ```
 
 Typically that binding module can live with your test helpers rather than
@@ -506,7 +494,7 @@ In F#, independent of the Store being used, the Equinox programming model
 involves (largely by convention, see [FAQ](README.md#FAQ)), per aggregation of
 events on a given category of stream:
 
-- `Stream.Category`: the common part of the [Stream Name](https://github.com/fscodec#streamname),
+- `Stream.CategoryName`: the common part of the [Stream Name](https://github.com/fscodec#streamname),
   i.e., the `"Favorites"` part of the `"Favorites-clientId"`
 
 - `Stream.id`: function responsible for mapping from the input elements that define the Aggregate's identity
@@ -604,7 +592,7 @@ brevity, that implements all the relevant functions above:
 (* Event stream naming + schemas *)
 
 module Stream =
-    let [<Literal>] Category = "Favorites"
+    let [<Literal>] CategoryName = "Favorites"
     let id = FsCodec.StreamId.gen ClientId.toString
 
 type Item = { id: int; name: string; added: DateTimeOffset }
@@ -878,7 +866,7 @@ context
 
 ```fsharp
 module Stream =
-    let [<Literal>] Category = "Favorites"
+    let [<Literal>] CategoryName = "Favorites"
     let id = FsCodec.StreamId.gen ClientId.toString
 
 type Service internal (resolve: ClientId -> Equinox.Decider<Events.Event, Fold.State>) =

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -965,14 +965,6 @@ result in you ending up with a model that's potentially both:
   facilitates testing independently with `MemoryStore` (which does necessitate a
   reference to a separate Assembly] as desired. 
 
-### Favorites (without Commands)
-
-TODO explain how life is simpler based on current code without commands (and how you can still use
-a DU to represent the cases in a property based tests)
-
-Potentially this can be done as a compare and contrast with the preceding section (though having
-a `query` and an `execute` is really an anti-pattern)
-
 ### Todo[Backend] walkthrough
 
 See [the TodoBackend.com sample](README.md#TodoBackend) for reference info

--- a/samples/Infrastructure/Services.fs
+++ b/samples/Infrastructure/Services.fs
@@ -37,21 +37,21 @@ type ServiceBuilder(storageConfig, storeLog) =
      member _.CreateFavoritesService() =
         let fold, initial = Favorites.Fold.fold, Favorites.Fold.initial
         let snapshot = Favorites.Fold.Snapshot.config
-        store.Category(Favorites.Stream.Category, Favorites.Events.codec, fold, initial, snapshot)
+        store.Category(Favorites.Stream.CategoryName, Favorites.Events.codec, fold, initial, snapshot)
         |> Decider.forStream storeLog
         |> Favorites.create
 
      member _.CreateSaveForLaterService() =
         let fold, initial = SavedForLater.Fold.fold, SavedForLater.Fold.initial
         let snapshot = SavedForLater.Fold.Snapshot.config
-        store.Category(SavedForLater.Stream.Category, SavedForLater.Events.codec, fold, initial, snapshot)
+        store.Category(SavedForLater.Stream.CategoryName, SavedForLater.Events.codec, fold, initial, snapshot)
         |> Decider.forStream storeLog
         |> SavedForLater.create 50
 
      member _.CreateTodosService() =
         let fold, initial = TodoBackend.Fold.fold, TodoBackend.Fold.initial
         let snapshot = TodoBackend.Fold.Snapshot.config
-        store.Category(TodoBackend.Stream.Category, TodoBackend.Events.codec, fold, initial, snapshot)
+        store.Category(TodoBackend.Stream.CategoryName, TodoBackend.Events.codec, fold, initial, snapshot)
         |> Decider.forStream storeLog
         |> TodoBackend.create
 

--- a/samples/Infrastructure/Services.fs
+++ b/samples/Infrastructure/Services.fs
@@ -31,34 +31,34 @@ type Store(store) =
         | Store.Config.Mdb (context, caching) ->
             MessageDb.MessageDbCategory<'event,'state,_>(context, name, codec, fold, initial, MessageDb.AccessStrategy.Unoptimized, caching)
 
-type ServiceBuilder(storageConfig, handlerLog) =
+type ServiceBuilder(storageConfig, storeLog) =
      let store = Store storageConfig
 
      member _.CreateFavoritesService() =
         let fold, initial = Favorites.Fold.fold, Favorites.Fold.initial
         let snapshot = Favorites.Fold.Snapshot.config
         store.Category(Favorites.Stream.Category, Favorites.Events.codec, fold, initial, snapshot)
-        |> Decider.forStream handlerLog
+        |> Decider.forStream storeLog
         |> Favorites.create
 
      member _.CreateSaveForLaterService() =
         let fold, initial = SavedForLater.Fold.fold, SavedForLater.Fold.initial
         let snapshot = SavedForLater.Fold.Snapshot.config
         store.Category(SavedForLater.Stream.Category, SavedForLater.Events.codec, fold, initial, snapshot)
-        |> Decider.forStream handlerLog
+        |> Decider.forStream storeLog
         |> SavedForLater.create 50
 
      member _.CreateTodosService() =
         let fold, initial = TodoBackend.Fold.fold, TodoBackend.Fold.initial
         let snapshot = TodoBackend.Fold.Snapshot.config
         store.Category(TodoBackend.Stream.Category, TodoBackend.Events.codec, fold, initial, snapshot)
-        |> Decider.forStream handlerLog
+        |> Decider.forStream storeLog
         |> TodoBackend.create
 
-let register (services : IServiceCollection, storageConfig, handlerLog) =
+let register (services : IServiceCollection, storageConfig, storeLog) =
     let regF (factory : IServiceProvider -> 'T) = services.AddSingleton<'T>(fun (sp: IServiceProvider) -> factory sp) |> ignore
 
-    regF <| fun _sp -> ServiceBuilder(storageConfig, handlerLog)
+    regF <| fun _sp -> ServiceBuilder(storageConfig, storeLog)
 
     regF <| fun sp -> sp.GetService<ServiceBuilder>().CreateFavoritesService()
     regF <| fun sp -> sp.GetService<ServiceBuilder>().CreateSaveForLaterService()

--- a/samples/Infrastructure/Services.fs
+++ b/samples/Infrastructure/Services.fs
@@ -37,21 +37,21 @@ type ServiceBuilder(storageConfig, storeLog) =
      member _.CreateFavoritesService() =
         let fold, initial = Favorites.Fold.fold, Favorites.Fold.initial
         let snapshot = Favorites.Fold.Snapshot.config
-        store.Category(Favorites.Stream.CategoryName, Favorites.Events.codec, fold, initial, snapshot)
+        store.Category(Favorites.CategoryName, Favorites.Events.codec, fold, initial, snapshot)
         |> Decider.forStream storeLog
         |> Favorites.create
 
      member _.CreateSaveForLaterService() =
         let fold, initial = SavedForLater.Fold.fold, SavedForLater.Fold.initial
         let snapshot = SavedForLater.Fold.Snapshot.config
-        store.Category(SavedForLater.Stream.CategoryName, SavedForLater.Events.codec, fold, initial, snapshot)
+        store.Category(SavedForLater.CategoryName, SavedForLater.Events.codec, fold, initial, snapshot)
         |> Decider.forStream storeLog
         |> SavedForLater.create 50
 
      member _.CreateTodosService() =
         let fold, initial = TodoBackend.Fold.fold, TodoBackend.Fold.initial
         let snapshot = TodoBackend.Fold.Snapshot.config
-        store.Category(TodoBackend.Stream.CategoryName, TodoBackend.Events.codec, fold, initial, snapshot)
+        store.Category(TodoBackend.CategoryName, TodoBackend.Events.codec, fold, initial, snapshot)
         |> Decider.forStream storeLog
         |> TodoBackend.create
 

--- a/samples/Store/Domain.Tests/CartTests.fs
+++ b/samples/Store/Domain.Tests/CartTests.fs
@@ -18,9 +18,9 @@ type Command =
     | RemoveItem of Context * SkuId
 
 let interpret = function
-    | AddItem (c, s, q, w) ->   SyncItem (c, s, Some q, w)    |> interpret
-    | PatchItem (c, s, q, w) -> SyncItem (c, s, q, w)         |> interpret
-    | RemoveItem (c, s) ->      SyncItem (c, s, Some 0, None) |> interpret
+    | AddItem (c, s, q, w) ->   (c, s, Some q, w)    |> interpretSync
+    | PatchItem (c, s, q, w) -> (c, s, q, w)         |> interpretSync
+    | RemoveItem (c, s) ->      (c, s, Some 0, None) |> interpretSync
 
 /// As a basic sanity check, verify the basic properties we'd expect per command if we were to run it on an empty stream
 // Note validating basics like this is not normally that useful a property; in this instance (I think) it takes some

--- a/samples/Store/Domain.Tests/ContactPreferencesTests.fs
+++ b/samples/Store/Domain.Tests/ContactPreferencesTests.fs
@@ -6,41 +6,39 @@ open Domain.ContactPreferences.Fold
 open Swensen.Unquote
 
 /// Put the aggregate into the state where the command should trigger an event; verify correct events are yielded
-let verifyCorrectEventGenerationWhenAppropriate variant command (originState: State) =
+let verifyCorrectEventGenerationWhenAppropriate variant prefs (originState: State) =
     let initialEvents =
-        match command, variant with
+        match prefs, variant with
         // Variant 1: Initial state
-        | Update _, Choice1Of3 () -> []
+        | _, Choice1Of3 () -> []
         // Variant 2: Same state
-        | Update value, Choice2Of3 () -> [Updated value]
+        | value, Choice2Of3 () -> [Updated value]
         // Variant 2: Force something to change
-        | Update ({ preferences = { quickSurveys = qs } as preferences } as value), Choice3Of3 () ->
+        | ({ preferences = { quickSurveys = qs } as preferences } as value), Choice3Of3 () ->
             [Updated { value with preferences = { preferences with quickSurveys = not qs}}]
     let state = fold originState initialEvents
-    let events = interpret command state
+    let events = interpretUpdate prefs state
     let state' = fold state events
 
-    match command, events with
-    | Update cValue, [| Updated eValue |] ->
+    match prefs, events with
+    | cValue, [| Updated eValue |] ->
         test <@ eValue.preferences = cValue.preferences
                 && cValue.preferences = state' @>
-    | Update cValue, [||] ->
+    | cValue, [||] ->
         test <@ state = cValue.preferences
                 && state' = state @>
-    | c, e -> failwith $"Invalid result - Command %A{c} yielded Events %A{e} in State %A{state}"
+    | c, e -> failwith $"Invalid result - Update %A{c} yielded Events %A{e} in State %A{state}"
 
 /// Processing should allow for any given Command to be retried at will
-let verifyIdempotency (cmd: Command) (originState: State) =
+let verifyIdempotency prefs (originState: State) =
     // Put the aggregate into the state where the command should not trigger an event
-    let establish: Event list = cmd |> function
-        | Update value ->
-            [ Updated value]
+    let establish: Event list = [ Updated prefs]
     let state = fold originState establish
-    let events = interpret cmd state
+    let events = interpretUpdate prefs state
     // Assert we decided nothing needs to happen
     test <@ Array.isEmpty events @>
 
 [<DomainProperty(MaxTest = 1000)>]
-let ``interpret yields correct events, idempotently`` variant (command: Command) (originState: State) =
-    verifyCorrectEventGenerationWhenAppropriate variant command originState
-    verifyIdempotency command originState
+let ``interpret yields correct events, idempotently`` variant prefs (originState: State) =
+    verifyCorrectEventGenerationWhenAppropriate variant prefs originState
+    verifyIdempotency prefs originState

--- a/samples/Store/Domain/Cart.fs
+++ b/samples/Store/Domain/Cart.fs
@@ -1,9 +1,8 @@
 ﻿module Domain.Cart
 
-module Stream =
-    let [<Literal>] CategoryName = "Cart"
-    let id = FsCodec.StreamId.gen CartId.toString
-    let name = id >> FsCodec.StreamName.create CategoryName
+let [<Literal>] CategoryName = "Cart"
+let private streamId = FsCodec.StreamId.gen CartId.toString
+let streamName = streamId >> FsCodec.StreamName.create CategoryName
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 [<RequireQualifiedAccess>]
@@ -133,4 +132,4 @@ type Service internal (resolve: CartId -> Equinox.Decider<Events.Event, Fold.Sta
         decider.Query(id, Equinox.LoadOption.AnyCachedValue)
 
 let create resolve =
-    Service(Stream.id >> resolve)
+    Service(streamId >> resolve)

--- a/samples/Store/Domain/Cart.fs
+++ b/samples/Store/Domain/Cart.fs
@@ -1,9 +1,9 @@
 ﻿module Domain.Cart
 
 module Stream =
-    let [<Literal>] Category = "Cart"
+    let [<Literal>] CategoryName = "Cart"
     let id = FsCodec.StreamId.gen CartId.toString
-    let name = id >> FsCodec.StreamName.create Category
+    let name = id >> FsCodec.StreamName.create CategoryName
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 [<RequireQualifiedAccess>]

--- a/samples/Store/Domain/ContactPreferences.fs
+++ b/samples/Store/Domain/ContactPreferences.fs
@@ -6,10 +6,10 @@ module ClientId =
     let parse = ClientId
 
 module Stream =
-    let [<Literal>] Category = "ContactPreferences"
+    let [<Literal>] CategoryName = "ContactPreferences"
     let id = FsCodec.StreamId.gen ClientId.toString // TODO hash >> base64
     let decodeId = FsCodec.StreamId.dec ClientId.parse
-    let name = id >> FsCodec.StreamName.create Category
+    let name = id >> FsCodec.StreamName.create CategoryName
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =

--- a/samples/Store/Domain/Favorites.fs
+++ b/samples/Store/Domain/Favorites.fs
@@ -1,9 +1,9 @@
 ﻿module Domain.Favorites
 
 module Stream =
-    let [<Literal>] Category = "Favorites"
+    let [<Literal>] CategoryName = "Favorites"
     let id = FsCodec.StreamId.gen ClientId.toString
-    let name = id >> FsCodec.StreamName.create Category
+    let name = id >> FsCodec.StreamName.create CategoryName
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =

--- a/samples/Store/Domain/Favorites.fs
+++ b/samples/Store/Domain/Favorites.fs
@@ -1,9 +1,8 @@
 ﻿module Domain.Favorites
 
-module Stream =
-    let [<Literal>] CategoryName = "Favorites"
-    let id = FsCodec.StreamId.gen ClientId.toString
-    let name = id >> FsCodec.StreamName.create CategoryName
+let [<Literal>] CategoryName = "Favorites"
+let private streamId = FsCodec.StreamId.gen ClientId.toString
+let streamName = streamId >> FsCodec.StreamName.create CategoryName
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -86,4 +85,4 @@ type Service internal (resolve: ClientId -> Equinox.Decider<Events.Event, Fold.S
         decider.TransactEx((fun c -> (), decideUnfavorite sku c.State), mapResult)
 
 let create resolve =
-    Service(Stream.id >> resolve)
+    Service(streamId >> resolve)

--- a/samples/Store/Domain/InventoryItem.fs
+++ b/samples/Store/Domain/InventoryItem.fs
@@ -3,9 +3,8 @@ module Domain.InventoryItem
 
 open System
 
-module Stream =
-    let [<Literal>] CategoryName = "InventoryItem"
-    let id = FsCodec.StreamId.gen InventoryItemId.toString
+let [<Literal>] private CategoryName = "InventoryItem"
+let private streamId = FsCodec.StreamId.gen InventoryItemId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -68,4 +67,4 @@ type Service internal (resolve: InventoryItemId -> Equinox.Decider<Events.Event,
         decider.Query id
 
 let create resolve =
-    Service(Stream.id >> resolve)
+    Service(streamId >> resolve)

--- a/samples/Store/Domain/InventoryItem.fs
+++ b/samples/Store/Domain/InventoryItem.fs
@@ -4,7 +4,7 @@ module Domain.InventoryItem
 open System
 
 module Stream =
-    let [<Literal>] Category = "InventoryItem"
+    let [<Literal>] CategoryName = "InventoryItem"
     let id = FsCodec.StreamId.gen InventoryItemId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care

--- a/samples/Store/Domain/SavedForLater.fs
+++ b/samples/Store/Domain/SavedForLater.fs
@@ -4,7 +4,7 @@ open System
 open System.Collections.Generic
 
 module Stream =
-    let [<Literal>] Category = "SavedForLater"
+    let [<Literal>] CategoryName = "SavedForLater"
     let id = FsCodec.StreamId.gen ClientId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care

--- a/samples/Store/Domain/SavedForLater.fs
+++ b/samples/Store/Domain/SavedForLater.fs
@@ -3,9 +3,8 @@
 open System
 open System.Collections.Generic
 
-module Stream =
-    let [<Literal>] CategoryName = "SavedForLater"
-    let id = FsCodec.StreamId.gen ClientId.toString
+let [<Literal>] CategoryName = "SavedForLater"
+let private streamId = FsCodec.StreamId.gen ClientId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -139,4 +138,4 @@ type Service internal (resolve: ClientId -> Equinox.Decider<Events.Event, Fold.S
         return! decider.Transact(decide maxSavedItems (Merge state)) }
 
 let create maxSavedItems resolve =
-    Service(Stream.id >> resolve, maxSavedItems)
+    Service(streamId >> resolve, maxSavedItems)

--- a/samples/Store/Integration/CartIntegration.fs
+++ b/samples/Store/Integration/CartIntegration.fs
@@ -11,7 +11,7 @@ let snapshot = Cart.Fold.Snapshot.config
 
 let createMemoryStore () = MemoryStore.VolatileStore<ReadOnlyMemory<byte>>()
 let createServiceMemory log store =
-    MemoryStore.MemoryStoreCategory(store, Cart.Stream.Category, Cart.Events.codec, fold, initial)
+    MemoryStore.MemoryStoreCategory(store, Cart.Stream.CategoryName, Cart.Events.codec, fold, initial)
     |> Decider.forStream log
     |> Cart.create
 
@@ -19,14 +19,14 @@ let codec = Cart.Events.codec
 let codecJe = Cart.Events.codecJe
 
 let categoryGesStreamWithRollingSnapshots context =
-    EventStoreDb.EventStoreCategory(context, Cart.Stream.Category, codec, fold, initial, EventStoreDb.AccessStrategy.RollingSnapshots snapshot, CachingStrategy.NoCaching)
+    EventStoreDb.EventStoreCategory(context, Cart.Stream.CategoryName, codec, fold, initial, EventStoreDb.AccessStrategy.RollingSnapshots snapshot, CachingStrategy.NoCaching)
 let categoryGesStreamWithoutCustomAccessStrategy context =
-    EventStoreDb.EventStoreCategory(context, Cart.Stream.Category, codec, fold, initial, EventStoreDb.AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
+    EventStoreDb.EventStoreCategory(context, Cart.Stream.CategoryName, codec, fold, initial, EventStoreDb.AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
 
 let categoryCosmosStreamWithSnapshotStrategy context =
-    CosmosStore.CosmosStoreCategory(context, Cart.Stream.Category, codecJe, fold, initial, CosmosStore.AccessStrategy.Snapshot snapshot, CachingStrategy.NoCaching)
+    CosmosStore.CosmosStoreCategory(context, Cart.Stream.CategoryName, codecJe, fold, initial, CosmosStore.AccessStrategy.Snapshot snapshot, CachingStrategy.NoCaching)
 let categoryCosmosStreamWithoutCustomAccessStrategy context =
-    CosmosStore.CosmosStoreCategory(context, Cart.Stream.Category, codecJe, fold, initial, CosmosStore.AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
+    CosmosStore.CosmosStoreCategory(context, Cart.Stream.CategoryName, codecJe, fold, initial, CosmosStore.AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
 
 let addAndThenRemoveItemsManyTimesExceptTheLastOne context cartId skuId (service: Cart.Service) count =
     service.SyncItems(cartId, false, seq {

--- a/samples/Store/Integration/CartIntegration.fs
+++ b/samples/Store/Integration/CartIntegration.fs
@@ -11,7 +11,7 @@ let snapshot = Cart.Fold.Snapshot.config
 
 let createMemoryStore () = MemoryStore.VolatileStore<ReadOnlyMemory<byte>>()
 let createServiceMemory log store =
-    MemoryStore.MemoryStoreCategory(store, Cart.Stream.CategoryName, Cart.Events.codec, fold, initial)
+    MemoryStore.MemoryStoreCategory(store, Cart.CategoryName, Cart.Events.codec, fold, initial)
     |> Decider.forStream log
     |> Cart.create
 
@@ -19,14 +19,14 @@ let codec = Cart.Events.codec
 let codecJe = Cart.Events.codecJe
 
 let categoryGesStreamWithRollingSnapshots context =
-    EventStoreDb.EventStoreCategory(context, Cart.Stream.CategoryName, codec, fold, initial, EventStoreDb.AccessStrategy.RollingSnapshots snapshot, CachingStrategy.NoCaching)
+    EventStoreDb.EventStoreCategory(context, Cart.CategoryName, codec, fold, initial, EventStoreDb.AccessStrategy.RollingSnapshots snapshot, CachingStrategy.NoCaching)
 let categoryGesStreamWithoutCustomAccessStrategy context =
-    EventStoreDb.EventStoreCategory(context, Cart.Stream.CategoryName, codec, fold, initial, EventStoreDb.AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
+    EventStoreDb.EventStoreCategory(context, Cart.CategoryName, codec, fold, initial, EventStoreDb.AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
 
 let categoryCosmosStreamWithSnapshotStrategy context =
-    CosmosStore.CosmosStoreCategory(context, Cart.Stream.CategoryName, codecJe, fold, initial, CosmosStore.AccessStrategy.Snapshot snapshot, CachingStrategy.NoCaching)
+    CosmosStore.CosmosStoreCategory(context, Cart.CategoryName, codecJe, fold, initial, CosmosStore.AccessStrategy.Snapshot snapshot, CachingStrategy.NoCaching)
 let categoryCosmosStreamWithoutCustomAccessStrategy context =
-    CosmosStore.CosmosStoreCategory(context, Cart.Stream.CategoryName, codecJe, fold, initial, CosmosStore.AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
+    CosmosStore.CosmosStoreCategory(context, Cart.CategoryName, codecJe, fold, initial, CosmosStore.AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
 
 let addAndThenRemoveItemsManyTimesExceptTheLastOne context cartId skuId (service: Cart.Service) count =
     service.SyncItems(cartId, false, seq {

--- a/samples/Store/Integration/CartIntegration.fs
+++ b/samples/Store/Integration/CartIntegration.fs
@@ -29,7 +29,7 @@ let categoryCosmosStreamWithoutCustomAccessStrategy context =
     CosmosStore.CosmosStoreCategory(context, Cart.Stream.Category, codecJe, fold, initial, CosmosStore.AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
 
 let addAndThenRemoveItemsManyTimesExceptTheLastOne context cartId skuId (service: Cart.Service) count =
-    service.ExecuteManyAsync(cartId, false, seq {
+    service.SyncItems(cartId, false, seq {
         for i in 1..count do
             yield (context, skuId, Some i, None)
             if i <> count then

--- a/samples/Store/Integration/CartIntegration.fs
+++ b/samples/Store/Integration/CartIntegration.fs
@@ -31,9 +31,9 @@ let categoryCosmosStreamWithoutCustomAccessStrategy context =
 let addAndThenRemoveItemsManyTimesExceptTheLastOne context cartId skuId (service: Cart.Service) count =
     service.ExecuteManyAsync(cartId, false, seq {
         for i in 1..count do
-            yield Cart.SyncItem (context, skuId, Some i, None)
+            yield (context, skuId, Some i, None)
             if i <> count then
-                yield Cart.SyncItem (context, skuId, Some 0, None) })
+                yield (context, skuId, Some 0, None) })
 
 type Tests(testOutputHelper) =
     let testOutput = TestOutput testOutputHelper

--- a/samples/Store/Integration/ContactPreferencesIntegration.fs
+++ b/samples/Store/Integration/ContactPreferencesIntegration.fs
@@ -7,27 +7,27 @@ open Swensen.Unquote
 
 let fold, initial = ContactPreferences.Fold.fold, ContactPreferences.Fold.initial
 
-let Category = ContactPreferences.Stream.Category
+let CategoryName = ContactPreferences.Stream.CategoryName
 let createMemoryStore () = MemoryStore.VolatileStore<_>()
 let createServiceMemory log store =
-    MemoryStore.MemoryStoreCategory(store, Category, FsCodec.Box.Codec.Create(), fold, initial)
+    MemoryStore.MemoryStoreCategory(store, CategoryName, FsCodec.Box.Codec.Create(), fold, initial)
     |> Decider.forStream log
     |> ContactPreferences.create
 
 let codec = ContactPreferences.Events.codec
 let codecJe = ContactPreferences.Events.codecJe
 let categoryGesWithOptimizedStorageSemantics context =
-    EventStoreDb.EventStoreCategory(context 1, Category, codec, fold, initial, EventStoreDb.AccessStrategy.LatestKnownEvent, CachingStrategy.NoCaching)
+    EventStoreDb.EventStoreCategory(context 1, CategoryName, codec, fold, initial, EventStoreDb.AccessStrategy.LatestKnownEvent, CachingStrategy.NoCaching)
 let categoryGesWithoutAccessStrategy context =
-    EventStoreDb.EventStoreCategory(context defaultBatchSize, Category, codec, fold, initial, EventStoreDb.AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
+    EventStoreDb.EventStoreCategory(context defaultBatchSize, CategoryName, codec, fold, initial, EventStoreDb.AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
 
 let categoryCosmosWithLatestKnownEventSemantics context =
-    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.AccessStrategy.LatestKnownEvent, CachingStrategy.NoCaching)
+    CosmosStore.CosmosStoreCategory(context, CategoryName, codecJe, fold, initial, CosmosStore.AccessStrategy.LatestKnownEvent, CachingStrategy.NoCaching)
 let categoryCosmosUnoptimized context =
-    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
+    CosmosStore.CosmosStoreCategory(context, CategoryName, codecJe, fold, initial, CosmosStore.AccessStrategy.Unoptimized, CachingStrategy.NoCaching)
 let categoryCosmosRollingUnfolds context =
     let access = CosmosStore.AccessStrategy.Custom(ContactPreferences.Fold.isOrigin, ContactPreferences.Fold.transmute)
-    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, access, CachingStrategy.NoCaching)
+    CosmosStore.CosmosStoreCategory(context, CategoryName, codecJe, fold, initial, access, CachingStrategy.NoCaching)
 
 type Tests(testOutputHelper) =
     let testOutput = TestOutput testOutputHelper

--- a/samples/Store/Integration/ContactPreferencesIntegration.fs
+++ b/samples/Store/Integration/ContactPreferencesIntegration.fs
@@ -7,7 +7,7 @@ open Swensen.Unquote
 
 let fold, initial = ContactPreferences.Fold.fold, ContactPreferences.Fold.initial
 
-let CategoryName = ContactPreferences.Stream.CategoryName
+let CategoryName = ContactPreferences.CategoryName
 let createMemoryStore () = MemoryStore.VolatileStore<_>()
 let createServiceMemory log store =
     MemoryStore.MemoryStoreCategory(store, CategoryName, FsCodec.Box.Codec.Create(), fold, initial)

--- a/samples/Store/Integration/FavoritesIntegration.fs
+++ b/samples/Store/Integration/FavoritesIntegration.fs
@@ -5,31 +5,31 @@ open Equinox
 open Equinox.CosmosStore.Integration.CosmosFixtures
 open Swensen.Unquote
 
-let [<Literal>] Category = Favorites.Stream.Category
+let [<Literal>] CategoryName = Favorites.Stream.CategoryName
 let fold, initial = Favorites.Fold.fold, Favorites.Fold.initial
 let snapshot = Favorites.Fold.Snapshot.config
 
 let createMemoryStore () = MemoryStore.VolatileStore<_>()
 let createServiceMemory log store =
-    MemoryStore.MemoryStoreCategory(store, Category, FsCodec.Box.Codec.Create(), fold, initial)
+    MemoryStore.MemoryStoreCategory(store, CategoryName, FsCodec.Box.Codec.Create(), fold, initial)
     |> Decider.forStream log
     |> Favorites.create
 
 let codec = Favorites.Events.codec
 let codecJe = Favorites.Events.codecJe
 let createServiceGes log context =
-    EventStoreDb.EventStoreCategory(context, Category, codec, fold, initial, EventStoreDb.AccessStrategy.RollingSnapshots snapshot, CachingStrategy.NoCaching)
+    EventStoreDb.EventStoreCategory(context, CategoryName, codec, fold, initial, EventStoreDb.AccessStrategy.RollingSnapshots snapshot, CachingStrategy.NoCaching)
     |> Decider.forStream log
     |> Favorites.create
 
 let createServiceCosmosSnapshotsUncached log context =
-    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, CosmosStore.AccessStrategy.Snapshot snapshot, CachingStrategy.NoCaching)
+    CosmosStore.CosmosStoreCategory(context, CategoryName, codecJe, fold, initial, CosmosStore.AccessStrategy.Snapshot snapshot, CachingStrategy.NoCaching)
     |> Decider.forStream log
     |> Favorites.create
 
 let createServiceCosmosRollingStateUncached log context =
     let access = CosmosStore.AccessStrategy.RollingState Favorites.Fold.Snapshot.generate
-    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, access, CachingStrategy.NoCaching)
+    CosmosStore.CosmosStoreCategory(context, CategoryName, codecJe, fold, initial, access, CachingStrategy.NoCaching)
     |> Decider.forStream log
     |> Favorites.create
 
@@ -38,7 +38,7 @@ let createServiceCosmosUnoptimizedButCached log context =
     let caching =
         let cache = Cache ("name", 10)
         CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
-    CosmosStore.CosmosStoreCategory(context, Category, codecJe, fold, initial, access, caching)
+    CosmosStore.CosmosStoreCategory(context, CategoryName, codecJe, fold, initial, access, caching)
     |> Decider.forStream log
     |> Favorites.create
 

--- a/samples/Store/Integration/FavoritesIntegration.fs
+++ b/samples/Store/Integration/FavoritesIntegration.fs
@@ -5,7 +5,7 @@ open Equinox
 open Equinox.CosmosStore.Integration.CosmosFixtures
 open Swensen.Unquote
 
-let [<Literal>] CategoryName = Favorites.Stream.CategoryName
+let [<Literal>] CategoryName = Favorites.CategoryName
 let fold, initial = Favorites.Fold.fold, Favorites.Fold.initial
 let snapshot = Favorites.Fold.Snapshot.config
 

--- a/samples/TodoBackend/Todo.fs
+++ b/samples/TodoBackend/Todo.fs
@@ -5,7 +5,7 @@ open Domain
 // The TodoBackend spec does not dictate having multiple lists, tenants or clients
 // Here, we implement such a discriminator in order to allow each virtual client to maintain independent state
 module Stream =
-    let [<Literal>] Category = "Todos"
+    let [<Literal>] CategoryName = "Todos"
     let id = FsCodec.StreamId.gen ClientId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care

--- a/samples/TodoBackend/Todo.fs
+++ b/samples/TodoBackend/Todo.fs
@@ -4,9 +4,8 @@ open Domain
 
 // The TodoBackend spec does not dictate having multiple lists, tenants or clients
 // Here, we implement such a discriminator in order to allow each virtual client to maintain independent state
-module Stream =
-    let [<Literal>] CategoryName = "Todos"
-    let id = FsCodec.StreamId.gen ClientId.toString
+let [<Literal>] CategoryName = "Todos"
+let private streamId = FsCodec.StreamId.gen ClientId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -82,4 +81,4 @@ type Service internal (resolve: ClientId -> Equinox.Decider<Events.Event, Fold.S
         let decider = resolve clientId
         decider.Transact(Decisions.clear)
 
-let create resolve = Service(Stream.id >> resolve)
+let create resolve = Service(streamId >> resolve)

--- a/samples/Tutorial/AsAt.fsx
+++ b/samples/Tutorial/AsAt.fsx
@@ -97,8 +97,8 @@ module Fold =
     // Recognize a relevant snapshot when we meet one in the chain
     let isValid : Events.Event -> bool = function _, Events.Snapshot _ -> true | _ -> false
 
-let decideAdd count = [| -1L, Events.Added { count = delta } |]
-let decideRemove count = [|
+let decideAdd delta _state = [| -1L, Events.Added { count = delta } |]
+let decideRemove delta state = [|
     let bal = state |> Fold.State.balance
     if bal < delta then invalidArg "delta" $"delta %d{delta} exceeds balance %d{bal}"
     else -1L, Events.Removed { count = delta } |]
@@ -116,7 +116,7 @@ type Service internal (resolve : string -> Equinox.Decider<Events.Event, Fold.St
         decider.Query Fold.State.balance
     member _.AsAt(clientId,index)  =
         let decider = resolve clientId
-        decider.Query((fun state -> state[index]))
+        decider.Query(fun state -> state[index])
 
 module Log =
     open Serilog

--- a/samples/Tutorial/AsAt.fsx
+++ b/samples/Tutorial/AsAt.fsx
@@ -45,8 +45,8 @@ let private streamId = FsCodec.StreamId.gen id
 
 module Events =
 
-    type Delta = { count : int }
-    type SnapshotInfo = { balanceLog : int[] }
+    type Delta = { count: int }
+    type SnapshotInfo = { balanceLog: int[] }
     type Contract =
         | Added of Delta
         | Removed of Delta
@@ -102,7 +102,7 @@ let decideRemove delta state = [|
     if bal < delta then invalidArg "delta" $"delta %d{delta} exceeds balance %d{bal}"
     else -1L, Events.Removed { count = delta } |]
 
-type Service internal (resolve : string -> Equinox.Decider<Events.Event, Fold.State>) =
+type Service internal (resolve: string -> Equinox.Decider<Events.Event, Fold.State>) =
 
     member _.Add(clientId, count) =
         let decider = resolve clientId

--- a/samples/Tutorial/AsAt.fsx
+++ b/samples/Tutorial/AsAt.fsx
@@ -40,9 +40,8 @@
 
 open System
 
-module Stream =
-    let [<Literal>] CategoryName = "Account"
-    let id = FsCodec.StreamId.gen id
+let [<Literal>] private CategoryName = "Account"
+let private streamId = FsCodec.StreamId.gen id
 
 module Events =
 
@@ -151,7 +150,7 @@ module EventStore =
     let context = EventStoreContext(connection, batchSize = snapshotWindow)
     // rig snapshots to be injected as events into the stream every `snapshotWindow` events
     let accessStrategy = AccessStrategy.RollingSnapshots (Fold.isValid,Fold.snapshot)
-    let cat = EventStoreCategory(context, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
+    let cat = EventStoreCategory(context, CategoryName, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
     let resolve = Equinox.Decider.forStream Log.log cat
 
 module Cosmos =
@@ -165,11 +164,11 @@ module Cosmos =
     let client = connector.Connect(databaseId, [| containerId |]) |> Async.RunSynchronously
     let context = CosmosStoreContext(client, databaseId, containerId, tipMaxEvents = 10)
     let accessStrategy = AccessStrategy.Snapshot (Fold.isValid,Fold.snapshot)
-    let cat = CosmosStoreCategory(context, Stream.CategoryName, Events.codecJe, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
+    let cat = CosmosStoreCategory(context, CategoryName, Events.codecJe, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
     let resolve = Equinox.Decider.forStream Log.log cat
 
-let service = Service(Stream.id >> EventStore.resolve)
-//let service= Service(Stream.id >> Cosmos.resolve)
+let service = Service(streamId >> EventStore.resolve)
+//let service= Service(streamId >> Cosmos.resolve)
 
 let client = "ClientA"
 service.Add(client, 1) |> Async.RunSynchronously

--- a/samples/Tutorial/AsAt.fsx
+++ b/samples/Tutorial/AsAt.fsx
@@ -41,7 +41,7 @@
 open System
 
 module Stream =
-    let [<Literal>] Category = "Account"
+    let [<Literal>] CategoryName = "Account"
     let id = FsCodec.StreamId.gen id
 
 module Events =
@@ -151,7 +151,7 @@ module EventStore =
     let context = EventStoreContext(connection, batchSize = snapshotWindow)
     // rig snapshots to be injected as events into the stream every `snapshotWindow` events
     let accessStrategy = AccessStrategy.RollingSnapshots (Fold.isValid,Fold.snapshot)
-    let cat = EventStoreCategory(context, Stream.Category, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
+    let cat = EventStoreCategory(context, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
     let resolve = Equinox.Decider.forStream Log.log cat
 
 module Cosmos =
@@ -165,7 +165,7 @@ module Cosmos =
     let client = connector.Connect(databaseId, [| containerId |]) |> Async.RunSynchronously
     let context = CosmosStoreContext(client, databaseId, containerId, tipMaxEvents = 10)
     let accessStrategy = AccessStrategy.Snapshot (Fold.isValid,Fold.snapshot)
-    let cat = CosmosStoreCategory(context, Stream.Category, Events.codecJe, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
+    let cat = CosmosStoreCategory(context, Stream.CategoryName, Events.codecJe, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
     let resolve = Equinox.Decider.forStream Log.log cat
 
 let service = Service(Stream.id >> EventStore.resolve)

--- a/samples/Tutorial/Cosmos.fsx
+++ b/samples/Tutorial/Cosmos.fsx
@@ -38,9 +38,8 @@ module Log =
 
 module Favorites =
 
-    module Stream =
-        let Categoryname = "Favorites"
-        let id = FsCodec.StreamId.gen id
+    let [<Literal>] private CategoryName = "Favorites"
+    let private streamId = FsCodec.StreamId.gen id
 
     module Events =
 
@@ -60,11 +59,11 @@ module Favorites =
             | Events.Removed { sku = sku } -> state |> List.filter (fun x -> x <> sku)
         let fold s xs = Array.fold evolve s xs
 
-     let decideAdd sku state = [|
-         if state |> List.contains sku |> not then
+    let decideAdd sku state = [|
+        if state |> List.contains sku |> not then
             Events.Added { sku = sku } |]
-     let decideRemove sku state = [|
-         if state |> List.contains sku then
+    let decideRemove sku state = [|
+        if state |> List.contains sku then
             Events.Removed { sku = sku } |]
 
     type Service internal (resolve : string -> Equinox.Decider<Events.Event, Fold.State>) =
@@ -79,7 +78,7 @@ module Favorites =
             let decider = resolve clientId
             decider.Query id
 
-    let create cat = Service(Stream.id >> Equinox.Decider.forStream Log.log cat)
+    let create cat = Service(streamId >> Equinox.Decider.forStream Log.log cat)
 
     module Cosmos =
 
@@ -87,7 +86,7 @@ module Favorites =
         let accessStrategy = AccessStrategy.Unoptimized // Or Snapshot etc https://github.com/jet/equinox/blob/master/DOCUMENTATION.md#access-strategies
         let category (context, cache) =
             let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
-            CosmosStoreCategory(context, Stream.Categoryname, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
+            CosmosStoreCategory(context, CategoryName, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
 
 let [<Literal>] appName = "equinox-tutorial"
 

--- a/samples/Tutorial/Cosmos.fsx
+++ b/samples/Tutorial/Cosmos.fsx
@@ -39,7 +39,7 @@ module Log =
 module Favorites =
 
     module Stream =
-        let Category = "Favorites"
+        let Categoryname = "Favorites"
         let id = FsCodec.StreamId.gen id
 
     module Events =
@@ -87,7 +87,7 @@ module Favorites =
         let accessStrategy = AccessStrategy.Unoptimized // Or Snapshot etc https://github.com/jet/equinox/blob/master/DOCUMENTATION.md#access-strategies
         let category (context, cache) =
             let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
-            CosmosStoreCategory(context, Stream.Category, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
+            CosmosStoreCategory(context, Stream.Categoryname, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
 
 let [<Literal>] appName = "equinox-tutorial"
 

--- a/samples/Tutorial/Counter.fsx
+++ b/samples/Tutorial/Counter.fsx
@@ -32,8 +32,8 @@ type Event =
 
 module Stream =
     // Events for a given DDD aggregate are considered to be in the same 'Category' for indexing purposes
-    // When reacting to events (using Propulsion), the Category will be a key thing to filter events based on
-    let [<Literal>] Category = "Counter"
+    // When reacting to events (using Propulsion), the CategoryName will be a key thing to filter events based on
+    let [<Literal>] CategoryName = "Counter"
     // Maps from an app-level counter name (perhaps a strongly typed id), to a well-formed StreamId that can be stored in the Event Store
     // For this sample, we let callers just pass a string, and we trust it's suitable for use as a StreamId directly
     let id = FsCodec.StreamId.gen id
@@ -98,7 +98,7 @@ let logEvents sn (events : FsCodec.ITimelineEvent<_>[]) =
 let store = Equinox.MemoryStore.VolatileStore()
 let _ = store.Committed.Subscribe(fun struct (sn, xs) -> logEvents sn xs)
 let codec = FsCodec.Box.Codec.Create()
-let cat = Equinox.MemoryStore.MemoryStoreCategory(store, Stream.Category, codec, fold, initial)
+let cat = Equinox.MemoryStore.MemoryStoreCategory(store, Stream.CategoryName, codec, fold, initial)
 let service = Service(Stream.id >> Equinox.Decider.forStream log cat)
 
 let clientId = "ClientA"

--- a/samples/Tutorial/Counter.fsx
+++ b/samples/Tutorial/Counter.fsx
@@ -30,13 +30,12 @@ type Event =
     | Cleared of Cleared
     interface TypeShape.UnionContract.IUnionContract
 
-module Stream =
-    // Events for a given DDD aggregate are considered to be in the same 'Category' for indexing purposes
-    // When reacting to events (using Propulsion), the CategoryName will be a key thing to filter events based on
-    let [<Literal>] CategoryName = "Counter"
-    // Maps from an app-level counter name (perhaps a strongly typed id), to a well-formed StreamId that can be stored in the Event Store
-    // For this sample, we let callers just pass a string, and we trust it's suitable for use as a StreamId directly
-    let id = FsCodec.StreamId.gen id
+// Events for a given DDD aggregate are considered to be in the same 'Category' for indexing purposes
+// When reacting to events (using Propulsion), the CategoryName will be a key thing to filter events based on
+let [<Literal>] private CategoryName = "Counter"
+// Maps from an app-level counter name (perhaps a strongly typed id), to a well-formed StreamId that can be stored in the Event Store
+// For this sample, we let callers just pass a string, and we trust it's suitable for use as a StreamId directly
+let private streamId = FsCodec.StreamId.gen id
 
 type State = State of int
 let initial : State = State 0
@@ -98,8 +97,8 @@ let logEvents sn (events : FsCodec.ITimelineEvent<_>[]) =
 let store = Equinox.MemoryStore.VolatileStore()
 let _ = store.Committed.Subscribe(fun struct (sn, xs) -> logEvents sn xs)
 let codec = FsCodec.Box.Codec.Create()
-let cat = Equinox.MemoryStore.MemoryStoreCategory(store, Stream.CategoryName, codec, fold, initial)
-let service = Service(Stream.id >> Equinox.Decider.forStream log cat)
+let cat = Equinox.MemoryStore.MemoryStoreCategory(store, CategoryName, codec, fold, initial)
+let service = Service(streamId >> Equinox.Decider.forStream log cat)
 
 let clientId = "ClientA"
 service.Read(clientId) |> Async.RunSynchronously

--- a/samples/Tutorial/Counter.fsx
+++ b/samples/Tutorial/Counter.fsx
@@ -68,7 +68,7 @@ let decide command (State state) = [|
     | Clear i ->
         if state <> i then Cleared {value = i } |]
 
-type Service internal (resolve : string -> Equinox.Decider<Event, State>) =
+type Service internal (resolve: string -> Equinox.Decider<Event, State>) =
 
     member _.Execute(instanceId, command) : Async<unit> =
         let decider = resolve instanceId

--- a/samples/Tutorial/Favorites.fsx
+++ b/samples/Tutorial/Favorites.fsx
@@ -55,7 +55,7 @@ let favesCba = fold initialState [| Added "a"; Added "b"; Added "c" |]
 module Decisions =
     
     let add sku state = [|
-        if state |> List.contains sku |> not then
+        if not (state |> List.contains sku) then
             Added sku |]
     let remove sku state = [|
         if state |> List.contains sku then

--- a/samples/Tutorial/Favorites.fsx
+++ b/samples/Tutorial/Favorites.fsx
@@ -75,7 +75,7 @@ let _removeBAgainEffect = Decisions.remove "b" favesCa
 //val _removeBAgainEffect : Event list = []
 
 // related streams are termed a Category; Each client will have it's own Stream.
-let [<Literal>] CategoryName = "Favorites"
+let [<Literal>] private CategoryName = "Favorites"
 let clientAFavoritesStreamId = FsCodec.StreamId.gen id "ClientA"
 
 // For test purposes, we use the in-memory store

--- a/samples/Tutorial/FulfilmentCenter.fsx
+++ b/samples/Tutorial/FulfilmentCenter.fsx
@@ -98,22 +98,24 @@ module FulfilmentCenter =
 
     type Service internal (resolve : string -> Equinox.Decider<Events.Event, Fold.State>) =
 
-        let execute fc command : Async<unit> =
+        member _.UpdateName(id, value) =
             let decider = resolve fc
-            decider.Transact(interpret command)
-        let read fc : Async<Summary> =
+            decider.Transact(interpret (Register value))
+        member _.UpdateAddress(id, value) =
+            let decider = resolve fc
+            decider.Transact(interpret (UpdateAddress value))
+        member _.UpdateContact(id, value) =
+            let decider = resolve fc
+            decider.Transact(interpret (UpdateContact value))
+        member _.UpdateDetails(id, value) =
+            let decider = resolve fc
+            decider.Transact(interpret (UpdateDetails value))
+        member _.Read id : Async<Summary> =
             let decider = resolve fc
             decider.Query id
-        let queryEx fc (projection : Fold.State -> 't) : Async<int64*'t> =
+        member _.QueryWithVersion(id, render : Fold.State -> 'res) : Async<int64*'res> =
             let decider = resolve fc
-            decider.QueryEx(fun c -> c.Version, projection c.State)
-
-        member _.UpdateName(id, value) = execute id (Register value)
-        member _.UpdateAddress(id, value) = execute id (UpdateAddress value)
-        member _.UpdateContact(id, value) = execute id (UpdateContact value)
-        member _.UpdateDetails(id, value) = execute id (UpdateDetails value)
-        member _.Read id : Async<Summary> = read id
-        member _.QueryWithVersion(id, render : Fold.State -> 'res) : Async<int64*'res> = queryEx id render
+            decider.QueryEx(fun c -> c.Version, render c.State)
 
 open Equinox.CosmosStore
 

--- a/samples/Tutorial/FulfilmentCenter.fsx
+++ b/samples/Tutorial/FulfilmentCenter.fsx
@@ -93,7 +93,7 @@ module FulfilmentCenter =
             if state.details <> Some d then
                 Events.FcDetailsChanged { details = d } |]
 
-    type Service internal (resolve : string -> Equinox.Decider<Events.Event, Fold.State>) =
+    type Service internal (resolve: string -> Equinox.Decider<Events.Event, Fold.State>) =
 
         member _.UpdateName(fc, value) =
             let decider = resolve fc

--- a/samples/Tutorial/FulfilmentCenter.fsx
+++ b/samples/Tutorial/FulfilmentCenter.fsx
@@ -51,7 +51,7 @@ module Types =
 module FulfilmentCenter =
 
     module Stream =
-        let [<Literal>] Category = "FulfilmentCenter"
+        let [<Literal>] CategoryName = "FulfilmentCenter"
         let id = FsCodec.StreamId.gen id
 
     module Events =
@@ -145,7 +145,7 @@ module Store =
 open FulfilmentCenter
 
 let service =
-    let cat = CosmosStoreCategory(Store.context, Stream.Category, Events.codec, Fold.fold, Fold.initial, AccessStrategy.Unoptimized, Store.cacheStrategy)
+    let cat = CosmosStoreCategory(Store.context, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial, AccessStrategy.Unoptimized, Store.cacheStrategy)
     Service(Stream.id >> Equinox.Decider.forStream Log.log cat)
 
 let fc = "fc0"
@@ -158,7 +158,7 @@ Log.dumpMetrics ()
 module FulfilmentCenterSummary =
 
     module Stream =
-        let [<Literal>] Category = "FulfilmentCenter"
+        let [<Literal>] CategoryName = "FulfilmentCenter"
         let id = FsCodec.StreamId.gen id
 
     module Events =

--- a/samples/Tutorial/FulfilmentCenter.fsx
+++ b/samples/Tutorial/FulfilmentCenter.fsx
@@ -82,13 +82,17 @@ module FulfilmentCenter =
     module Decisions =
 
         let register name = [|
-            if state.name <> Some c then Events.FcCreated name |]
+            if state.name <> Some c then
+                Events.FcCreated name |]
         let updateAddress a = [|
-            if state.address <> Some a then Events.FcAddressChanged { address = a } |]
+            if state.address <> Some a then
+                Events.FcAddressChanged { address = a } |]
         let updateContact c = [|
-            if state.contact <> Some c then Events.FcContactChanged { contact = c } |]
+            if state.contact <> Some c then
+                Events.FcContactChanged { contact = c } |]
         let updateDetails d = [|
-            if state.details <> Some d then Events.FcDetailsChanged { details = d } |]
+            if state.details <> Some d then
+                Events.FcDetailsChanged { details = d } |]
 
     type Service internal (resolve : string -> Equinox.Decider<Events.Event, Fold.State>) =
 

--- a/samples/Tutorial/FulfilmentCenter.fsx
+++ b/samples/Tutorial/FulfilmentCenter.fsx
@@ -98,22 +98,22 @@ module FulfilmentCenter =
 
     type Service internal (resolve : string -> Equinox.Decider<Events.Event, Fold.State>) =
 
-        member _.UpdateName(id, value) =
+        member _.UpdateName(fc, value) =
             let decider = resolve fc
             decider.Transact(interpret (Register value))
-        member _.UpdateAddress(id, value) =
+        member _.UpdateAddress(fc, value) =
             let decider = resolve fc
             decider.Transact(interpret (UpdateAddress value))
-        member _.UpdateContact(id, value) =
+        member _.UpdateContact(fc, value) =
             let decider = resolve fc
             decider.Transact(interpret (UpdateContact value))
-        member _.UpdateDetails(id, value) =
+        member _.UpdateDetails(fc, value) =
             let decider = resolve fc
             decider.Transact(interpret (UpdateDetails value))
-        member _.Read id : Async<Summary> =
+        member _.Read fc : Async<Summary> =
             let decider = resolve fc
             decider.Query id
-        member _.QueryWithVersion(id, render : Fold.State -> 'res) : Async<int64*'res> =
+        member _.QueryWithVersion(fc, render : Fold.State -> 'res) : Async<int64*'res> =
             let decider = resolve fc
             decider.QueryEx(fun c -> c.Version, render c.State)
 

--- a/samples/Tutorial/Gapless.fs
+++ b/samples/Tutorial/Gapless.fs
@@ -4,9 +4,8 @@ module Gapless
 
 open System
 
-module Stream =
-    let [<Literal>] CategoryName = "Gapless"
-    let id = FsCodec.StreamId.gen SequenceId.toString
+let [<Literal>] private CategoryName = "Gapless"
+let private streamId = FsCodec.StreamId.gen SequenceId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -79,14 +78,14 @@ type Service internal (resolve: SequenceId -> Equinox.Decider<Events.Event, Fold
 
 let [<Literal>] appName = "equinox-tutorial-gapless"
 
-let create cat = Service(Stream.id >> Equinox.Decider.forStream Serilog.Log.Logger cat)
+let create cat = Service(streamId >> Equinox.Decider.forStream Serilog.Log.Logger cat)
 
 module Cosmos =
 
     open Equinox.CosmosStore
     let private category (context, cache, accessStrategy) =
         let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
-        CosmosStoreCategory(context, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
+        CosmosStoreCategory(context, CategoryName, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
 
     module Snapshot =
 

--- a/samples/Tutorial/Gapless.fs
+++ b/samples/Tutorial/Gapless.fs
@@ -5,7 +5,7 @@ module Gapless
 open System
 
 module Stream =
-    let [<Literal>] Category = "Gapless"
+    let [<Literal>] CategoryName = "Gapless"
     let id = FsCodec.StreamId.gen SequenceId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
@@ -86,7 +86,7 @@ module Cosmos =
     open Equinox.CosmosStore
     let private category (context, cache, accessStrategy) =
         let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
-        CosmosStoreCategory(context, Stream.Category, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
+        CosmosStoreCategory(context, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
 
     module Snapshot =
 

--- a/samples/Tutorial/Index.fs
+++ b/samples/Tutorial/Index.fs
@@ -1,7 +1,7 @@
 module Index
 
 module Stream =
-    let [<Literal>] Category = "Index"
+    let [<Literal>] CategoryName = "Index"
     let id = FsCodec.StreamId.gen IndexId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
@@ -55,9 +55,9 @@ module Cosmos =
     let category (context,cache) =
         let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
         let accessStrategy = AccessStrategy.RollingState Fold.snapshot
-        CosmosStoreCategory(context, Stream.Category, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
+        CosmosStoreCategory(context, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
 
 module MemoryStore =
 
     let category store =
-        Equinox.MemoryStore.MemoryStoreCategory(store, Stream.Category, Events.codec, Fold.fold, Fold.initial)
+        Equinox.MemoryStore.MemoryStoreCategory(store, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial)

--- a/samples/Tutorial/Index.fs
+++ b/samples/Tutorial/Index.fs
@@ -1,8 +1,7 @@
 module Index
 
-module Stream =
-    let [<Literal>] CategoryName = "Index"
-    let id = FsCodec.StreamId.gen IndexId.toString
+let [<Literal>] private CategoryName = "Index"
+let private streamId = FsCodec.StreamId.gen IndexId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -47,7 +46,7 @@ type Service<'t> internal (decider : Equinox.Decider<Events.Event<'t>, Fold.Stat
         decider.Query id
 
 let create<'t> indexId cat =
-    Service(Stream.id indexId |> Equinox.Decider.forStream Serilog.Log.Logger cat)
+    Service(streamId indexId |> Equinox.Decider.forStream Serilog.Log.Logger cat)
 
 module Cosmos =
 
@@ -55,9 +54,9 @@ module Cosmos =
     let category (context,cache) =
         let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
         let accessStrategy = AccessStrategy.RollingState Fold.snapshot
-        CosmosStoreCategory(context, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
+        CosmosStoreCategory(context, CategoryName, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
 
 module MemoryStore =
 
     let category store =
-        Equinox.MemoryStore.MemoryStoreCategory(store, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial)
+        Equinox.MemoryStore.MemoryStoreCategory(store, CategoryName, Events.codec, Fold.fold, Fold.initial)

--- a/samples/Tutorial/Sequence.fs
+++ b/samples/Tutorial/Sequence.fs
@@ -29,7 +29,7 @@ module Fold =
 let decideReserve (count : int) (state : Fold.State) : int64 * Events.Event[] =
     state.next, [| Events.Reserved { next = state.next + int64 count } |]
 
-type Service internal (resolve : SequenceId -> Equinox.Decider<Events.Event, Fold.State>) =
+type Service internal (resolve: SequenceId -> Equinox.Decider<Events.Event, Fold.State>) =
 
     /// Reserves an id, yielding the reserved value. Optional <c>count</c> enables reserving more than the default count of <c>1</c> in a single transaction
     member _.Reserve(series,?count) : Async<int64> =

--- a/samples/Tutorial/Sequence.fs
+++ b/samples/Tutorial/Sequence.fs
@@ -5,7 +5,7 @@ module Sequence
 open System
 
 module Stream =
-    let [<Literal>] Category = "Sequence"
+    let [<Literal>] CategoryName = "Sequence"
     let id = FsCodec.StreamId.gen SequenceId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
@@ -44,7 +44,7 @@ module Cosmos =
     open Equinox.CosmosStore
     let private create (context, cache, accessStrategy) =
         let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
-        CosmosStoreCategory(context, Stream.Category, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
+        CosmosStoreCategory(context, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
 
     module LatestKnownEvent =
 

--- a/samples/Tutorial/Set.fs
+++ b/samples/Tutorial/Set.fs
@@ -1,8 +1,7 @@
 module Set
 
-module Stream =
-    let [<Literal>] CategoryName = "Set"
-    let id = FsCodec.StreamId.gen SetId.toString
+let [<Literal>] private CategoryName = "Set"
+let streamId = FsCodec.StreamId.gen SetId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
@@ -54,16 +53,16 @@ type Service internal (decider: Equinox.Decider<Events.Event, Fold.State>) =
         decider.Query id
 
 let create setId cat =
-    Service(Stream.id setId |> Equinox.Decider.forStream Serilog.Log.Logger cat)
+    Service(streamId setId |> Equinox.Decider.forStream Serilog.Log.Logger cat)
 
 module Cosmos =
 
     let category (context, cache) =
         let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
         let accessStrategy = Equinox.CosmosStore.AccessStrategy.RollingState Fold.Snapshot.generate
-        Equinox.CosmosStore.CosmosStoreCategory(context, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
+        Equinox.CosmosStore.CosmosStoreCategory(context, CategoryName, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
 
 module MemoryStore =
 
     let category store =
-        Equinox.MemoryStore.MemoryStoreCategory(store, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial)
+        Equinox.MemoryStore.MemoryStoreCategory(store, CategoryName, Events.codec, Fold.fold, Fold.initial)

--- a/samples/Tutorial/Set.fs
+++ b/samples/Tutorial/Set.fs
@@ -1,7 +1,7 @@
 module Set
 
 module Stream =
-    let [<Literal>] Category = "Set"
+    let [<Literal>] CategoryName = "Set"
     let id = FsCodec.StreamId.gen SetId.toString
 
 // NOTE - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
@@ -61,9 +61,9 @@ module Cosmos =
     let category (context, cache) =
         let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
         let accessStrategy = Equinox.CosmosStore.AccessStrategy.RollingState Fold.Snapshot.generate
-        Equinox.CosmosStore.CosmosStoreCategory(context, Stream.Category, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
+        Equinox.CosmosStore.CosmosStoreCategory(context, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy)
 
 module MemoryStore =
 
     let category store =
-        Equinox.MemoryStore.MemoryStoreCategory(store, Stream.Category, Events.codec, Fold.fold, Fold.initial)
+        Equinox.MemoryStore.MemoryStoreCategory(store, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial)

--- a/samples/Tutorial/Todo.fsx
+++ b/samples/Tutorial/Todo.fsx
@@ -53,7 +53,7 @@ module Snapshot =
 let private evolve s = function
     | Added item -> { items = item :: s.items; nextId = s.nextId + 1 }
     | Updated value -> { s with items = s.items |> List.map (function { id = id } when id = value.id -> value | item -> item) }
-    | Deleted { id=id } -> { s with items = s.items |> List.filter (fun x -> x.id <> id) }
+    | Deleted { id = id } -> { s with items = s.items |> List.filter (fun x -> x.id <> id) }
     | Cleared -> { s with items = [] }
     | Snapshotted { items=items } -> { s with items = List.ofArray items }
 let fold = Array.fold evolve
@@ -73,7 +73,7 @@ module Decisions =
         if state.items |> List.isEmpty |> not then
             Cleared |]
 
-type Service internal (resolve : string -> Equinox.Decider<Event, State>) =
+type Service internal (resolve: string -> Equinox.Decider<Event, State>) =
 
     member _.List(clientId): Async<Todo seq> =
         let decider = resolve clientId

--- a/samples/Tutorial/Todo.fsx
+++ b/samples/Tutorial/Todo.fsx
@@ -27,7 +27,7 @@ open System
    This tutorial stresses different aspects *)
 
 module Stream =
-    let Category = "Todos"
+    let CategoryName = "Todos"
     let id = FsCodec.StreamId.gen id
 
 type Todo =             { id: int; order: int; title: string; completed: bool }
@@ -133,7 +133,7 @@ module Store =
     let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
 
     let access = AccessStrategy.Snapshot Snapshot.config
-    let category = CosmosStoreCategory(context, Stream.Category, codec, fold, initial, access, cacheStrategy)
+    let category = CosmosStoreCategory(context, Stream.CategoryName, codec, fold, initial, access, cacheStrategy)
 
 let service = Service(Stream.id >> Equinox.Decider.forStream log Store.category)
 

--- a/samples/Tutorial/Upload.fs
+++ b/samples/Tutorial/Upload.fs
@@ -14,9 +14,8 @@ and [<Measure>] companyId
 module CompanyId =
     let toString (value : CompanyId) : string = %value
 
-module Stream =
-    let [<Literal>] CategoryName = "Upload"
-    let id = FsCodec.StreamId.gen2 CompanyId.toString PurchaseOrderId.toString
+let [<Literal>] private CategoryName = "Upload"
+let private streamId = FsCodec.StreamId.gen2 CompanyId.toString PurchaseOrderId.toString
 
 type UploadId = string<uploadId>
 and [<Measure>] uploadId
@@ -53,16 +52,16 @@ type Service internal (resolve: struct (CompanyId * PurchaseOrderId) -> Equinox.
         let decider = resolve (companyId, purchaseOrderId)
         decider.Transact(decide value)
 
-let create cat = Service(Stream.id >> Equinox.Decider.forStream Serilog.Log.Logger cat)
+let create cat = Service(streamId >> Equinox.Decider.forStream Serilog.Log.Logger cat)
 
 module Cosmos =
 
     open Equinox.CosmosStore
     let category (context, cache) =
         let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
-        CosmosStoreCategory(context, Stream.CategoryName, Events.codecJe, Fold.fold, Fold.initial, AccessStrategy.LatestKnownEvent, cacheStrategy)
+        CosmosStoreCategory(context, CategoryName, Events.codecJe, Fold.fold, Fold.initial, AccessStrategy.LatestKnownEvent, cacheStrategy)
 
 module EventStore =
     open Equinox.EventStoreDb
     let category context =
-        EventStoreCategory(context, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial, AccessStrategy.LatestKnownEvent, Equinox.CachingStrategy.NoCaching)
+        EventStoreCategory(context, CategoryName, Events.codec, Fold.fold, Fold.initial, AccessStrategy.LatestKnownEvent, Equinox.CachingStrategy.NoCaching)

--- a/samples/Tutorial/Upload.fs
+++ b/samples/Tutorial/Upload.fs
@@ -15,7 +15,7 @@ module CompanyId =
     let toString (value : CompanyId) : string = %value
 
 module Stream =
-    let [<Literal>] Category = "Upload"
+    let [<Literal>] CategoryName = "Upload"
     let id = FsCodec.StreamId.gen2 CompanyId.toString PurchaseOrderId.toString
 
 type UploadId = string<uploadId>
@@ -60,9 +60,9 @@ module Cosmos =
     open Equinox.CosmosStore
     let category (context, cache) =
         let cacheStrategy = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.) // OR CachingStrategy.NoCaching
-        CosmosStoreCategory(context, Stream.Category, Events.codecJe, Fold.fold, Fold.initial, AccessStrategy.LatestKnownEvent, cacheStrategy)
+        CosmosStoreCategory(context, Stream.CategoryName, Events.codecJe, Fold.fold, Fold.initial, AccessStrategy.LatestKnownEvent, cacheStrategy)
 
 module EventStore =
     open Equinox.EventStoreDb
     let category context =
-        EventStoreCategory(context, Stream.Category, Events.codec, Fold.fold, Fold.initial, AccessStrategy.LatestKnownEvent, Equinox.CachingStrategy.NoCaching)
+        EventStoreCategory(context, Stream.CategoryName, Events.codec, Fold.fold, Fold.initial, AccessStrategy.LatestKnownEvent, Equinox.CachingStrategy.NoCaching)

--- a/samples/Web/Controllers/TodosController.fs
+++ b/samples/Web/Controllers/TodosController.fs
@@ -55,8 +55,8 @@ type TodosController(service: Service) =
 
     [<HttpDelete "{id}">]
     member _.Delete([<FromClientIdHeader>]clientId : ClientId, id): Async<unit> =
-        service.Execute(clientId, Delete id)
+        service.Delete(clientId, id)
 
     [<HttpDelete>]
     member _.DeleteAll([<FromClientIdHeader>]clientId : ClientId): Async<unit> =
-        service.Execute(clientId, Clear)
+        service.Clear(clientId)

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -416,7 +416,7 @@ type private StoreCategory<'event, 'state, 'req>(context: MessageDbContext, code
         context.StoreSnapshot(log, category, streamId, encodedWithMeta, ct)
 
 /// <summary>
-/// The ~ handler will be handed the <c>streamId</c>, <c>state</c>,
+/// The handler will be handed the <c>streamId</c>, <c>state</c>,
 /// and the <c>connection</c> (still in an open transaction) that was used to
 /// append events to the store. This allows you to update other tables
 /// in the same transaction. Use only if you know what you're doing

--- a/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
+++ b/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
@@ -33,9 +33,8 @@ module WiringHelpers =
 /// This is especially relevant when events are spread between a Tip page and preceding pages as the Tip reading logic is special cased compared to querying
 module SequenceCheck =
 
-    module Stream =
-        let [<Literal>] CategoryName = "_SequenceCheck"
-        let id = FsCodec.StreamId.gen (fun (g : Guid) -> g.ToString "N")
+    let [<Literal>] private CategoryName = "_SequenceCheck"
+    let private streamId = FsCodec.StreamId.gen (fun (g : Guid) -> g.ToString "N")
 
     module Events =
 
@@ -72,14 +71,14 @@ module SequenceCheck =
             decider.Transact(decide (value, count), id)
 
     let private create resolve =
-        Service(Stream.id >> resolve)
+        Service(streamId >> resolve)
 
     module Config =
 
         let createUncached log context =
-            createCategoryUnoptimizedUncached Stream.CategoryName Events.codec Fold.initial Fold.fold context |> Equinox.Decider.forStream log |> create
+            createCategoryUnoptimizedUncached CategoryName Events.codec Fold.initial Fold.fold context |> Equinox.Decider.forStream log |> create
         let create log (context, cache) =
-            createCategoryUnoptimized Stream.CategoryName Events.codec Fold.initial Fold.fold (context, cache) |> Equinox.Decider.forStream log |> create
+            createCategoryUnoptimized CategoryName Events.codec Fold.initial Fold.fold (context, cache) |> Equinox.Decider.forStream log |> create
 
 module Props =
     open FsCheck

--- a/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
+++ b/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
@@ -34,7 +34,7 @@ module WiringHelpers =
 module SequenceCheck =
 
     module Stream =
-        let [<Literal>] Category = "_SequenceCheck"
+        let [<Literal>] CategoryName = "_SequenceCheck"
         let id = FsCodec.StreamId.gen (fun (g : Guid) -> g.ToString "N")
 
     module Events =
@@ -77,9 +77,9 @@ module SequenceCheck =
     module Config =
 
         let createUncached log context =
-            createCategoryUnoptimizedUncached Stream.Category Events.codec Fold.initial Fold.fold context |> Equinox.Decider.forStream log |> create
+            createCategoryUnoptimizedUncached Stream.CategoryName Events.codec Fold.initial Fold.fold context |> Equinox.Decider.forStream log |> create
         let create log (context, cache) =
-            createCategoryUnoptimized Stream.Category Events.codec Fold.initial Fold.fold (context, cache) |> Equinox.Decider.forStream log |> create
+            createCategoryUnoptimized Stream.CategoryName Events.codec Fold.initial Fold.fold (context, cache) |> Equinox.Decider.forStream log |> create
 
 module Props =
     open FsCheck

--- a/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
+++ b/tests/Equinox.CosmosStore.Integration/AccessStrategies.fs
@@ -60,13 +60,13 @@ module SequenceCheck =
         then Array.init count (fun i -> Events.Add {| value = start + i |})
         else failwith $"Invalid Add of %d{start} to list %A{state}"
 
-    type Service(resolve : Guid -> Equinox.Decider<Events.Event, Fold.State>) =
+    type Service(resolve: Guid -> Equinox.Decider<Events.Event, Fold.State>) =
 
-        member _.Read(instance : Guid) : Async<int[]> =
+        member _.Read(instance: Guid): Async<int[]> =
             let decider = resolve instance
             decider.Query(id)
 
-        member _.Add(instance : Guid, value : int, count) : Async<int[]> =
+        member _.Add(instance: Guid, value: int, count): Async<int[]> =
             let decider = resolve instance
             decider.Transact(decide (value, count), id)
 

--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -21,27 +21,27 @@ module Cart =
     let codec = Cart.Events.codecJe
 #endif
     let createServiceWithoutOptimization log context =
-        StoreCategory(context, Cart.Stream.Category, codec, fold, initial, AccessStrategy.Unoptimized, Equinox.CachingStrategy.NoCaching)
+        StoreCategory(context, Cart.Stream.CategoryName, codec, fold, initial, AccessStrategy.Unoptimized, Equinox.CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> Cart.create
     /// Trigger looking in Tip (we want those calls to occur, but without leaning on snapshots, which would reduce the paths covered)
     let createServiceWithEmptyUnfolds log context =
         let unfArgs = Cart.Fold.Snapshot.isOrigin, fun _ -> Array.empty
-        StoreCategory(context, Cart.Stream.Category, codec, fold, initial, AccessStrategy.MultiSnapshot unfArgs, Equinox.CachingStrategy.NoCaching)
+        StoreCategory(context, Cart.Stream.CategoryName, codec, fold, initial, AccessStrategy.MultiSnapshot unfArgs, Equinox.CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> Cart.create
     let createServiceWithSnapshotStrategy log context =
-        StoreCategory(context, Cart.Stream.Category, codec, fold, initial, AccessStrategy.Snapshot Cart.Fold.Snapshot.config, Equinox.CachingStrategy.NoCaching)
+        StoreCategory(context, Cart.Stream.CategoryName, codec, fold, initial, AccessStrategy.Snapshot Cart.Fold.Snapshot.config, Equinox.CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> Cart.create
     let createServiceWithSnapshotStrategyAndCaching log context cache =
         let sliding20m = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        StoreCategory(context, Cart.Stream.Category, codec, fold, initial, AccessStrategy.Snapshot Cart.Fold.Snapshot.config, sliding20m)
+        StoreCategory(context, Cart.Stream.CategoryName, codec, fold, initial, AccessStrategy.Snapshot Cart.Fold.Snapshot.config, sliding20m)
         |> Equinox.Decider.forStream log
         |> Cart.create
     let createServiceWithRollingState log context =
         let access = AccessStrategy.RollingState Cart.Fold.Snapshot.generate
-        StoreCategory(context, Cart.Stream.Category, codec, fold, initial, access, Equinox.CachingStrategy.NoCaching)
+        StoreCategory(context, Cart.Stream.CategoryName, codec, fold, initial, access, Equinox.CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> Cart.create
 
@@ -53,7 +53,7 @@ module ContactPreferences =
     let codec = ContactPreferences.Events.codecJe
 #endif
     let private createServiceWithLatestKnownEvent context log cachingStrategy =
-        StoreCategory(context, ContactPreferences.Stream.Category, codec, fold, initial, AccessStrategy.LatestKnownEvent, cachingStrategy)
+        StoreCategory(context, ContactPreferences.Stream.CategoryName, codec, fold, initial, AccessStrategy.LatestKnownEvent, cachingStrategy)
         |> Equinox.Decider.forStream log
         |> ContactPreferences.create
     let createServiceWithoutCaching log context =

--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -68,7 +68,7 @@ type Tests(testOutputHelper) =
     let log, capture = testContext.CreateLoggerWithCapture()
 
     let addAndThenRemoveItems optimistic exceptTheLastOne context cartId skuId (service: Cart.Service) count =
-        service.ExecuteManyAsync(cartId, optimistic, seq {
+        service.SyncItems(cartId, optimistic, seq {
             for i in 1..count do
                 yield (context, skuId, Some i, None)
                 if not exceptTheLastOne || i <> count then
@@ -201,7 +201,7 @@ type Tests(testOutputHelper) =
                     return Some (skuId, addRemoveCount) }
 
         let act prepare (service: Cart.Service) skuId count =
-            service.ExecuteManyAsync(cartId, false, prepare = prepare, items = [ (cartContext, skuId, Some count, None) ])
+            service.SyncItems(cartId, false, prepare = prepare, items = [ (cartContext, skuId, Some count, None) ])
 
         let eventWaitSet () = let e = new ManualResetEvent(false) in (Async.AwaitWaitHandle e |> Async.Ignore), async { e.Set() |> ignore }
         let w0, s0 = eventWaitSet ()
@@ -363,7 +363,7 @@ type Tests(testOutputHelper) =
                     return Some (skuId, addRemoveCount) }
 
         let act prepare (service: Cart.Service) skuId count =
-            service.ExecuteManyAsync(cartId, false, prepare = prepare, items = [ (cartContext, skuId, Some count, None) ])
+            service.SyncItems(cartId, false, prepare = prepare, items = [ (cartContext, skuId, Some count, None) ])
 
         let eventWaitSet () = let e = new ManualResetEvent(false) in (Async.AwaitWaitHandle e |> Async.Ignore), async { e.Set() |> ignore }
         let w0, s0 = eventWaitSet ()
@@ -500,7 +500,7 @@ type Tests(testOutputHelper) =
 
         // While we now have 12 events, we should be able to read them with a single call
         capture.Clear()
-        let! _ = service2.ReadStale cartId
+        let! _ = service2.ReadAnyCachedValue cartId
         // A Stale read doesn't roundtrip
         test <@ [] = capture.ExternalCalls @>
         let! _ = service2.Read cartId

--- a/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
+++ b/tests/Equinox.CosmosStore.Integration/DocumentStoreIntegration.fs
@@ -70,9 +70,9 @@ type Tests(testOutputHelper) =
     let addAndThenRemoveItems optimistic exceptTheLastOne context cartId skuId (service: Cart.Service) count =
         service.ExecuteManyAsync(cartId, optimistic, seq {
             for i in 1..count do
-                yield Cart.SyncItem (context, skuId, Some i, None)
+                yield (context, skuId, Some i, None)
                 if not exceptTheLastOne || i <> count then
-                    yield Cart.SyncItem (context, skuId, Some 0, None) })
+                    yield (context, skuId, Some 0, None) })
     let addAndThenRemoveItemsManyTimes context cartId skuId service count =
         addAndThenRemoveItems false false context cartId skuId service count
     let addAndThenRemoveItemsManyTimesExceptTheLastOne context cartId skuId service count =
@@ -201,7 +201,7 @@ type Tests(testOutputHelper) =
                     return Some (skuId, addRemoveCount) }
 
         let act prepare (service: Cart.Service) skuId count =
-            service.ExecuteManyAsync(cartId, false, prepare = prepare, commands = [Cart.SyncItem (cartContext, skuId, Some count, None)])
+            service.ExecuteManyAsync(cartId, false, prepare = prepare, items = [ (cartContext, skuId, Some count, None) ])
 
         let eventWaitSet () = let e = new ManualResetEvent(false) in (Async.AwaitWaitHandle e |> Async.Ignore), async { e.Set() |> ignore }
         let w0, s0 = eventWaitSet ()
@@ -363,7 +363,7 @@ type Tests(testOutputHelper) =
                     return Some (skuId, addRemoveCount) }
 
         let act prepare (service: Cart.Service) skuId count =
-            service.ExecuteManyAsync(cartId, false, prepare = prepare, commands = [Cart.SyncItem (cartContext, skuId, Some count, None)])
+            service.ExecuteManyAsync(cartId, false, prepare = prepare, items = [ (cartContext, skuId, Some count, None) ])
 
         let eventWaitSet () = let e = new ManualResetEvent(false) in (Async.AwaitWaitHandle e |> Async.Ignore), async { e.Set() |> ignore }
         let w0, s0 = eventWaitSet ()

--- a/tests/Equinox.EventStoreDb.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStoreDb.Integration/StoreIntegration.fs
@@ -107,40 +107,40 @@ module Cart =
     let fold, initial = Cart.Fold.fold, Cart.Fold.initial
     let codec = Cart.Events.codec
     let createServiceWithoutOptimization log context =
-        Category(context, Cart.Stream.Category, codec, fold, initial, AccessStrategy.Unoptimized, Equinox.CachingStrategy.NoCaching)
+        Category(context, Cart.Stream.CategoryName, codec, fold, initial, AccessStrategy.Unoptimized, Equinox.CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> Cart.create
 
     #if STORE_MESSAGEDB
     let snapshot = Cart.Fold.Snapshot.eventCaseName, Cart.Fold.Snapshot.generate
     let createServiceWithAdjacentSnapshotting log context =
-        Category(context, Cart.Stream.Category, codec, fold, initial, AccessStrategy.AdjacentSnapshots snapshot, Equinox.CachingStrategy.NoCaching)
+        Category(context, Cart.Stream.CategoryName, codec, fold, initial, AccessStrategy.AdjacentSnapshots snapshot, Equinox.CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> Cart.create
     #else
     let snapshot = Cart.Fold.Snapshot.config
     let createServiceWithCompaction log context =
-        Category(context, Cart.Stream.Category, codec, fold, initial, AccessStrategy.RollingSnapshots snapshot, Equinox.CachingStrategy.NoCaching)
+        Category(context, Cart.Stream.CategoryName, codec, fold, initial, AccessStrategy.RollingSnapshots snapshot, Equinox.CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> Cart.create
     #endif
 
     let createServiceWithCaching log context cache =
         let sliding20m = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        Category(context, Cart.Stream.Category, codec, fold, initial, AccessStrategy.Unoptimized, caching = sliding20m)
+        Category(context, Cart.Stream.CategoryName, codec, fold, initial, AccessStrategy.Unoptimized, caching = sliding20m)
         |> Equinox.Decider.forStream log
         |> Cart.create
 
     #if STORE_MESSAGEDB
     let createServiceWithSnapshottingAndCaching log context cache =
             let sliding20m = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-            Category(context, Cart.Stream.Category, codec, fold, initial, AccessStrategy.AdjacentSnapshots snapshot, sliding20m)
+            Category(context, Cart.Stream.CategoryName, codec, fold, initial, AccessStrategy.AdjacentSnapshots snapshot, sliding20m)
             |> Equinox.Decider.forStream log
             |> Cart.create
     #else
     let createServiceWithCompactionAndCaching log context cache =
         let sliding20m = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        Category(context, Cart.Stream.Category, codec, fold, initial, AccessStrategy.RollingSnapshots snapshot, sliding20m)
+        Category(context, Cart.Stream.CategoryName, codec, fold, initial, AccessStrategy.RollingSnapshots snapshot, sliding20m)
         |> Equinox.Decider.forStream log
         |> Cart.create
     #endif
@@ -150,12 +150,12 @@ module ContactPreferences =
     let codec = ContactPreferences.Events.codec
     let createServiceWithoutOptimization log connection =
         let context = createContext connection defaultBatchSize
-        Category(context, ContactPreferences.Stream.Category, codec, fold, initial, AccessStrategy.Unoptimized, Equinox.CachingStrategy.NoCaching)
+        Category(context, ContactPreferences.Stream.CategoryName, codec, fold, initial, AccessStrategy.Unoptimized, Equinox.CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> ContactPreferences.create
 
     let createService log connection =
-        Category(createContext connection 1, ContactPreferences.Stream.Category, codec, fold, initial, AccessStrategy.LatestKnownEvent, Equinox.CachingStrategy.NoCaching)
+        Category(createContext connection 1, ContactPreferences.Stream.CategoryName, codec, fold, initial, AccessStrategy.LatestKnownEvent, Equinox.CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> ContactPreferences.create
 

--- a/tests/Equinox.EventStoreDb.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStoreDb.Integration/StoreIntegration.fs
@@ -162,9 +162,9 @@ module ContactPreferences =
 let addAndThenRemoveItems optimistic exceptTheLastOne context cartId skuId (service: Cart.Service) count =
         service.ExecuteManyAsync(cartId, optimistic, seq {
             for i in 1..count do
-                yield Cart.SyncItem (context, skuId, Some i, None)
+                yield (context, skuId, Some i, None)
                 if not exceptTheLastOne || i <> count then
-                    yield Cart.SyncItem (context, skuId, Some 0, None) })
+                    yield (context, skuId, Some 0, None) })
 let addAndThenRemoveItemsManyTimes context cartId skuId service count =
     addAndThenRemoveItems false false context cartId skuId service count
 let addAndThenRemoveItemsManyTimesExceptTheLastOne context cartId skuId service count =
@@ -253,7 +253,7 @@ type GeneralTests(testOutputHelper) =
                     return Some (skuId, addRemoveCount) }
 
         let act prepare (service: Cart.Service) skuId count =
-            service.ExecuteManyAsync(cartId, false, prepare = prepare, commands = [ Cart.SyncItem (ctx, skuId, Some count, None) ])
+            service.ExecuteManyAsync(cartId, false, prepare = prepare, items = [ (ctx, skuId, Some count, None) ])
 
         let eventWaitSet () = let e = new ManualResetEvent(false) in (Async.AwaitWaitHandle e |> Async.Ignore), async { e.Set() |> ignore }
         let w0, s0 = eventWaitSet ()

--- a/tests/Equinox.EventStoreDb.Integration/StoreIntegration.fs
+++ b/tests/Equinox.EventStoreDb.Integration/StoreIntegration.fs
@@ -97,7 +97,7 @@ module SimplestThing =
     let evolve (_state: Event) (event: Event) = event
     let fold = Array.fold evolve
     let initial = StuffHappened
-    let [<Literal>] CategoryName = "SimplestThing"
+    let [<Literal>] private CategoryName = "SimplestThing"
     let streamId = FsCodec.StreamId.gen Guid.toStringN
     let decider log context id =
         let cat = Category(context, CategoryName, codec, fold, initial, AccessStrategy.Unoptimized, Equinox.CachingStrategy.NoCaching)
@@ -107,40 +107,40 @@ module Cart =
     let fold, initial = Cart.Fold.fold, Cart.Fold.initial
     let codec = Cart.Events.codec
     let createServiceWithoutOptimization log context =
-        Category(context, Cart.Stream.CategoryName, codec, fold, initial, AccessStrategy.Unoptimized, Equinox.CachingStrategy.NoCaching)
+        Category(context, Cart.CategoryName, codec, fold, initial, AccessStrategy.Unoptimized, Equinox.CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> Cart.create
 
     #if STORE_MESSAGEDB
     let snapshot = Cart.Fold.Snapshot.eventCaseName, Cart.Fold.Snapshot.generate
     let createServiceWithAdjacentSnapshotting log context =
-        Category(context, Cart.Stream.CategoryName, codec, fold, initial, AccessStrategy.AdjacentSnapshots snapshot, Equinox.CachingStrategy.NoCaching)
+        Category(context, Cart.CategoryName, codec, fold, initial, AccessStrategy.AdjacentSnapshots snapshot, Equinox.CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> Cart.create
     #else
     let snapshot = Cart.Fold.Snapshot.config
     let createServiceWithCompaction log context =
-        Category(context, Cart.Stream.CategoryName, codec, fold, initial, AccessStrategy.RollingSnapshots snapshot, Equinox.CachingStrategy.NoCaching)
+        Category(context, Cart.CategoryName, codec, fold, initial, AccessStrategy.RollingSnapshots snapshot, Equinox.CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> Cart.create
     #endif
 
     let createServiceWithCaching log context cache =
         let sliding20m = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        Category(context, Cart.Stream.CategoryName, codec, fold, initial, AccessStrategy.Unoptimized, caching = sliding20m)
+        Category(context, Cart.CategoryName, codec, fold, initial, AccessStrategy.Unoptimized, caching = sliding20m)
         |> Equinox.Decider.forStream log
         |> Cart.create
 
     #if STORE_MESSAGEDB
     let createServiceWithSnapshottingAndCaching log context cache =
             let sliding20m = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-            Category(context, Cart.Stream.CategoryName, codec, fold, initial, AccessStrategy.AdjacentSnapshots snapshot, sliding20m)
+            Category(context, Cart.CategoryName, codec, fold, initial, AccessStrategy.AdjacentSnapshots snapshot, sliding20m)
             |> Equinox.Decider.forStream log
             |> Cart.create
     #else
     let createServiceWithCompactionAndCaching log context cache =
         let sliding20m = Equinox.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
-        Category(context, Cart.Stream.CategoryName, codec, fold, initial, AccessStrategy.RollingSnapshots snapshot, sliding20m)
+        Category(context, Cart.CategoryName, codec, fold, initial, AccessStrategy.RollingSnapshots snapshot, sliding20m)
         |> Equinox.Decider.forStream log
         |> Cart.create
     #endif
@@ -150,12 +150,12 @@ module ContactPreferences =
     let codec = ContactPreferences.Events.codec
     let createServiceWithoutOptimization log connection =
         let context = createContext connection defaultBatchSize
-        Category(context, ContactPreferences.Stream.CategoryName, codec, fold, initial, AccessStrategy.Unoptimized, Equinox.CachingStrategy.NoCaching)
+        Category(context, ContactPreferences.CategoryName, codec, fold, initial, AccessStrategy.Unoptimized, Equinox.CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> ContactPreferences.create
 
     let createService log connection =
-        Category(createContext connection 1, ContactPreferences.Stream.CategoryName, codec, fold, initial, AccessStrategy.LatestKnownEvent, Equinox.CachingStrategy.NoCaching)
+        Category(createContext connection 1, ContactPreferences.CategoryName, codec, fold, initial, AccessStrategy.LatestKnownEvent, Equinox.CachingStrategy.NoCaching)
         |> Equinox.Decider.forStream log
         |> ContactPreferences.create
 

--- a/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
+++ b/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
@@ -28,7 +28,7 @@ type Tests(testOutputHelper) =
         | Some c -> Some (max 1 c)
 
     [<AutoData>]
-    let ``Basic tracer bullet, sending an pdate and verifying the folded result directly and via a reload``
+    let ``Basic tracer bullet, sending an update and verifying the folded result directly and via a reload``
             cartId1 cartId2 (ctx,skuId,NonZero quantity,waive) = async {
         let store = createMemoryStore ()
         let service = createServiceMemory log store

--- a/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
+++ b/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
@@ -17,7 +17,7 @@ type AutoDataAttribute() =
 let createMemoryStore () = VolatileStore<_>()
 
 let createServiceMemory log store =
-    let cat = MemoryStoreCategory(store, Cart.Stream.CategoryName, FsCodec.Box.Codec.Create(), Cart.Fold.fold, Cart.Fold.initial)
+    let cat = MemoryStoreCategory(store, Cart.CategoryName, FsCodec.Box.Codec.Create(), Cart.Fold.fold, Cart.Fold.initial)
     cat |> Equinox.Decider.forStream log |> Cart.create
 
 type Tests(testOutputHelper) =
@@ -58,7 +58,7 @@ type Tests(testOutputHelper) =
     }
 
 let createFavoritesServiceMemory store log : Favorites.Service =
-    let cat = MemoryStoreCategory(store, Favorites.Stream.CategoryName, FsCodec.Box.Codec.Create(), Favorites.Fold.fold, Favorites.Fold.initial)
+    let cat = MemoryStoreCategory(store, Favorites.CategoryName, FsCodec.Box.Codec.Create(), Favorites.Fold.fold, Favorites.Fold.initial)
     cat |> Equinox.Decider.forStream log |> Favorites.create
 
 type ChangeFeed(testOutputHelper) =
@@ -74,7 +74,7 @@ type ChangeFeed(testOutputHelper) =
             List.ofArray xs
         use _ = store.Committed.Subscribe(fun struct (sn, xs) -> events.Add(FsCodec.StreamName.toString sn, List.ofArray xs))
         let service = createFavoritesServiceMemory store log
-        let expectedStream = Favorites.Stream.name clientId |> FsCodec.StreamName.toString
+        let expectedStream = Favorites.streamName clientId |> FsCodec.StreamName.toString
 
         do! service.Favorite(clientId, [sku])
         let written = takeCaptured ()

--- a/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
+++ b/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
@@ -17,7 +17,7 @@ type AutoDataAttribute() =
 let createMemoryStore () = VolatileStore<_>()
 
 let createServiceMemory log store =
-    let cat = MemoryStoreCategory(store, Cart.Stream.Category, FsCodec.Box.Codec.Create(), Cart.Fold.fold, Cart.Fold.initial)
+    let cat = MemoryStoreCategory(store, Cart.Stream.CategoryName, FsCodec.Box.Codec.Create(), Cart.Fold.fold, Cart.Fold.initial)
     cat |> Equinox.Decider.forStream log |> Cart.create
 
 type Tests(testOutputHelper) =
@@ -58,7 +58,7 @@ type Tests(testOutputHelper) =
     }
 
 let createFavoritesServiceMemory store log : Favorites.Service =
-    let cat = MemoryStoreCategory(store, Favorites.Stream.Category, FsCodec.Box.Codec.Create(), Favorites.Fold.fold, Favorites.Fold.initial)
+    let cat = MemoryStoreCategory(store, Favorites.Stream.CategoryName, FsCodec.Box.Codec.Create(), Favorites.Fold.fold, Favorites.Fold.initial)
     cat |> Equinox.Decider.forStream log |> Favorites.create
 
 type ChangeFeed(testOutputHelper) =

--- a/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
+++ b/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
@@ -36,10 +36,10 @@ type Tests(testOutputHelper) =
 
         // Act: Run the decision twice...
         let actTrappingStateAsSaved cartId =
-            service.Run(cartId, false, [ item ])
+            service.RunInternal(cartId, false, [ item ])
 
         let actLoadingStateSeparately cartId = async {
-            let! _ = service.ExecuteManyAsync(cartId, false, [ item ])
+            let! _ = service.SyncItems(cartId, false, [ item ])
             return! service.Read cartId }
         let! expected = cartId1 |> actTrappingStateAsSaved
         let! actual = cartId2 |> actLoadingStateSeparately

--- a/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
+++ b/tests/Equinox.MemoryStore.Integration/MemoryStoreIntegration.fs
@@ -28,18 +28,18 @@ type Tests(testOutputHelper) =
         | Some c -> Some (max 1 c)
 
     [<AutoData>]
-    let ``Basic tracer bullet, sending a command and verifying the folded result directly and via a reload``
+    let ``Basic tracer bullet, sending an pdate and verifying the folded result directly and via a reload``
             cartId1 cartId2 (ctx,skuId,NonZero quantity,waive) = async {
         let store = createMemoryStore ()
         let service = createServiceMemory log store
-        let command = Cart.SyncItem (ctx,skuId,quantity,waive)
+        let item = (ctx,skuId,quantity,waive)
 
         // Act: Run the decision twice...
         let actTrappingStateAsSaved cartId =
-            service.Run(cartId, false, [command])
+            service.Run(cartId, false, [ item ])
 
         let actLoadingStateSeparately cartId = async {
-            let! _ = service.ExecuteManyAsync(cartId, false, [command])
+            let! _ = service.ExecuteManyAsync(cartId, false, [ item ])
             return! service.Read cartId }
         let! expected = cartId1 |> actTrappingStateAsSaved
         let! actual = cartId2 |> actLoadingStateSeparately

--- a/tests/Equinox.MessageDb.Integration/OnSync.fs
+++ b/tests/Equinox.MessageDb.Integration/OnSync.fs
@@ -4,7 +4,6 @@ open Dapper
 open Domain
 open Equinox.MessageDb
 open Swensen.Unquote
-open Xunit
 
 let defaultBatchSize = 500
 let connectionString = "Host=localhost; Username=postgres; Password=; Database=message_store; Port=5432; Maximum Pool Size=10; Search Path=message_store, public"
@@ -51,7 +50,7 @@ module ContactPreferences =
     let createWithOnSync log connection onSync =
         let access = AccessStrategy.LatestKnownEvent
         let caching = Equinox.CachingStrategy.NoCaching
-        Category(createContext connection 1, ContactPreferences.Stream.CategoryName, codec, fold, initial, access, caching, onSync)
+        Category(createContext connection 1, ContactPreferences.CategoryName, codec, fold, initial, access, caching, onSync)
         |> Equinox.Decider.forStream log
         |> ContactPreferences.create
     let create log connection = createWithOnSync log connection Projection.project

--- a/tests/Equinox.MessageDb.Integration/OnSync.fs
+++ b/tests/Equinox.MessageDb.Integration/OnSync.fs
@@ -51,7 +51,7 @@ module ContactPreferences =
     let createWithOnSync log connection onSync =
         let access = AccessStrategy.LatestKnownEvent
         let caching = Equinox.CachingStrategy.NoCaching
-        Category(createContext connection 1, ContactPreferences.Stream.Category, codec, fold, initial, access, caching, onSync)
+        Category(createContext connection 1, ContactPreferences.Stream.CategoryName, codec, fold, initial, access, caching, onSync)
         |> Equinox.Decider.forStream log
         |> ContactPreferences.create
     let create log connection = createWithOnSync log connection Projection.project

--- a/tools/Equinox.Tool/Tests.fs
+++ b/tools/Equinox.Tool/Tests.fs
@@ -56,7 +56,7 @@ let executeLocal (container: ServiceProvider) test: ClientId -> Async<unit> =
         fun clientId -> async {
             let! items = service.List(clientId)
             if Seq.length items > 1000 then
-                return! service.Execute(clientId, TodoBackend.Command.Clear)
+                return! service.Clear(clientId)
             else
                 let! _ = service.Create(clientId, TodoBackend.Events.Todo.Create size)
                 return ()}


### PR DESCRIPTION
Some of the samples are showing their age...
- There was once a `Handler` that went with the `Service` - while this did separate out technical concerns from Service concerns, the cost of another concept ultimately is not justifiable
- `execute` and `query` helpers are similarly well intentioned and arguably separate things out technical concerns from business logic, but again don't bring enough to justify naming them
- once you lose those technical abstractions, the Command Pattern ceases to add anything