### PR TITLE
feat(eqx stats): Oldest, Newest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Equinox.CosmosStore`: Group metrics by Container Name [#449](https://github.com/jet/equinox/pull/449)
 - `Equinox.Core.Batcher`: Add Settable `Linger` [#454](https://github.com/jet/equinox/pull/454)
 - `Equinox.CosmosStore`: Group metrics by Category; split out `Tip` [#453](https://github.com/jet/equinox/pull/453)
+- `eqx stats`: Added `-O` and `-N` to extract oldest and newest `_ts` within a store [#458](https://github.com/jet/equinox/pull/458)
+- `eqx`: Added `-Q` flag to omit timestamps from console output logging [#458](https://github.com/jet/equinox/pull/458)
 
 ### Changed
 
@@ -20,6 +22,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Equinox.MessageDb`: Up min `Npgsql` to v `7.0.7` as `7.0.0` is on CVE blacklist
 
 ### Removed
+
+- `eqx stats`: `-A` (all stats) is now the default unless you specify >=1 of the individual stats via `ESDNO` flags [#458](https://github.com/jet/equinox/pull/458)
+
 ### Fixed
 
 <a name="4.0.4"></a>

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ While Equinox is implemented in F#, and F# is a great fit for writing event-sour
 
     ```powershell
     # run queries to determine how many streams, docs, events there are in the container
-    eqx -VC stats -SDEP cosmos # -P to run in parallel # -V -C to show underlying query being used
+    eqx -V stats -P cosmos # -P to run in parallel # -V to show underlying query being used
     ```
 
 5. Use the `eqx` tool to query streams and/or snapshots in a CosmosDB store


### PR DESCRIPTION
- Add two new `eqx stats cosmos` queries
- remove `-A` flag (it's now on by default unless you specify >= 1)
- add top level `-Q` flag to omit timestamps/noise from output