### PR TITLE
refactor(Tool)!: run->loadTest, config->initSql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `MessageDb`: Implements a [message-db](http://docs.eventide-project.org/user-guide/message-db/) storage backend [#339](https://github.com/jet/equinox/pull/339) with OpenTelemetry tracing and snapshotting support [#348](https://github.com/jet/equinox/pull/348) :pray: [@nordfjord](https://github.com/nordfjord)
 - `eqx init --indexUnfolds cosmos`: enables querying uncompressed unfolds (see `shouldCompress`) [#434](https://github.com/jet/equinox/pull/434)
 - `eqx query cosmos`: Queries based on uncompressed unfolds (see `eqx init -U`) [#434](https://github.com/jet/equinox/pull/434)
-- `eqx query -m raw -o FILEPATH cosmos`: Allows capture of raw JSON to a file [#444](https://github.com/jet/equinox/pull/444)
+- `eqx query -o FILEPATH cosmos`: Allows capture of raw JSON to a file [#444](https://github.com/jet/equinox/pull/444)
 - `eqx dump`: `-s` flag is now optional
 - `eqx stats`: `-A` flag to request all stats (equivalent to requesting `-ESD`) [#424](https://github.com/jet/equinox/pull/424)
 

--- a/README.md
+++ b/README.md
@@ -186,13 +186,13 @@ The components within this repository are delivered as multi-targeted Nuget pack
 
 Equinox does not focus on projection logic - each store brings its own strengths, needs, opportunities and idiosyncrasies. Here's a list of some relevant libraries from sibling projects that get used with regard to this:
 
-- `FsKafka` [![FsKafka NuGet](https://img.shields.io/nuget/v/FsKafka.svg)](https://www.nuget.org/packages/FsKafka/): Wraps `Confluent.Kafka` to provide efficient batched Kafka Producer and Consumer configurations, with basic logging instrumentation. Used in the [`propulsion project kafka`](https://github.com/jet/propulsion#dotnet-tool-provisioning--projections-test-tool) tool command; see [`dotnet new proProjector -k; dotnet new proConsumer` to generate a sample app](https://github.com/jet/dotnet-templates#propulsion-related) using it (see the `BatchedAsync` and `BatchedSync` modules in `Examples.fs`).
+- `FsKafka` [![FsKafka NuGet](https://img.shields.io/nuget/v/FsKafka.svg)](https://www.nuget.org/packages/FsKafka/): Wraps `Confluent.Kafka` to provide efficient batched Kafka Producer and Consumer configurations, with basic logging instrumentation. Used in the [`propulsion sync kafka`](https://github.com/jet/propulsion#dotnet-tool-provisioning--projections-test-tool) tool command; see [`dotnet new proProjector -k; dotnet new proConsumer` to generate a sample app](https://github.com/jet/dotnet-templates#propulsion-related) using it (see the `BatchedAsync` and `BatchedSync` modules in `Examples.fs`).
 - `Propulsion` [![Propulsion NuGet](https://img.shields.io/nuget/v/Propulsion.svg)](https://www.nuget.org/packages/Propulsion/): A library that provides an easy way to implement projection logic. It defines `Propulsion.Streams.StreamEvent` used to interop with `Propulsion.*` in processing pipelines for the `proProjector` and `proSync` templates in the [templates repo](https://github.com/jet/dotnet-templates), together with the `Ingestion`, `Streams`, `Progress` and `Parallel` modules that get composed into those processing pipelines. ([depends](https://www.fuget.org/packages/Propulsion) on `Serilog`)
 - `Propulsion.Cosmos` [![Propulsion.Cosmos NuGet](https://img.shields.io/nuget/v/Propulsion.Cosmos.svg)](https://www.nuget.org/packages/Propulsion.Cosmos/): Wraps the [Microsoft .NET `ChangeFeedProcessor` library](https://github.com/Azure/azure-documentdb-changefeedprocessor-dotnet) providing a [processor loop](DOCUMENTATION.md#change-feed-processors) that maintains a continuous query loop per CosmosDB Physical Partition (Range) yielding new or updated documents (optionally unrolling events written by `Equinox.CosmosStore` for processing or forwarding). ([depends](https://www.fuget.org/packages/Propulsion.Cosmos) on `Equinox.Cosmos`, `Microsoft.Azure.DocumentDb.ChangeFeedProcessor >= 2.2.5`)
-- `Propulsion.CosmosStore` [![Propulsion.CosmosStore NuGet](https://img.shields.io/nuget/v/Propulsion.CosmosStore.svg)](https://www.nuget.org/packages/Propulsion.CosmosStore/): Wraps the CosmosDB V3 SDK's Change Feed API, providing a [processor loop](DOCUMENTATION.md#change-feed-processors) that maintains a continuous query loop per CosmosDB Physical Partition (Range) yielding new or updated documents (optionally unrolling events written by `Equinox.CosmosStore` for processing or forwarding). Used in the [`propulsion project stats cosmos`](dotnet-tool-provisioning--benchmarking-tool) tool command; see [`dotnet new proProjector` to generate a sample app](#quickstart) using it. ([depends](https://www.fuget.org/packages/Propulsion.CosmosStore) on `Equinox.CosmosStore`)
+- `Propulsion.CosmosStore` [![Propulsion.CosmosStore NuGet](https://img.shields.io/nuget/v/Propulsion.CosmosStore.svg)](https://www.nuget.org/packages/Propulsion.CosmosStore/): Wraps the CosmosDB V3 SDK's Change Feed API, providing a [processor loop](DOCUMENTATION.md#change-feed-processors) that maintains a continuous query loop per CosmosDB Physical Partition (Range) yielding new or updated documents (optionally unrolling events written by `Equinox.CosmosStore` for processing or forwarding). Used in the [`propulsion sync stats from cosmos`](dotnet-tool-provisioning--benchmarking-tool) tool command; see [`dotnet new proProjector` to generate a sample app](#quickstart) using it. ([depends](https://www.fuget.org/packages/Propulsion.CosmosStore) on `Equinox.CosmosStore`)
 - `Propulsion.DynamoStore` [![Propulsion.DynamoStore NuGet](https://img.shields.io/nuget/v/Propulsion.DynamoStore.svg)](https://www.nuget.org/packages/Propulsion.DynamoStore/): Provides a `DynamoStoreSource` that provides equivalent functionality to `Propulsion.CosmosStore` in concert with `Propulsion.DynamoStore.Lambda`; ([depends](https://www.fuget.org/packages/Propulsion.DynamoStore) on `Equinox.DynamoStore`)
 - `Propulsion.DynamoStore.Lambda` [![Propulsion.DynamoStore.Lambda NuGet](https://img.shields.io/nuget/v/Propulsion.DynamoStore.Lambda.svg)](https://www.nuget.org/packages/Propulsion.DynamoStore.Lambda/): Indexes events written by `Equinox.DynamoStore` via a DynamoDB Streams-triggered Lambda. (Depends on `Propulsion.DynamoStore`)
-- `Propulsion.EventStore` [![Propulsion.EventStore NuGet](https://img.shields.io/nuget/v/Propulsion.EventStore.svg)](https://www.nuget.org/packages/Propulsion.EventStore/) Used in the [`propulsion project es`](dotnet-tool-provisioning--benchmarking-tool) tool command; see [`dotnet new proSync` to generate a sample app](#quickstart) using it. ([depends](https://www.fuget.org/packages/Propulsion.EventStore) on `Equinox.EventStore`)
+- `Propulsion.EventStore` [![Propulsion.EventStore NuGet](https://img.shields.io/nuget/v/Propulsion.EventStore.svg)](https://www.nuget.org/packages/Propulsion.EventStore/) Used in the [`propulsion sync stats from es`](dotnet-tool-provisioning--benchmarking-tool) tool command; see [`dotnet new proSync` to generate a sample app](#quickstart) using it. ([depends](https://www.fuget.org/packages/Propulsion.EventStore) on `Equinox.EventStore`)
 - `Propulsion.EventStoreDb` [![Propulsion.EventStoreDb NuGet](https://img.shields.io/nuget/v/Propulsion.EventStoreDb.svg)](https://www.nuget.org/packages/Propulsion.EventStoreDb/) Consumes from `EventStoreDB` v `21.10` or later using the gRPC interface. ([depends](https://www.fuget.org/packages/Propulsion.EventStoreDb) on `Equinox.EventStoreDb`)
 - `Propulsion.MessageDb` [![Propulsion.MessageDb NuGet](https://img.shields.io/nuget/v/Propulsion.MessageDb.svg)](https://www.nuget.org/packages/Propulsion.MessageDb) Consumes from a `MessageDB` store (in Postgres) using `Npgsql`. ([depends](https://www.fuget.org/packages/Propulsion.MessageDb) on `Npgsql`, `Propulsion.Feed`)
 - `Propulsion.Kafka` [![Propulsion.Kafka NuGet](https://img.shields.io/nuget/v/Propulsion.Kafka.svg)](https://www.nuget.org/packages/Propulsion.Kafka/): Provides a canonical `RenderedSpan` that can be used as a default format when projecting events via e.g. the Producer/Consumer pair in `dotnet new proProjector -k; dotnet new proConsumer`. ([depends](https://www.fuget.org/packages/Propulsion.Kafka) on `Newtonsoft.Json >= 11.0.2`, `Propulsion`, `FsKafka`)
@@ -204,7 +204,7 @@ Equinox does not focus on projection logic - each store brings its own strengths
     - can render events from any of the stores via `eqx dump`.
     - incorporates a benchmark scenario runner, running load tests composed of transactions in `samples/Store` and `samples/TodoBackend` against any supported store; this allows perf tuning and measurement in terms of both latency and transaction charge aspects. (Install via: `dotnet tool install Equinox.Tool -g`)
     - can configure indices in Azure CosmosDB for an `Equinox.CosmosStore` Container via `eqx init`. See [here](#store-data-in-azure-cosmosdb).
-    - can search for streams based on name (`p`) or Uncompressed `u`nfold values for an `Equinox.CosmosStore` Container in Azure CosmosDB`. See [here](#eqx-query).
+    - can search for streams and/or perform a JSON export based on name (`p`) or Uncompressed `u`nfold values for an `Equinox.CosmosStore` Container in Azure CosmosDB`. See [here](#eqx-query).
     - can create tables in Amazon DynamoDB for `Equinox.DynamoStore` via `eqx initaws`.
     - can initialize databases for `SqlStreamStore` via `eqx initsql`
 
@@ -360,7 +360,7 @@ While Equinox is implemented in F#, and F# is a great fit for writing event-sour
 
     ```powershell
     dotnet tool uninstall Equinox.Tool -g
-    dotnet tool install Equinox.Tool -g
+    dotnet tool install Equinox.Tool -g --prerelease
     eqx init -ru 400 cosmos # generates a database+container, adds optimized indexes
     ```
 
@@ -408,7 +408,7 @@ While Equinox is implemented in F#, and F# is a great fit for writing event-sour
     # > TOTALS 0c, 0s, 2.80RU 0.7s {} # 👈 only 2.8RU if nothing is returned
    
     # DUMP ONE STREAM TO A FILE (equivalent to queries performed by CosmosStore.AccessStrategy.Unoptimized)
-    # Can be imported into another store via https://github.com/jet/dotnet-templates/blob/master/propulsion-indexer
+    # Can be imported into another store via `propulsion sync cosmos from json`
     eqx query -m readOnly -sn 'user-f28fb6feea00550e93ca77b6f29899cd' -o dump-user.json cosmos -d db -c $EQUINOX_COSMOS_CONTAINER -b 9999
     # > Dumping Raw content to ./dump-user.json {}
     # > Querying Raw: SELECT * FROM c WHERE c.p = "user-f28fb6feea00550e93ca77b6f29899cd" AND 1=1 {}
@@ -416,7 +416,7 @@ While Equinox is implemented in F#, and F# is a great fit for writing event-sour
     # > TOTALS 1c, 9s, 3.23RU R/W 0.0/0.0MiB 3.9s {}
  
     # DUMP FULL CONTENT OF THE CONTAINER TO A FILE
-    # Can be imported into another store via https://github.com/jet/dotnet-templates/blob/master/propulsion-indexer
+    # Can be imported into another store via `propulsion sync cosmos from json`
     eqx query -m raw -o ../dump-240216.json -m raw cosmos -d db -c $EQUINOX_COSMOS_CONTAINER -b 9999                             
     # > Dumping Raw content to ~/dumps/dump-240216.json {}
     # > No StreamName or CategoryName/CategoryLike specified - Unfold Criteria better be unambiguous {}
@@ -432,18 +432,18 @@ While Equinox is implemented in F#, and F# is a great fit for writing event-sour
     # > TOTALS 11c, 206,356s, 7,886.75RU R/W 290.4/290.4MiB 225.3s {}
     ```
 
-6. Use `propulsion` tool to run a CosmosDB ChangeFeedProcessor
+6. Use `propulsion sync` tool to run a CosmosDB ChangeFeedProcessor
 
     ```powershell
     dotnet tool uninstall Propulsion.Tool -g
-    dotnet tool install Propulsion.Tool -g
+    dotnet tool install Propulsion.Tool -g --prerelease
 
     propulsion init -ru 400 cosmos # generates a -aux container for the ChangeFeedProcessor to maintain consumer group progress within
     # -V for verbose ChangeFeedProcessor logging
     # `-g projector1` represents the consumer group - >=1 are allowed, allowing multiple independent projections to run concurrently
     # stats specifies one only wants stats regarding items (other options include `kafka` to project to Kafka)
     # cosmos specifies source overrides (using defaults in step 1 in this instance)
-    propulsion -V project -g projector1 stats cosmos
+    propulsion -V sync -g projector1 stats from cosmos
     ```
 
 7. Generate a CosmosDB ChangeFeedProcessor sample `.fsproj` (without Kafka producer/consumer), using `Propulsion.CosmosStore`
@@ -469,7 +469,7 @@ While Equinox is implemented in F#, and F# is a great fit for writing event-sour
     # `kafka` specifies one wants to emit to Kafka	
     # `temp-topic` is the topic to emit to	
     # `cosmos` specifies source overrides (using defaults in step 1 in this instance)	
-    propulsion -V project -g projector3 -l 5 kafka temp-topic cosmos	
+    propulsion -V sync -g projector3 -l 5 kafka temp-topic from cosmos	
     ```	
 
 9. Generate CosmosDB [Kafka Projector and Consumer](https://github.com/jet/propulsion#feeding-to-kafka) `.fsproj`ects (using `Propulsion.Kafka`)
@@ -544,7 +544,7 @@ While Equinox is implemented in F#, and F# is a great fit for writing event-sour
 
 SqlStreamStore is provided in the samples and the `eqx` tool:
 
-- being able to supply `ms`, `my`, `pg` flag to `eqx loadTest`, e.g. `eqx loadTest -t cart -f 50 -d 5 -C -U ms -c "sqlserverconnectionstring" -s schema`
+- being able to supply `ms`, `my`, `pg` flag to `eqx loadtest`, e.g. `eqx loadtest -t cart -f 50 -d 5 -C -U ms -c "sqlserverconnectionstring" -s schema`
 - being able to supply `ms`, `my`, `pg` flag to `eqx dump`, e.g. `eqx dump -CU "Favorites-ab25cc9f24464d39939000aeb37ea11a" ms -c "sqlserverconnectionstring" -s schema`
 - being able to supply `ms`, `my`, `pg` flag to Web sample, e.g. `dotnet run --project samples/Web/ -- my -c "mysqlconnectionstring"`
 - being able to supply `ms`, `my`, `pg` flag to new `eqx initsql` command e.g. `eqx initsql pg -c "postgresconnectionstring" -u p "usercredentialsNotToBeLogged" -s schema`
@@ -553,10 +553,10 @@ SqlStreamStore is provided in the samples and the `eqx` tool:
 cd ~/code/equinox
 
 # set up the DB/schema
-dotnet run --project tools/Equinox.Tool -- config pg -c "connectionstring" -p "u=un;p=password" -s "schema"
+dotnet run --project tools/Equinox.Tool -- initsql pg -c "connectionstring" -p "u=un;p=password" -s "schema"
 
 # run a benchmark
-dotnet run -c Release --project tools/Equinox.Tool -- run -t saveforlater -f 50 -d 5 -C -U pg -c "connectionstring" -p "u=un;p=password" -s "schema"
+dotnet run -c Release --project tools/Equinox.Tool -- loadtest -t saveforlater -f 50 -d 5 -C -U pg -c "connectionstring" -p "u=un;p=password" -s "schema"
 
 # run the webserver, -A to autocreate schema on connection
 dotnet run --project samples/Web/ -- my -c "mysqlconnectionstring" -A
@@ -628,14 +628,14 @@ DynamoDB is supported in the samples and the `eqx` tool equivalent to the Cosmos
     dotnet run --project tools/Equinox.Tool -- stats dynamo -t TableName -sr us-east-1
    
     # run a benchmark
-    dotnet run -c Release --project tools/Equinox.Tool -- run -t saveforlater -f 50 -d 5 -CU dynamo
+    dotnet run -c Release --project tools/Equinox.Tool -- loadtest -t saveforlater -f 50 -d 5 -CU dynamo
 
     # run the webserver
     dotnet run --project samples/Web/ -- dynamo -t TableName
 
     # run a benchmark connecting to the webserver
     eqx loadtest -t saveforlater -f 50 -d 5 -CU web
-    eqx dump "SavedForLater-ab25cc9f24464d39939000aeb37ea11a" dynamo # show stored JSON (Guid shown in eqx loadTest output) 
+    eqx dump "SavedForLater-ab25cc9f24464d39939000aeb37ea11a" dynamo # show stored JSON (Guid shown in eqx loadtest output) 
     ```
 
 3. Useful articles
@@ -687,7 +687,7 @@ Run, including running the tests that assume you've got a local EventStore and p
 
 At present, .NET Core seems to show comparable perf under normal load, but becomes very unpredictable under load. The following benchmark should produce pretty consistent levels of reads and writes, and can be used as a baseline for investigation:
 
-    & dotnet run -c Release --project tools/Equinox.Tool -- run -t saveforlater -f 1000 -d 5 -C -U es
+    & dotnet run -c Release --project tools/Equinox.Tool -- loadtest -t saveforlater -f 1000 -d 5 -C -U es
 
 ### run Web benchmark
 
@@ -699,12 +699,12 @@ The CLI can drive the Store and TodoBackend samples in the `samples/Web` ASP.NET
 
 #### in Window 2
 
-    dotnet tool install -g Equinox.Tool # only once
+    dotnet tool install -g Equinox.Tool --prerelease # only once
     eqx loadtest -t saveforlater -f 200 web
 
 ### run CosmosDB benchmark (when provisioned)
 
-    dotnet run --project tools/Equinox.Tool -- run `
+    dotnet run --project tools/Equinox.Tool -- loadtest `
       cosmos -s $env:EQUINOX_COSMOS_CONNECTION -d $env:EQUINOX_COSMOS_DATABASE -c $env:EQUINOX_COSMOS_CONTAINER
 
 ## PROVISIONING

--- a/README.md
+++ b/README.md
@@ -409,15 +409,15 @@ While Equinox is implemented in F#, and F# is a great fit for writing event-sour
    
     # DUMP ONE STREAM TO A FILE (equivalent to queries performed by CosmosStore.AccessStrategy.Unoptimized)
     # Can be imported into another store via `propulsion sync cosmos from json`
-    eqx query -m readOnly -sn 'user-f28fb6feea00550e93ca77b6f29899cd' -o dump-user.json cosmos -d db -c $EQUINOX_COSMOS_CONTAINER -b 9999
+    eqx query -sn 'user-f28fb6feea00550e93ca77b6f29899cd' -o dump-user.json cosmos -d db -c $EQUINOX_COSMOS_CONTAINER -b 9999
     # > Dumping Raw content to ./dump-user.json {}
     # > Querying Raw: SELECT * FROM c WHERE c.p = "user-f28fb6feea00550e93ca77b6f29899cd" AND 1=1 {}
-    # > Page 9s, 1u, 10e 3.23RU 0.5s 0.0MiB age 0002.10:04:13 {}
+    # > Page 9s, 1u, 10e 3.23RU 0.5s 0.0MiB age 0002.10:04:13 {} # 👈 2.80 if no results, adds per KiB charge if there are results 
     # > TOTALS 1c, 9s, 3.23RU R/W 0.0/0.0MiB 3.9s {}
  
     # DUMP FULL CONTENT OF THE CONTAINER TO A FILE
     # Can be imported into another store via `propulsion sync cosmos from json`
-    eqx query -m raw -o ../dump-240216.json -m raw cosmos -d db -c $EQUINOX_COSMOS_CONTAINER -b 9999                             
+    eqx query -o ../dump-240216.json cosmos -d db -c $EQUINOX_COSMOS_CONTAINER -b 9999                             
     # > Dumping Raw content to ~/dumps/dump-240216.json {}
     # > No StreamName or CategoryName/CategoryLike specified - Unfold Criteria better be unambiguous {}
     # > Querying Raw: SELECT * FROM c WHERE 1=1 AND 1=1 {}

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Equinox does not focus on projection logic - each store brings its own strengths
     - can configure indices in Azure CosmosDB for an `Equinox.CosmosStore` Container via `eqx init`. See [here](#store-data-in-azure-cosmosdb).
     - can search for streams based on name (`p`) or Uncompressed `u`nfold values for an `Equinox.CosmosStore` Container in Azure CosmosDB`. See [here](#eqx-query).
     - can create tables in Amazon DynamoDB for `Equinox.DynamoStore` via `eqx initaws`.
-    - can initialize databases for `SqlStreamStore` via `eqx config`
+    - can initialize databases for `SqlStreamStore` via `eqx initsql`
 
 ## Starter Project Templates and Sample Applications 
 
@@ -544,10 +544,10 @@ While Equinox is implemented in F#, and F# is a great fit for writing event-sour
 
 SqlStreamStore is provided in the samples and the `eqx` tool:
 
-- being able to supply `ms`, `my`, `pg` flag to `eqx run`, e.g. `eqx run -t cart -f 50 -d 5 -C -U ms -c "sqlserverconnectionstring" -s schema`
+- being able to supply `ms`, `my`, `pg` flag to `eqx loadTest`, e.g. `eqx loadTest -t cart -f 50 -d 5 -C -U ms -c "sqlserverconnectionstring" -s schema`
 - being able to supply `ms`, `my`, `pg` flag to `eqx dump`, e.g. `eqx dump -CU "Favorites-ab25cc9f24464d39939000aeb37ea11a" ms -c "sqlserverconnectionstring" -s schema`
 - being able to supply `ms`, `my`, `pg` flag to Web sample, e.g. `dotnet run --project samples/Web/ -- my -c "mysqlconnectionstring"`
-- being able to supply `ms`, `my`, `pg` flag to new `eqx config` command e.g. `eqx config pg -c "postgresconnectionstring" -u p "usercredentialsNotToBeLogged" -s schema`
+- being able to supply `ms`, `my`, `pg` flag to new `eqx initsql` command e.g. `eqx initsql pg -c "postgresconnectionstring" -u p "usercredentialsNotToBeLogged" -s schema`
 
 ```powershell
 cd ~/code/equinox
@@ -562,11 +562,11 @@ dotnet run -c Release --project tools/Equinox.Tool -- run -t saveforlater -f 50 
 dotnet run --project samples/Web/ -- my -c "mysqlconnectionstring" -A
 
 # set up the DB/schema
-eqx config pg -c "connectionstring" -p "u=un;p=password" -s "schema"
+eqx initsql pg -c "connectionstring" -p "u=un;p=password" -s "schema"
 
 # run a benchmark
-eqx run -t saveforlater -f 50 -d 5 -C -U pg -c "connectionstring" -p "u=un;p=password" -s "schema" 
-eqx dump "SavedForLater-ab25cc9f24464d39939000aeb37ea11a" pg -c "connectionstring" -p "u=un;p=password" -s "schema" # show stored JSON (Guid shown in eqx run output) 
+eqx loadtest -t saveforlater -f 50 -d 5 -C -U pg -c "connectionstring" -p "u=un;p=password" -s "schema" 
+eqx dump "SavedForLater-ab25cc9f24464d39939000aeb37ea11a" pg -c "connectionstring" -p "u=un;p=password" -s "schema" # show stored JSON (Guid shown in eqx loadtest output) 
 ```
 
 <a name="message-db"></a>
@@ -574,7 +574,7 @@ eqx dump "SavedForLater-ab25cc9f24464d39939000aeb37ea11a" pg -c "connectionstrin
 
 MessageDb support is provided in the samples and the `eqx` tool:
 
-- being able to supply `mdb` flag to `eqx run`, e.g. `eqx run -f 50 -d 5 -C -U mdb -c "pgconnectionstring"`
+- being able to supply `mdb` flag to `eqx loadtest`, e.g. `eqx loadtest -f 50 -d 5 -C -U mdb -c "pgconnectionstring"`
 - being able to supply `mdb` flag to `eqx dump`, e.g. `eqx dump -CU "Favorites-ab25cc9f24464d39939000aeb37ea11a" mdb -c "pgconnectionstring"`
 - being able to supply `mdb` flag to Web sample, e.g. `dotnet run --project samples/Web/ -- mdb -c "pgconnectionstring"`
 
@@ -597,7 +597,7 @@ In addition to the default access strategy of reading the whole stream forwards 
 ### Use [Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Introduction.html)
 
 DynamoDB is supported in the samples and the `eqx` tool equivalent to the CosmosDB support as described:
-- being able to supply `dynamo` source to `eqx run` wherever `cosmos` works, e.g. `eqx run -t cart -f 50 -d 5 -CU dynamo -s http://localhost:8000 -t TableName`
+- being able to supply `dynamo` source to `eqx loadtest` wherever `cosmos` works, e.g. `eqx loadtest -t cart -f 50 -d 5 -CU dynamo -s http://localhost:8000 -t TableName`
 - being able to supply `dynamo` flag to `eqx dump`, e.g. `eqx dump -CU "Favorites-ab25cc9f24464d39939000aeb37ea11a" dynamo`
 - being able to supply `dynamo` flag to Web sample, e.g. `dotnet run --project samples/Web/ -- dynamo -s http://localhost:8000`
 - being able to supply `dynamo` flag to `eqx initaws` command e.g. `eqx initaws -r 10 -w 10 -s new dynamo -t TableName`
@@ -634,8 +634,8 @@ DynamoDB is supported in the samples and the `eqx` tool equivalent to the Cosmos
     dotnet run --project samples/Web/ -- dynamo -t TableName
 
     # run a benchmark connecting to the webserver
-    eqx run -t saveforlater -f 50 -d 5 -CU web
-    eqx dump "SavedForLater-ab25cc9f24464d39939000aeb37ea11a" dynamo # show stored JSON (Guid shown in eqx run output) 
+    eqx loadtest -t saveforlater -f 50 -d 5 -CU web
+    eqx dump "SavedForLater-ab25cc9f24464d39939000aeb37ea11a" dynamo # show stored JSON (Guid shown in eqx loadTest output) 
     ```
 
 3. Useful articles
@@ -700,7 +700,7 @@ The CLI can drive the Store and TodoBackend samples in the `samples/Web` ASP.NET
 #### in Window 2
 
     dotnet tool install -g Equinox.Tool # only once
-    eqx run -t saveforlater -f 200 web
+    eqx loadtest -t saveforlater -f 200 web
 
 ### run CosmosDB benchmark (when provisioned)
 

--- a/samples/Infrastructure/Infrastructure.fsproj
+++ b/samples/Infrastructure/Infrastructure.fsproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="6.0.7" ExcludeAssets="contentfiles" />
     
-    <PackageReference Include="Argu" Version="6.1.4" />
+    <PackageReference Include="Argu" Version="6.2.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 

--- a/samples/Store/Domain/Infrastructure.fs
+++ b/samples/Store/Domain/Infrastructure.fs
@@ -86,7 +86,9 @@ module CartId = let toString (value: CartId): string = Guid.toStringN %value
 /// ClientId strongly typed id; represented internally as a Guid; not used for storage so rendering is not significant
 type ClientId = Guid<clientId>
 and [<Measure>] clientId
-module ClientId = let toString (value: ClientId): string = Guid.toStringN %value
+module ClientId =
+    let gen (): ClientId = Guid.gen () |> UMX.tag
+    let toString (value: ClientId): string = Guid.toStringN %value
 
 /// InventoryItemId strongly typed id
 type InventoryItemId = Guid<inventoryItemId>

--- a/samples/Web/Program.fs
+++ b/samples/Web/Program.fs
@@ -23,7 +23,7 @@ let createWebHostBuilder (args, parsed) : IWebHostBuilder =
 [<EntryPoint>]
 let main argv =
     try printfn "Running at pid %d" (System.Diagnostics.Process.GetCurrentProcess().Id)
-        let p = Arguments.parse argv
+        let p = Arguments.Parse argv
         // Replace logger chain with https://github.com/serilog/serilog-aspnetcore
         let c =
             LoggerConfiguration()
@@ -39,5 +39,5 @@ let main argv =
             createWebHostBuilder(argv, p).Build().Run()
             0
         finally Log.CloseAndFlush()
-    with :? ArguParseException as e -> eprintfn "%s" e.Message; 1
-        | e -> eprintfn "EXCEPTION: %O" e; 1
+    with :? ArguParseException as e -> eprintfn $"%s{e.Message}"; 1
+        | e -> eprintfn $"EXCEPTION: %O{e}"; 1

--- a/samples/Web/Startup.fs
+++ b/samples/Web/Startup.fs
@@ -36,10 +36,7 @@ type Arguments =
             | MySql _ ->                    "specify storage in MySql (--help for options)."
             | Postgres _ ->                 "specify storage in Postgres (--help for options)."
             | Memory _ ->                   "specify In-Memory Volatile Store (Default store)."
-module Arguments =
-    let parse argv =
-        let programName = System.Reflection.Assembly.GetEntryAssembly().GetName().Name
-        ArgumentParser.Create<Arguments>(programName = programName).ParseCommandLine(argv)
+    static member Parse argv = ArgumentParser.Create<Arguments>().ParseCommandLine(argv)
 
 type App = class end
 

--- a/tools/Equinox.Tool/Infrastructure/Infrastructure.fs
+++ b/tools/Equinox.Tool/Infrastructure/Infrastructure.fs
@@ -1,5 +1,5 @@
 ﻿[<AutoOpen>]
-module internal Equinox.Tool.Infrastructure.Prelude
+module Equinox.Tool.Infrastructure
 
 open Equinox.Tools.TestHarness.HttpHelpers
 open System

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -130,16 +130,16 @@ and [<NoComparison; NoEquality; RequireSubcommand>] QueryParameters =
             | UnfoldCriteria _ ->           "Specify constraints on Unfold (reference unfold fields via `u.d.`, top level fields via `c.`), e.g. `u.d.name = \"TenantName1\"`."
             | Mode _ ->                     "readOnly: Only read `u`nfolds, not `_etag`.\n" +
                                             "readWithStream: Read `u`nfolds and `p` (stream name), but not `_etag`.\n" +
-                                            "default: Retrieve full data (p, u, _etag).\n" +
-                                            "raw: Read all Items(documents) in full.\n"
-            | File _ ->                     "Export retrieved JSON to file"
+                                            "default: Retrieve full data (p, u, _etag). <- Default for normal queries\n" +
+                                            "raw: Read all Items(documents) in full. <- Default when Output File specified\n"
+            | File _ ->                     "Export full retrieved JSON to file. NOTE this switches the default mode to `Raw`"
             | Pretty ->                     "Render the JSON indented over multiple lines"
-            | Console ->                    "Also emit the JSON to the console. Default: Gather statistics (and, optionally, write to specified file)"
+            | Console ->                    "Also emit the JSON to the console. Default: Gather statistics (but only write to a File if specified)"
             | Cosmos _ ->                   "Parameters for CosmosDB."
 and [<RequireQualifiedAccess>] Mode = ReadOnly | ReadWithStream | Default | Raw
 and [<RequireQualifiedAccess>] Criteria = SingleStream of string | CatName of string | CatLike of string | Unfiltered
 and QueryArguments(p: ParseResults<QueryParameters>) =
-    member val Mode = p.GetResult(Mode, Mode.Default)
+    member val Mode = p.GetResult(Mode, if p.Contains File then Mode.Raw else Mode.Default)
     member val Pretty = p.Contains QueryParameters.Pretty
     member val TeeConsole = p.Contains Console
     member val Criteria =

--- a/tools/Equinox.Tool/Program.fs
+++ b/tools/Equinox.Tool/Program.fs
@@ -1,16 +1,11 @@
 ﻿module Equinox.Tool.Program
 
 open Argu
-open Equinox.Tool.Infrastructure
 open FSharp.AWS.DynamoDB // Throughput
-open FSharp.Control
-open FSharp.UMX
-open Microsoft.Extensions.DependencyInjection
 open Samples.Infrastructure
 open Serilog
 open Serilog.Events
 open System
-open System.Net.Http
 open System.Threading
 
 module CosmosInit = Equinox.CosmosStore.Core.Initialization
@@ -24,7 +19,7 @@ type Parameters =
     | [<AltCommandLine "-S"; Unique>]       LocalSeq
     | [<AltCommandLine "-l"; Unique>]       LogFile of string
     | [<CliPrefix(CliPrefix.None); Last>]   Dump of ParseResults<DumpParameters>
-    | [<CliPrefix(CliPrefix.None); Last>]   LoadTest of ParseResults<LoadTestParameters>
+    | [<CliPrefix(CliPrefix.None); Last>]   LoadTest of ParseResults<Tests.LoadTest.LoadTestParameters>
     | [<CliPrefix(CliPrefix.None); Last>]   Init of ParseResults<InitParameters>
     | [<CliPrefix(CliPrefix.None); Last>]   InitAws of ParseResults<TableParameters>
     | [<CliPrefix(CliPrefix.None); Last>]   InitSql of ParseResults<InitSqlParameters>
@@ -227,93 +222,6 @@ and DumpArguments(p: ParseResults<DumpParameters>) =
             let storeLog = createStoreLog false
             storeLog, Store.MessageDb.config log None p
         | x -> p.Raise $"unexpected subcommand %A{x}"
-and [<NoComparison>] WebParameters =
-    | [<AltCommandLine "-u">]               Endpoint of string
-    interface IArgParserTemplate with
-        member a.Usage = a |> function
-            | Endpoint _ ->                 "Target address. Default: https://localhost:5001"
-and [<NoComparison; NoEquality; RequireSubcommand>] LoadTestParameters =
-    | [<AltCommandLine "-t"; Unique>]       Name of Test
-    | [<AltCommandLine "-s">]               Size of int
-    | [<AltCommandLine "-C">]               Cached
-    | [<AltCommandLine "-U">]               Unfolds
-    | [<AltCommandLine "-f">]               TestsPerSecond of int
-    | [<AltCommandLine "-d">]               DurationM of float
-    | [<AltCommandLine "-e">]               ErrorCutoff of int64
-    | [<AltCommandLine "-i">]               ReportIntervalS of int
-    | [<CliPrefix(CliPrefix.None); Last>]                      Cosmos    of ParseResults<Store.Cosmos.Parameters>
-    | [<CliPrefix(CliPrefix.None); Last>]                      Dynamo    of ParseResults<Store.Dynamo.Parameters>
-    | [<CliPrefix(CliPrefix.None); Last>]                      Es        of ParseResults<Store.EventStore.Parameters>
-    | [<CliPrefix(CliPrefix.None); Last>]                      Memory    of ParseResults<Store.MemoryStore.Parameters>
-    | [<CliPrefix(CliPrefix.None); Last; AltCommandLine "ms">] MsSql     of ParseResults<Store.Sql.Ms.Parameters>
-    | [<CliPrefix(CliPrefix.None); Last; AltCommandLine "my">] MySql     of ParseResults<Store.Sql.My.Parameters>
-    | [<CliPrefix(CliPrefix.None); Last; AltCommandLine "pg">] Postgres  of ParseResults<Store.Sql.Pg.Parameters>
-    | [<CliPrefix(CliPrefix.None); Last>]                      Mdb       of ParseResults<Store.MessageDb.Parameters>
-    | [<CliPrefix(CliPrefix.None); Last>]                      Web       of ParseResults<WebParameters>
-    interface IArgParserTemplate with
-        member a.Usage = a |> function
-            | Name _ ->                     "specify which test to run. (default: Favorite)."
-            | Size _ ->                     "For `-t Todo`: specify random title length max size to use (default 100)."
-            | Cached ->                     "employ a 50MB cache, wire in to Stream configuration."
-            | Unfolds ->                    "employ a store-appropriate Rolling Snapshots and/or Unfolding strategy."
-            | TestsPerSecond _ ->           "specify a target number of requests per second (default: 1000)."
-            | DurationM _ ->                "specify a run duration in minutes (default: 30)."
-            | ErrorCutoff _ ->              "specify an error cutoff; test ends when exceeded (default: 10000)."
-            | ReportIntervalS _ ->          "specify reporting intervals in seconds (default: 10)."
-            | Es _ ->                       "Run transactions in-process against EventStore."
-            | Cosmos _ ->                   "Run transactions in-process against CosmosDB."
-            | Dynamo _ ->                   "Run transactions in-process against DynamoDB."
-            | Memory _ ->                   "target in-process Transient Memory Store (Default if not other target specified)."
-            | MsSql _ ->                    "Run transactions in-process against Sql Server."
-            | MySql _ ->                    "Run transactions in-process against MySql."
-            | Postgres _ ->                 "Run transactions in-process against Postgres."
-            | Mdb _ ->                      "Run transactions in-process against MessageDB."
-            | Web _ ->                      "Run transactions against a Web endpoint."
-and Test = Favorite | SaveForLater | Todo
-and TestArguments(p : ParseResults<LoadTestParameters>) =
-    member val Options =                    p.GetResults Cached @ p.GetResults Unfolds
-    member x.Cache =                        x.Options |> List.exists (function Cached ->  true | _ -> false)
-    member x.Unfolds =                      x.Options |> List.exists (function Unfolds -> true | _ -> false)
-    member val Test =                       p.GetResult(Name, Test.Favorite)
-    member val ErrorCutoff =                p.GetResult(ErrorCutoff, 10000L)
-    member val TestsPerSecond =             p.GetResult(TestsPerSecond, 1000)
-    member val Duration =                   p.GetResult(DurationM, 30.) |> TimeSpan.FromMinutes
-    member x.ReportingIntervals =           match p.GetResults(ReportIntervalS) with
-                                            | [] -> TimeSpan.FromSeconds 10.|> Seq.singleton
-                                            | intervals -> seq { for i in intervals -> TimeSpan.FromSeconds(float i) }
-                                            |> fun intervals -> [| yield x.Duration; yield! intervals |]
-    member x.ConfigureStore(log : ILogger, createStoreLog) =
-        let cache = if x.Cache then Equinox.Cache(appName, sizeMb = 50) |> Some else None
-        match p.GetSubCommand() with
-        | Cosmos p ->   let storeLog = createStoreLog <| p.Contains Store.Cosmos.Parameters.StoreVerbose
-                        log.Information("Running transactions in-process against CosmosDB with storage options: {options:l}", x.Options)
-                        storeLog, Store.Cosmos.config log (cache, x.Unfolds) (Store.Cosmos.Arguments p)
-        | Dynamo p ->   let storeLog = createStoreLog <| p.Contains Store.Dynamo.Parameters.StoreVerbose
-                        log.Information("Running transactions in-process against DynamoDB with storage options: {options:l}", x.Options)
-                        storeLog, Store.Dynamo.config log (cache, x.Unfolds) (Store.Dynamo.Arguments p)
-        | Es p ->       let storeLog = createStoreLog <| p.Contains Store.EventStore.Parameters.StoreVerbose
-                        log.Information("Running transactions in-process against EventStore with storage options: {options:l}", x.Options)
-                        storeLog, Store.EventStore.config log (cache, x.Unfolds) p
-        | MsSql p ->    let storeLog = createStoreLog false
-                        log.Information("Running transactions in-process against MsSql with storage options: {options:l}", x.Options)
-                        storeLog, Store.Sql.Ms.config log (cache, x.Unfolds) p
-        | MySql p ->    let storeLog = createStoreLog false
-                        log.Information("Running transactions in-process against MySql with storage options: {options:l}", x.Options)
-                        storeLog, Store.Sql.My.config log (cache, x.Unfolds) p
-        | Postgres p -> let storeLog = createStoreLog false
-                        log.Information("Running transactions in-process against Postgres with storage options: {options:l}", x.Options)
-                        storeLog, Store.Sql.Pg.config log (cache, x.Unfolds) p
-        | Mdb p ->      let storeLog = createStoreLog false
-                        log.Information("Running transactions in-process against MessageDb with storage options: {options:l}", x.Options)
-                        storeLog, Store.MessageDb.config log cache p
-        | Memory _ ->   log.Warning("Running transactions in-process against Volatile Store with storage options: {options:l}", x.Options)
-                        createStoreLog false, Store.MemoryStore.config ()
-        | x ->          p.Raise $"unexpected subcommand %A{x}"
-    member _.Tests =    match p.GetResult(Name, Favorite) with
-                        | Favorite ->     Tests.Favorite
-                        | SaveForLater -> Tests.SaveForLater
-                        | Todo ->         Tests.Todo (p.GetResult(Size, 100))
-
 let writeToStatsSinks (c : LoggerConfiguration) =
     c.WriteTo.Sink(Equinox.CosmosStore.Core.Log.InternalMetrics.Stats.LogSink())
      .WriteTo.Sink(Equinox.DynamoStore.Core.Log.InternalMetrics.Stats.LogSink())
@@ -611,69 +519,6 @@ module Dump =
         if verboseConsole then
             dumpStats log storeConfig
 
-module LoadTest =
-
-    open Equinox.Tools.TestHarness
-
-    let private runLoadTest log testsPerSecond duration errorCutoff reportingIntervals (clients : ClientId[]) runSingleTest =
-        let mutable idx = -1L
-        let selectClient () =
-            let clientIndex = Interlocked.Increment(&idx) |> int
-            clients[clientIndex % clients.Length]
-        let selectClient = async { return async { return selectClient() } }
-        Local.runLoadTest log reportingIntervals testsPerSecond errorCutoff duration selectClient runSingleTest
-    let private decorateWithLogger (domainLog : ILogger, verbose) (run: 't -> Async<unit>) =
-        let execute clientId =
-            if not verbose then run clientId
-            else async {
-                domainLog.Information("Executing for client {sessionId}", clientId)
-                try return! run clientId
-                with e -> domainLog.Warning(e, "Test threw an exception"); e.Reraise () }
-        execute
-    let private createResultLog fileName = LoggerConfiguration().WriteTo.File(fileName).CreateLogger()
-    let run (log : ILogger) (verbose, verboseConsole, maybeSeq) reportFilename (p : ParseResults<LoadTestParameters>) =
-        let createStoreLog storeVerbose = createStoreLog storeVerbose verboseConsole maybeSeq
-        let a = TestArguments p
-        let storeLog, storeConfig, httpClient: ILogger * Store.Config option * HttpClient option =
-            match p.GetSubCommand() with
-            | Web p ->
-                let uri = p.GetResult(WebParameters.Endpoint,"https://localhost:5001") |> Uri
-                log.Information("Running web test targeting: {url}", uri)
-                createStoreLog false, None, new HttpClient(BaseAddress = uri) |> Some
-            | _ ->
-                let storeLog, storeConfig = a.ConfigureStore(log, createStoreLog)
-                storeLog, Some storeConfig, None
-        let test, duration = a.Tests, a.Duration
-        let runSingleTest : ClientId -> Async<unit> =
-            match storeConfig, httpClient with
-            | None, Some client ->
-                let execForClient = Tests.executeRemote client test
-                decorateWithLogger (log, verbose) execForClient
-            | Some storeConfig, _ ->
-                let services = ServiceCollection()
-                Services.register(services, storeConfig, storeLog)
-                let container = services.BuildServiceProvider()
-                let execForClient = Tests.executeLocal container test
-                decorateWithLogger (log, verbose) execForClient
-            | None, None -> invalidOp "impossible None, None"
-        let clients = Array.init (a.TestsPerSecond * 2) (fun _ -> % Guid.NewGuid())
-
-        let renderedIds = clients |> Seq.map ClientId.toString |> if verboseConsole then id else Seq.truncate 5
-        log.ForContext((if verboseConsole then "clientIds" else "clientIdsExcerpt"),renderedIds)
-            .Information("Running {test} for {duration} @ {tps} hits/s across {clients} clients; Max errors: {errorCutOff}, reporting intervals: {ri}, report file: {report}",
-            test, a.Duration, a.TestsPerSecond, clients.Length, a.ErrorCutoff, a.ReportingIntervals, reportFilename)
-
-        resetStats ()
-
-        let results = runLoadTest log a.TestsPerSecond (duration.Add(TimeSpan.FromSeconds 5.)) a.ErrorCutoff a.ReportingIntervals clients runSingleTest |> Async.RunSynchronously
-
-        let resultFile = createResultLog reportFilename
-        for r in results do
-            resultFile.Information("Aggregate: {aggregate}", r)
-        log.Information("Run completed; Current memory allocation: {bytes:n2} MiB", (GC.GetTotalMemory(true) |> float) / 1024./1024.)
-
-        storeConfig |> Option.iter (dumpStats log)
-
 type Arguments(p: ParseResults<Parameters>) =
     let maybeSeq = if p.Contains LocalSeq then Some "http://localhost:5341" else None
     let verbose = p.Contains Verbose
@@ -690,9 +535,9 @@ type Arguments(p: ParseResults<Parameters>) =
         | Stats a ->    CosmosStats.run (Log.Logger, verboseConsole, maybeSeq) a |> Async.RunSynchronously
         | LoadTest a -> let n = p.GetResult(LogFile, programName () + ".log")
                         let reportFilename = System.IO.FileInfo(n).FullName
-                        LoadTest.run Log.Logger (verbose, verboseConsole, maybeSeq) reportFilename a
-        | x ->          p.Raise $"unexpected subcommand %A{x}"
-    }
+                        let createStoreLog storeVerbose = createStoreLog storeVerbose verboseConsole maybeSeq
+                        Tests.LoadTest.run Log.Logger (createStoreLog, verbose, verboseConsole) (resetStats, dumpStats) reportFilename a
+        | x ->          p.Raise $"unexpected subcommand %A{x}" }
     static member Parse argv = ArgumentParser.Create().ParseCommandLine(argv) |> Arguments
 
 [<EntryPoint>]

--- a/tools/Equinox.Tool/StoreClient.fs
+++ b/tools/Equinox.Tool/StoreClient.fs
@@ -1,6 +1,5 @@
 ﻿module Equinox.Tool.StoreClient
 
-open Equinox.Tool.Infrastructure
 open System
 open System.Net
 open System.Net.Http

--- a/tools/Equinox.Tool/Tests.fs
+++ b/tools/Equinox.Tool/Tests.fs
@@ -1,12 +1,12 @@
 ﻿module Equinox.Tool.Tests
 
-open System.Threading
 open Domain
 open Microsoft.Extensions.DependencyInjection
+open Serilog
 open System
 open System.Net.Http
 open System.Text
-open Serilog
+open System.Threading
 
 type TestKind = Favorite | SaveForLater | Todo of size: int
 
@@ -186,7 +186,6 @@ module LoadTest =
                             | Favorite ->     TestKind.Favorite
                             | SaveForLater -> TestKind.SaveForLater
                             | Todo ->         TestKind.Todo (p.GetResult(Size, 100))
-
 
     let private runLoadTest log testsPerSecond duration errorCutoff reportingIntervals (clients : ClientId[]) runSingleTest =
         let mutable idx = -1L

--- a/tools/Equinox.Tool/Tests.fs
+++ b/tools/Equinox.Tool/Tests.fs
@@ -1,13 +1,14 @@
 ﻿module Equinox.Tool.Tests
 
+open System.Threading
 open Domain
-open Equinox.Tool.Infrastructure
 open Microsoft.Extensions.DependencyInjection
 open System
 open System.Net.Http
 open System.Text
+open Serilog
 
-type Test = Favorite | SaveForLater | Todo of size: int
+type TestKind = Favorite | SaveForLater | Todo of size: int
 
 let [<Literal>] seed = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor. Praesent et diam eget libero egestas mattis sit amet vitae augue. Nam tincidunt congue enim, ut porta lorem lacinia consectetur! "
 let lipsum len =
@@ -93,3 +94,154 @@ let executeRemote (client: HttpClient) test =
             else
                 let! _ = client.Add(TodoClient.Todo.Create size)
                 return () }
+
+module LoadTest =
+
+    open Argu
+    open Samples.Infrastructure
+
+    type [<NoComparison; NoEquality; RequireSubcommand>] LoadTestParameters =
+        | [<AltCommandLine "-t"; Unique>]       Name of Test
+        | [<AltCommandLine "-s">]               Size of int
+        | [<AltCommandLine "-C">]               Cached
+        | [<AltCommandLine "-U">]               Unfolds
+        | [<AltCommandLine "-f">]               TestsPerSecond of int
+        | [<AltCommandLine "-d">]               DurationM of float
+        | [<AltCommandLine "-e">]               ErrorCutoff of int64
+        | [<AltCommandLine "-i">]               ReportIntervalS of int
+        | [<CliPrefix(CliPrefix.None); Last>]                      Cosmos    of ParseResults<Store.Cosmos.Parameters>
+        | [<CliPrefix(CliPrefix.None); Last>]                      Dynamo    of ParseResults<Store.Dynamo.Parameters>
+        | [<CliPrefix(CliPrefix.None); Last>]                      Es        of ParseResults<Store.EventStore.Parameters>
+        | [<CliPrefix(CliPrefix.None); Last>]                      Memory    of ParseResults<Store.MemoryStore.Parameters>
+        | [<CliPrefix(CliPrefix.None); Last; AltCommandLine "ms">] MsSql     of ParseResults<Store.Sql.Ms.Parameters>
+        | [<CliPrefix(CliPrefix.None); Last; AltCommandLine "my">] MySql     of ParseResults<Store.Sql.My.Parameters>
+        | [<CliPrefix(CliPrefix.None); Last; AltCommandLine "pg">] Postgres  of ParseResults<Store.Sql.Pg.Parameters>
+        | [<CliPrefix(CliPrefix.None); Last>]                      Mdb       of ParseResults<Store.MessageDb.Parameters>
+        | [<CliPrefix(CliPrefix.None); Last>]                      Web       of ParseResults<WebParameters>
+        interface IArgParserTemplate with
+            member a.Usage = a |> function
+                | Name _ ->                     "specify which test to run. (default: Favorite)."
+                | Size _ ->                     "For `-t Todo`: specify random title length max size to use (default 100)."
+                | Cached ->                     "employ a 50MB cache, wire in to Stream configuration."
+                | Unfolds ->                    "employ a store-appropriate Rolling Snapshots and/or Unfolding strategy."
+                | TestsPerSecond _ ->           "specify a target number of requests per second (default: 1000)."
+                | DurationM _ ->                "specify a run duration in minutes (default: 30)."
+                | ErrorCutoff _ ->              "specify an error cutoff; test ends when exceeded (default: 10000)."
+                | ReportIntervalS _ ->          "specify reporting intervals in seconds (default: 10)."
+                | Es _ ->                       "Run transactions in-process against EventStore."
+                | Cosmos _ ->                   "Run transactions in-process against CosmosDB."
+                | Dynamo _ ->                   "Run transactions in-process against DynamoDB."
+                | Memory _ ->                   "target in-process Transient Memory Store (Default if not other target specified)."
+                | MsSql _ ->                    "Run transactions in-process against Sql Server."
+                | MySql _ ->                    "Run transactions in-process against MySql."
+                | Postgres _ ->                 "Run transactions in-process against Postgres."
+                | Mdb _ ->                      "Run transactions in-process against MessageDB."
+                | Web _ ->                      "Run transactions against a Web endpoint."
+    and [<NoComparison>] WebParameters =
+        | [<AltCommandLine "-u">]               Endpoint of string
+        interface IArgParserTemplate with
+            member a.Usage = a |> function
+                | Endpoint _ ->                 "Target address. Default: https://localhost:5001"
+    and Test = Favorite | SaveForLater | Todo
+    and TestArguments(p : ParseResults<LoadTestParameters>) =
+        member val Options =                    p.GetResults Cached @ p.GetResults Unfolds
+        member x.Cache =                        x.Options |> List.exists (function Cached ->  true | _ -> false)
+        member x.Unfolds =                      x.Options |> List.exists (function Unfolds -> true | _ -> false)
+        member val Test =                       p.GetResult(Name, Test.Favorite)
+        member val ErrorCutoff =                p.GetResult(ErrorCutoff, 10000L)
+        member val TestsPerSecond =             p.GetResult(TestsPerSecond, 1000)
+        member val Duration =                   p.GetResult(DurationM, 30.) |> TimeSpan.FromMinutes
+        member x.ReportingIntervals =           match p.GetResults(ReportIntervalS) with
+                                                | [] -> TimeSpan.FromSeconds 10.|> Seq.singleton
+                                                | intervals -> seq { for i in intervals -> TimeSpan.FromSeconds(float i) }
+                                                |> fun intervals -> [| yield x.Duration; yield! intervals |]
+        member x.ConfigureStore(log : ILogger, createStoreLog) =
+            let cache = if x.Cache then Equinox.Cache("dummy", sizeMb = 50) |> Some else None
+            match p.GetSubCommand() with
+            | Cosmos p ->   let storeLog = createStoreLog <| p.Contains Store.Cosmos.Parameters.StoreVerbose
+                            log.Information("Running transactions in-process against CosmosDB with storage options: {options:l}", x.Options)
+                            storeLog, Store.Cosmos.config log (cache, x.Unfolds) (Store.Cosmos.Arguments p)
+            | Dynamo p ->   let storeLog = createStoreLog <| p.Contains Store.Dynamo.Parameters.StoreVerbose
+                            log.Information("Running transactions in-process against DynamoDB with storage options: {options:l}", x.Options)
+                            storeLog, Store.Dynamo.config log (cache, x.Unfolds) (Store.Dynamo.Arguments p)
+            | Es p ->       let storeLog = createStoreLog <| p.Contains Store.EventStore.Parameters.StoreVerbose
+                            log.Information("Running transactions in-process against EventStore with storage options: {options:l}", x.Options)
+                            storeLog, Store.EventStore.config log (cache, x.Unfolds) p
+            | MsSql p ->    let storeLog = createStoreLog false
+                            log.Information("Running transactions in-process against MsSql with storage options: {options:l}", x.Options)
+                            storeLog, Store.Sql.Ms.config log (cache, x.Unfolds) p
+            | MySql p ->    let storeLog = createStoreLog false
+                            log.Information("Running transactions in-process against MySql with storage options: {options:l}", x.Options)
+                            storeLog, Store.Sql.My.config log (cache, x.Unfolds) p
+            | Postgres p -> let storeLog = createStoreLog false
+                            log.Information("Running transactions in-process against Postgres with storage options: {options:l}", x.Options)
+                            storeLog, Store.Sql.Pg.config log (cache, x.Unfolds) p
+            | Mdb p ->      let storeLog = createStoreLog false
+                            log.Information("Running transactions in-process against MessageDb with storage options: {options:l}", x.Options)
+                            storeLog, Store.MessageDb.config log cache p
+            | Memory _ ->   log.Warning("Running transactions in-process against Volatile Store with storage options: {options:l}", x.Options)
+                            createStoreLog false, Store.MemoryStore.config ()
+            | x ->          p.Raise $"unexpected subcommand %A{x}"
+        member _.TestKind = match p.GetResult(Name, Favorite) with
+                            | Favorite ->     TestKind.Favorite
+                            | SaveForLater -> TestKind.SaveForLater
+                            | Todo ->         TestKind.Todo (p.GetResult(Size, 100))
+
+
+    let private runLoadTest log testsPerSecond duration errorCutoff reportingIntervals (clients : ClientId[]) runSingleTest =
+        let mutable idx = -1L
+        let selectClient () =
+            let clientIndex = Interlocked.Increment(&idx) |> int
+            clients[clientIndex % clients.Length]
+        let selectClient = async { return async { return selectClient() } }
+        Equinox.Tools.TestHarness.Local.runLoadTest log reportingIntervals testsPerSecond errorCutoff duration selectClient runSingleTest
+    let private decorateWithLogger (domainLog : ILogger, verbose) (run: 't -> Async<unit>) =
+        let execute clientId =
+            if not verbose then run clientId
+            else async {
+                domainLog.Information("Executing for client {sessionId}", clientId)
+                try return! run clientId
+                with e -> domainLog.Warning(e, "Test threw an exception"); e.Reraise () }
+        execute
+    let private createResultLog fileName = LoggerConfiguration().WriteTo.File(fileName).CreateLogger()
+    let run (log : ILogger) (createStoreLog, verbose, verboseConsole) (resetStats, dumpStats) reportFilename (p : ParseResults<LoadTestParameters>) =
+        let a = TestArguments p
+        let storeLog, storeConfig, httpClient: ILogger * Store.Config option * HttpClient option =
+            match p.GetSubCommand() with
+            | Web p ->
+                let uri = p.GetResult(WebParameters.Endpoint,"https://localhost:5001") |> Uri
+                log.Information("Running web test targeting: {url}", uri)
+                createStoreLog false, None, new HttpClient(BaseAddress = uri) |> Some
+            | _ ->
+                let storeLog, storeConfig = a.ConfigureStore(log, createStoreLog)
+                storeLog, Some storeConfig, None
+        let test, duration = a.TestKind, a.Duration
+        let runSingleTest : ClientId -> Async<unit> =
+            match storeConfig, httpClient with
+            | None, Some client ->
+                let execForClient = executeRemote client test
+                decorateWithLogger (log, verbose) execForClient
+            | Some storeConfig, _ ->
+                let services = ServiceCollection()
+                Services.register(services, storeConfig, storeLog)
+                let container = services.BuildServiceProvider()
+                let execForClient = executeLocal container test
+                decorateWithLogger (log, verbose) execForClient
+            | None, None -> invalidOp "impossible None, None"
+        let clients = Array.init (a.TestsPerSecond * 2) (fun _ -> ClientId.gen())
+
+        let renderedIds = clients |> Seq.map ClientId.toString |> if verboseConsole then id else Seq.truncate 5
+        log.ForContext((if verboseConsole then "clientIds" else "clientIdsExcerpt"),renderedIds)
+            .Information("Running {test} for {duration} @ {tps} hits/s across {clients} clients; Max errors: {errorCutOff}, reporting intervals: {ri}, report file: {report}",
+            test, a.Duration, a.TestsPerSecond, clients.Length, a.ErrorCutoff, a.ReportingIntervals, reportFilename)
+
+        resetStats ()
+
+        let results = runLoadTest log a.TestsPerSecond (duration.Add(TimeSpan.FromSeconds 5.)) a.ErrorCutoff a.ReportingIntervals clients runSingleTest |> Async.RunSynchronously
+
+        let resultFile = createResultLog reportFilename
+        for r in results do
+            resultFile.Information("Aggregate: {aggregate}", r)
+        log.Information("Run completed; Current memory allocation: {bytes:n2} MiB", (GC.GetTotalMemory(true) |> float) / 1024./1024.)
+
+        storeConfig |> Option.iter (dumpStats log)

--- a/tools/Equinox.Tool/TodoClient.fs
+++ b/tools/Equinox.Tool/TodoClient.fs
@@ -1,6 +1,5 @@
 ﻿module Equinox.Tool.TodoClient
 
-open Equinox.Tool.Infrastructure
 open System.Net
 open System.Net.Http
 open System

--- a/tools/Equinox.Tool/TodoClient.fs
+++ b/tools/Equinox.Tool/TodoClient.fs
@@ -1,8 +1,8 @@
 ﻿module Equinox.Tool.TodoClient
 
+open System
 open System.Net
 open System.Net.Http
-open System
 
 type Todo = { id: int; url: string; order: int; title: string; completed: bool }
 


### PR DESCRIPTION
Aligns the Tool's commandline processing with that of Propulsion.Tool (i.e. more evolved patterns for commandline parsing)

- Minor tweaks re/ as a side-effect of https://github.com/fsprojects/Argu/issues/171
- rename the Tool's `run` Subcommand to the more 'say what you see' `loadTest`
- rename the mysterious-sounding `config` to `initSql` to align with `propulsion init`/`initAws` etc and https://github.com/jet/propulsion/pull/249
- minor polishing of CosmosQuery (follow-ups to #444) 
- re-ordering (no logic changes to stuff reordered other than `CosmosQuery`)
- move LoadTest logic to separate file, as it's not really part of the tool in any significant way
- change `eqx query` default format to `Raw` when writing to a `File` cia `-o`