### PR TITLE
fix(CosmosStore): Drop min STJ to 6.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Changed
 
 - `Equinox.*Store`,`Equinox.*Store.Prometheus`: Pin `Equinox` dependencies to `[4.0.0, 5.0.0)`] [#448](https://github.com/jet/equinox/pull/448)
-- `Equinox.CosmosStore`: Minimum `System.Text.Json` requirement updated to `8.0.4` as that's the lowest non-flagged version [#462](https://github.com/jet/equinox/pull/462)
+- `Equinox.CosmosStore`: Update `System.Text.Json` dep to `6.0.10` per [CVE-2024-43485](https://github.com/advisories/GHSA-8g4q-xg66-9fp4) [#470](https://github.com/jet/equinox/pull/470)
 - `Equinox.MessageDb`: Up min `Npgsql` to v `7.0.7` as `7.0.0` is on CVE blacklist
 
 ### Removed

--- a/samples/Store/Domain.Tests/Domain.Tests.fsproj
+++ b/samples/Store/Domain.Tests/Domain.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Store/Domain/Domain.fsproj
+++ b/samples/Store/Domain/Domain.fsproj
@@ -19,7 +19,7 @@
     <PackageReference Include="FSharp.Core" Version="6.0.7" ExcludeAssets="contentfiles" />
 
     <PackageReference Include="FsCodec.NewtonsoftJson" Version="3.0.0" />
-    <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.2" />
+    <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.3" />
 
     <ProjectReference Include="..\..\..\src\Equinox\Equinox.fsproj" />
   </ItemGroup>

--- a/samples/Store/Integration/Integration.fsproj
+++ b/samples/Store/Integration/Integration.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Tutorial/Tutorial.fsproj
+++ b/samples/Tutorial/Tutorial.fsproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.2" />
+    <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.3" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="7.0.0" />
   </ItemGroup>

--- a/samples/Web/Web.fsproj
+++ b/samples/Web/Web.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Equinox.CosmosStore/Equinox.CosmosStore.fsproj
+++ b/src/Equinox.CosmosStore/Equinox.CosmosStore.fsproj
@@ -28,7 +28,7 @@
 
     <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.35.4" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="6.0.10" />
   </ItemGroup>
 
 </Project>

--- a/src/Equinox.Tests/Equinox.Tests.fsproj
+++ b/src/Equinox.Tests/Equinox.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/Equinox.Core.Tests/Equinox.Core.Tests.fsproj
+++ b/tests/Equinox.Core.Tests/Equinox.Core.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Equinox.CosmosStore.Integration/Equinox.CosmosStore.Integration.fsproj
+++ b/tests/Equinox.CosmosStore.Integration/Equinox.CosmosStore.Integration.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Equinox.DynamoStore.Integration/Equinox.DynamoStore.Integration.fsproj
+++ b/tests/Equinox.DynamoStore.Integration/Equinox.DynamoStore.Integration.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DefineConstants>$(DefineConstants);STORE_DYNAMO</DefineConstants>
   </PropertyGroup>
 

--- a/tests/Equinox.EventStore.Integration/Equinox.EventStore.Integration.fsproj
+++ b/tests/Equinox.EventStore.Integration/Equinox.EventStore.Integration.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DefineConstants>$(DefineConstants);STORE_EVENTSTORE_LEGACY</DefineConstants>
   </PropertyGroup>
 

--- a/tests/Equinox.EventStoreDb.Integration/Equinox.EventStoreDb.Integration.fsproj
+++ b/tests/Equinox.EventStoreDb.Integration/Equinox.EventStoreDb.Integration.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <DefineConstants>$(DefineConstants);STORE_EVENTSTOREDB</DefineConstants>
     </PropertyGroup>
 

--- a/tests/Equinox.MemoryStore.Integration/Equinox.MemoryStore.Integration.fsproj
+++ b/tests/Equinox.MemoryStore.Integration/Equinox.MemoryStore.Integration.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Equinox.MessageDb.Integration/Equinox.MessageDb.Integration.fsproj
+++ b/tests/Equinox.MessageDb.Integration/Equinox.MessageDb.Integration.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DefineConstants>$(DefineConstants);STORE_MESSAGEDB</DefineConstants>
   </PropertyGroup>
 

--- a/tests/Equinox.SqlStreamStore.MsSql.Integration/Equinox.SqlStreamStore.MsSql.Integration.fsproj
+++ b/tests/Equinox.SqlStreamStore.MsSql.Integration/Equinox.SqlStreamStore.MsSql.Integration.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DefineConstants>$(DefineConstants);STORE_MSSQL</DefineConstants>
   </PropertyGroup>
 

--- a/tests/Equinox.SqlStreamStore.MySql.Integration/Equinox.SqlStreamStore.MySql.Integration.fsproj
+++ b/tests/Equinox.SqlStreamStore.MySql.Integration/Equinox.SqlStreamStore.MySql.Integration.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DefineConstants>$(DefineConstants);STORE_MYSQL</DefineConstants>
   </PropertyGroup>
 

--- a/tests/Equinox.SqlStreamStore.Postgres.Integration/Equinox.SqlStreamStore.Postgres.Integration.fsproj
+++ b/tests/Equinox.SqlStreamStore.Postgres.Integration/Equinox.SqlStreamStore.Postgres.Integration.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DefineConstants>$(DefineConstants);STORE_POSTGRES</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
In the previous round of STJ vulnernabilities, we updated min requirement to 8.0.4 to appease the scanner databases

Now dropping back down to the latest 6.x: 6.0.10 in the hope of the older version having less features and hence vuln-churn

- See also https://github.com/jet/FsCodec/releases/tag/3.0.3 (samples now ref same)
- Updated tests to net80 to match latest images (library packages don't yet have any net80 specific features)