### PR TITLE
fix(Cache): Correct wait for concurrent request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+- `Equinox`: `LoadOption.AnyCachedValue`, `LoadOption.AllowStale` excessive `TaskCanceledException` outcomes due to failure to correctly coalesce concurrent attempts [#452](https://github.com/jet/equinox/pull/452)
+
 <a name="4.0.2"></a>
 ## [4.0.2] - 2024-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Fixed
 
 - `Equinox`: `LoadOption.AnyCachedValue`, `LoadOption.AllowStale` excessive `TaskCanceledException` outcomes due to failure to correctly coalesce concurrent attempts [#452](https://github.com/jet/equinox/pull/452)
+- `Equinox`: `LoadOption.AnyCachedValue`, `LoadOption.AllowStale` prevent yielding of superseded value where overlapping call in flight [#452](https://github.com/jet/equinox/pull/452)
+- `Equinox`: `LoadOption.AnyCachedValue`, `LoadOption.AllowStale` correct to ensure optimal loading where first flight was in progress [#452](https://github.com/jet/equinox/pull/452)
 
 <a name="4.0.2"></a>
 ## [4.0.2] - 2024-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
-- `Equinox`: `LoadOption.AnyCachedValue`, `LoadOption.AllowStale` excessive `TaskCanceledException` outcomes due to failure to correctly coalesce concurrent attempts [#452](https://github.com/jet/equinox/pull/452)
 - `Equinox`: `LoadOption.AnyCachedValue`, `LoadOption.AllowStale` prevent yielding of superseded value where overlapping call in flight [#452](https://github.com/jet/equinox/pull/452)
+- `Equinox`: `LoadOption.AnyCachedValue`, `LoadOption.AllowStale` prevent incorrect `TaskCanceledException` outcome where overlapping call cancelled [#452](https://github.com/jet/equinox/pull/452)
 - `Equinox`: `LoadOption.AnyCachedValue`, `LoadOption.AllowStale` correct to ensure optimal loading where first flight was in progress [#452](https://github.com/jet/equinox/pull/452)
 
 <a name="4.0.2"></a>

--- a/src/Equinox.Tests/CachingTests.fs
+++ b/src/Equinox.Tests/CachingTests.fs
@@ -124,6 +124,11 @@ type Tests() =
 
     let allowStale toleranceMs = load sn (TimeSpan.FromMilliseconds toleranceMs) sut
 
+    // TODO: the tests below that involve triggering of expiration and/or ensuring overlapping requests are in flight are very naive.
+    // 1. TimeProvider APIs can be used ot shift time deterministically
+    // 2. instead of using a delay to ensure that requests are in flight, the SpyCategory should deterministically signal a ManualResetEvent or similar
+    // see also https://github.com/jet/equinox/pull/452#issuecomment-2048647249
+
     let [<Fact>] ``allowStale unifies compatible concurrent loads`` () = task {
         cat.Delay <- TimeSpan.FromMilliseconds 70 // Ensure it's still in progress when our Delay is over
         let t1 = allowStale 1

--- a/src/Equinox.Tests/CachingTests.fs
+++ b/src/Equinox.Tests/CachingTests.fs
@@ -127,7 +127,7 @@ type Tests() =
     let [<Fact>] ``allowStale unifies compatible concurrent loads`` () = task {
         cat.Delay <- TimeSpan.FromMilliseconds 70 // Ensure it's still in progress when our Delay is over
         let t1 = allowStale 1
-        do! Task.Delay 50 // Allow it time to definitely have started
+        do! Task.Delay 35 // Allow it time to definitely have started
         test <@ (1, 0) = (cat.Loads, cat.Reloads) @>
         let! struct (_token, state) = allowStale 300
         test <@ (1, 1, 0) = (state, cat.Loads, cat.Reloads) @>

--- a/src/Equinox.Tests/CachingTests.fs
+++ b/src/Equinox.Tests/CachingTests.fs
@@ -130,9 +130,9 @@ type Tests() =
     // see also https://github.com/jet/equinox/pull/452#issuecomment-2048647249
 
     let [<Fact>] ``allowStale unifies compatible concurrent loads`` () = task {
-        cat.Delay <- TimeSpan.FromMilliseconds 70 // Ensure it's still in progress when our Delay is over
+        cat.Delay <- TimeSpan.FromMilliseconds 80 // Ensure it's still in progress when our Delay is over
         let t1 = allowStale 1
-        do! Task.Delay 35 // Allow it time to definitely have started
+        do! Task.Delay 50 // Allow it time to definitely have started
         test <@ (1, 0) = (cat.Loads, cat.Reloads) @>
         let! struct (_token, state) = allowStale 300
         test <@ (1, 1, 0) = (state, cat.Loads, cat.Reloads) @>


### PR DESCRIPTION
Fixes the condition for the swap, which has a race condition that can mean delivering the value we've just literally determined to be too old
Reduce a test timeout to hopefully reduce flakiness
Also fixes an oversight: even if a concurrent request was too old for the `maxAge`, it can still serve as the base state for an incremental load (not a big deal in the normal case; only the very first load would be suboptimal)