### PR TITLE
feat(CosmosStore)!: Remove bypassCertificateValidation option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,10 +68,10 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 
 - `Equinox.ISyncContext.CreateMemento` [#413](https://github.com/jet/equinox/pull/413)
-- Stores: `*StoreCategory.FromMemento` [#413](https://github.com/jet/equinox/pull/413)
 - Stores: Removed `Equinox.Core` dependency; everything a store needs is either inlined privately, or lives in `Equinox` [#420](https://github.com/jet/equinox/pull/420)
 - Remove explicit `net461` handling; minimum target now `net6.0` / `FSharp.Core` v `6.0.0` [#310](https://github.com/jet/equinox/pull/310) [#323](https://github.com/jet/equinox/pull/323) [#354](https://github.com/jet/equinox/pull/354)
 - Remove `Equinox.Core.ICache` (there is/was only one impl, and the interface has changed as part of [#386](https://github.com/jet/equinox/pull/386)) [#389](https://github.com/jet/equinox/pull/389)
+- `CosmosStore.CosmosStoreConnector`: Removed `bypassCertificateValidation` (superseded by connection string `IgnoreEndpointCertificate`) [#443](https://github.com/jet/equinox/pull/443)
 
 ### Fixed
 

--- a/src/Equinox.CosmosStore/CosmosStore.fs
+++ b/src/Equinox.CosmosStore/CosmosStore.fs
@@ -1194,19 +1194,12 @@ type CosmosStoreConnector
         [<O; D null>] ?mode: ConnectionMode,
         // consistency mode (default: use configuration specified for Database)
         [<O; D null>] ?defaultConsistencyLevel: ConsistencyLevel,
-        // Inhibits certificate verification when set to `true`. Default: false.
-        [<O; D null>] ?bypassCertificateValidation: bool,
         [<O; D null>] ?customize: Action<CosmosClientOptions>) =
     let discoveryMode = discovery.ToDiscoveryMode()
     let factory =
         let o = CosmosClientFactory.CreateDefaultOptions(requestTimeout, maxRetryAttemptsOnRateLimitedRequests, maxRetryWaitTimeOnRateLimitedRequests)
         mode |> Option.iter (fun x -> o.ConnectionMode <- x)
         defaultConsistencyLevel |> Option.iter (fun x -> o.ConsistencyLevel <- x)
-        // https://github.com/Azure/azure-cosmos-dotnet-v3/blob/1ef6e399f114a0fd580272d4cdca86b9f8732cf3/Microsoft.Azure.Cosmos.Samples/Usage/HttpClientFactory/Program.cs#L96
-        if defaultArg bypassCertificateValidation false then
-            let cb = System.Net.Http.HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-            let ch = new System.Net.Http.HttpClientHandler(ServerCertificateCustomValidationCallback = cb)
-            o.HttpClientFactory <- fun () -> new System.Net.Http.HttpClient(ch)
         customize |> Option.iter (fun c -> c.Invoke o)
         CosmosClientFactory o
 


### PR DESCRIPTION
Given the SDK supports a flag in the connection string, apps should stop leaning on this mechanism

See https://github.com/Azure/azure-cosmos-dotnet-v3/issues/4222