### PR TITLE
Added read retry policy to EventStoreDb.

### DIFF
--- a/src/Equinox/Infrastructure.fs
+++ b/src/Equinox/Infrastructure.fs
@@ -70,3 +70,15 @@ module Array =
 
     let inline chooseV f xs = [| for item in xs do match f item with ValueSome v -> yield v | ValueNone -> () |]
     let inline tryFirstV (xs: _[]) = if xs.Length = 0 then ValueNone else ValueSome xs[0]
+    let takeWhileInclusive (predicate: 'T -> bool) (array: 'T[]) : 'T[] =
+        let result = ResizeArray<'T>()
+        let mutable i, continue' = 0, true
+
+        while i < array.Length && continue' do
+            let current = array[i]
+            result.Add(current)
+            if not (predicate current) then
+                continue' <- false
+            i <- i + 1
+
+        result.ToArray()


### PR DESCRIPTION
Here is the implementation for the issue #475. 

The issue I was unable to resolve is efficiently loading only the subset of events up to the origin point. In the current implementation, the entire batch is loaded first, and then filtered using "take while origin." This approach has a significant drawback: in the worst-case scenario, substantially more data than necessary will be loaded into memory.