### PR TITLE
chore(Deps): Pin internal deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- `Equinox.*Store`,`Equinox.*Store.Prometheus`: Pin `Equinox` dependencies to `[4.0.0, 5.0.0)`] [#448](https://github.com/jet/equinox/pull/448)
+
 ### Removed
 ### Fixed
 

--- a/src/Equinox.CosmosStore.Prometheus/Equinox.CosmosStore.Prometheus.fsproj
+++ b/src/Equinox.CosmosStore.Prometheus/Equinox.CosmosStore.Prometheus.fsproj
@@ -9,7 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Equinox.CosmosStore\Equinox.CosmosStore.fsproj" />
+    <ProjectReference Condition=" '$(Configuration)' == 'Debug' " Include="..\Equinox.CosmosStore\Equinox.CosmosStore.fsproj" />
+    <PackageReference Condition=" '$(Configuration)' == 'Release' " Include="Equinox.CosmosStore" Version="[4.0.0, 5.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Equinox.CosmosStore/Equinox.CosmosStore.fsproj
+++ b/src/Equinox.CosmosStore/Equinox.CosmosStore.fsproj
@@ -14,7 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Equinox\Equinox.fsproj" />
+    <ProjectReference Condition=" '$(Configuration)' == 'Debug' " Include="..\Equinox\Equinox.fsproj" />
+    <PackageReference Condition=" '$(Configuration)' == 'Release' " Include="Equinox" Version="[4.0.0, 5.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Equinox.DynamoStore.Prometheus/Equinox.DynamoStore.Prometheus.fsproj
+++ b/src/Equinox.DynamoStore.Prometheus/Equinox.DynamoStore.Prometheus.fsproj
@@ -9,7 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Equinox.DynamoStore\Equinox.DynamoStore.fsproj" />
+    <ProjectReference Condition=" '$(Configuration)' == 'Debug' " Include="..\Equinox.DynamoStore\Equinox.DynamoStore.fsproj" />
+    <PackageReference Condition=" '$(Configuration)' == 'Release' " Include="Equinox.DynamoStore" Version="[4.0.0, 5.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Equinox.DynamoStore/Equinox.DynamoStore.fsproj
+++ b/src/Equinox.DynamoStore/Equinox.DynamoStore.fsproj
@@ -11,16 +11,17 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Condition=" '$(Configuration)' == 'Debug' " Include="..\Equinox\Equinox.fsproj" />
+    <PackageReference Condition=" '$(Configuration)' == 'Release' " Include="Equinox" Version="[4.0.0, 5.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
     <PackageReference Include="FSharp.Core" Version="6.0.7" ExcludeAssets="contentfiles" />
 
     <PackageReference Include="FSharp.AWS.DynamoDB" Version="0.12.0-beta" />
     <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Equinox\Equinox.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Equinox.EventStore/Equinox.EventStore.fsproj
+++ b/src/Equinox.EventStore/Equinox.EventStore.fsproj
@@ -11,7 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Equinox\Equinox.fsproj" />
+    <ProjectReference Condition=" '$(Configuration)' == 'Debug' " Include="..\Equinox\Equinox.fsproj" />
+    <PackageReference Condition=" '$(Configuration)' == 'Release' " Include="Equinox" Version="[4.0.0, 5.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Equinox.EventStoreDb/Equinox.EventStoreDb.fsproj
+++ b/src/Equinox.EventStoreDb/Equinox.EventStoreDb.fsproj
@@ -11,13 +11,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Equinox\Equinox.fsproj" />
+    <ProjectReference Condition=" '$(Configuration)' == 'Debug' " Include="..\Equinox\Equinox.fsproj" />
+    <PackageReference Condition=" '$(Configuration)' == 'Release' " Include="Equinox" Version="[4.0.0, 5.0.0)" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
     <PackageReference Include="FSharp.Core" Version="6.0.7" ExcludeAssets="contentfiles" />
+    
     <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
     <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
   </ItemGroup>

--- a/src/Equinox.MemoryStore/Equinox.MemoryStore.fsproj
+++ b/src/Equinox.MemoryStore/Equinox.MemoryStore.fsproj
@@ -10,7 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Equinox\Equinox.fsproj" />
+    <ProjectReference Condition=" '$(Configuration)' == 'Debug' " Include="..\Equinox\Equinox.fsproj" />
+    <PackageReference Condition=" '$(Configuration)' == 'Release' " Include="Equinox" Version="[4.0.0, 5.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Equinox.MessageDb/Equinox.MessageDb.fsproj
+++ b/src/Equinox.MessageDb/Equinox.MessageDb.fsproj
@@ -13,7 +13,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Equinox\Equinox.fsproj" />
+        <ProjectReference Condition=" '$(Configuration)' == 'Debug' " Include="..\Equinox\Equinox.fsproj" />
+        <PackageReference Condition=" '$(Configuration)' == 'Release' " Include="Equinox" Version="[4.0.0, 5.0.0)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Equinox.SqlStreamStore.MsSql/Equinox.SqlStreamStore.MsSql.fsproj
+++ b/src/Equinox.SqlStreamStore.MsSql/Equinox.SqlStreamStore.MsSql.fsproj
@@ -10,15 +10,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Condition=" '$(Configuration)' == 'Debug' " Include="..\Equinox.SqlStreamStore\Equinox.SqlStreamStore.fsproj" />
+    <PackageReference Condition=" '$(Configuration)' == 'Release' " Include="Equinox.SqlStreamStore" Version="[4.0.0, 5.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
     <PackageReference Include="FSharp.Core" Version="6.0.7" ExcludeAssets="contentfiles" />
 
     <PackageReference Include="SqlStreamStore.MsSql" Version="1.2.0-beta.8" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Equinox.SqlStreamStore\Equinox.SqlStreamStore.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Equinox.SqlStreamStore.MySql/Equinox.SqlStreamStore.MySql.fsproj
+++ b/src/Equinox.SqlStreamStore.MySql/Equinox.SqlStreamStore.MySql.fsproj
@@ -10,15 +10,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Condition=" '$(Configuration)' == 'Debug' " Include="..\Equinox.SqlStreamStore\Equinox.SqlStreamStore.fsproj" />
+    <PackageReference Condition=" '$(Configuration)' == 'Release' " Include="Equinox.SqlStreamStore" Version="[4.0.0, 5.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
     <PackageReference Include="FSharp.Core" Version="6.0.7" ExcludeAssets="contentfiles" />
 
     <PackageReference Include="SqlStreamStore.MySql" Version="1.2.0-beta.8" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Equinox.SqlStreamStore\Equinox.SqlStreamStore.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Equinox.SqlStreamStore.Postgres/Equinox.SqlStreamStore.Postgres.fsproj
+++ b/src/Equinox.SqlStreamStore.Postgres/Equinox.SqlStreamStore.Postgres.fsproj
@@ -10,15 +10,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Condition=" '$(Configuration)' == 'Debug' " Include="..\Equinox.SqlStreamStore\Equinox.SqlStreamStore.fsproj" />
+    <PackageReference Condition=" '$(Configuration)' == 'Release' " Include="Equinox.SqlStreamStore" Version="[4.0.0, 5.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
     <PackageReference Include="FSharp.Core" Version="6.0.7" ExcludeAssets="contentfiles" />
 
     <PackageReference Include="SqlStreamStore.Postgres" Version="1.2.0-beta.8" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Equinox.SqlStreamStore\Equinox.SqlStreamStore.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Equinox.SqlStreamStore/Equinox.SqlStreamStore.fsproj
+++ b/src/Equinox.SqlStreamStore/Equinox.SqlStreamStore.fsproj
@@ -11,7 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Equinox\Equinox.fsproj" />
+    <ProjectReference Condition=" '$(Configuration)' == 'Debug' " Include="..\Equinox\Equinox.fsproj" />
+    <PackageReference Condition=" '$(Configuration)' == 'Release' " Include="Equinox" Version="[4.0.0, 5.0.0)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adjusts internal dependencies to
- pin `Equinox.*Store` to depend on `Equinox [4.0.0, 5.0.0)`
- pin `Equinox.SqlStreamStore.*` to depend on `Equinox.SqlStreamStore [4.0.0, 5.0.0)`
This should mean:
- Equinox and library dependencies can be be independently updated
- The release of an Equinox v5 should not require any changes to the pinning at the app level