### PR TITLE
feat(eqx query cosmos): Add -sn, -o, -P, -C, -m raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `EventStore`: Revise test rig to target a Docker-hosted cluster [#317](https://github.com/jet/equinox/pull/317)
 - `EventStoreDb`: As per `EventStore` module, but using the modern `EventStore.Client.Grpc.Streams` client [#196](https://github.com/jet/equinox/pull/196)
 - `MessageDb`: Implements a [message-db](http://docs.eventide-project.org/user-guide/message-db/) storage backend [#339](https://github.com/jet/equinox/pull/339) with OpenTelemetry tracing and snapshotting support [#348](https://github.com/jet/equinox/pull/348) :pray: [@nordfjord](https://github.com/nordfjord)
-- `eqx init`: `-U/--indexunfolds` enables querying uncompressed unfolds (see `shouldCompress`) [#434](https://github.com/jet/equinox/pull/434)
-- `eqx query`: Queries based on uncompressed unfolds (see `eqx init -U`) [#434](https://github.com/jet/equinox/pull/434)
+- `eqx init --indexUnfolds cosmos`: enables querying uncompressed unfolds (see `shouldCompress`) [#434](https://github.com/jet/equinox/pull/434)
+- `eqx query cosmos`: Queries based on uncompressed unfolds (see `eqx init -U`) [#434](https://github.com/jet/equinox/pull/434)
+- `eqx query -m raw -o FILEPATH cosmos`: Allows capture of raw JSON to a file [#444](https://github.com/jet/equinox/pull/444)
 - `eqx dump`: `-s` flag is now optional
 - `eqx stats`: `-A` flag to request all stats (equivalent to requesting `-ESD`) [#424](https://github.com/jet/equinox/pull/424)
 

--- a/src/Equinox.Tests/CachingTests.fs
+++ b/src/Equinox.Tests/CachingTests.fs
@@ -182,7 +182,7 @@ type Tests() =
         let! struct (_token, state) = allowStale 250 // Delay of 90 overlapped with delay of 50+10 should not have expired the entry (was 200)
         test <@ (4, 1, 3) = (state, cat.Loads, cat.Reloads) @> // The newer cache entry won
         cat.Delay <- TimeSpan.FromMilliseconds 10 // Reduce the delay, but we do want to overlap a write
-        let t4 = allowStale 200 // Delay of 75 in load2/load3 should not have aged the read result beyond 200
+        let t4 = allowStale 300 // Delay of 75 in load2/load3 should not have aged the read result beyond 200
         do! Task.Delay 10 // ensure delay has been picked up, before...
         cat.Delay <- TimeSpan.Zero // no further delays required for the rest of the tests
 


### PR DESCRIPTION
Adds features to `eqx query ... cosmos`:
- `-C`: emit query output to Console
- `-o/--output filepath`: emit CR-delimited JSON showing raw query output
- `-P`: pretty print the output indented over multiple lines
- `-m/--mode raw`: `SELECT *` from matching docs (and show ages)
- `-sn`: specify exact stream name instead of category name or category pattern

Example use cases:
- Useful complement to `eqx dump` for troubleshooting (`eqx query` focuses on the raw JSON and uses CosmosDB queries; `eqx dump` does a read Equivalent to an application-level `Query` call)
- Great for gathering event counts/RU cost stats for tuning/sanity checking
- Also useful for shuffling categories or streams between stores for inspection and/or doing general things that you do via `SELECT INTO` hackery in SQL stores
- the `propulsion-indexer` template's `upconvert` and `sync` commands and/or the `propulsion-sync` templates can be used to import and/or upconvert based on such dumps (NOTE they can of course also identically work from the changefeed)