### PR TITLE
Moves to AWSSDK 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ## [Unreleased]
 
-### Added 
+### Changed
+
+- Update DynamoDB dependencies to 4.x [#480](https://github.com/jet/equinox/pull/480)
+
+### Added
 
 - `Equinox.CosmosStore.Linq`: Add LINQ querying support for Indexed `u`nfolds [#450](https://github.com/jet/equinox/pull/450)
 
@@ -283,7 +287,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [3.0.0-beta.1] - 2021-02-24
 
 ### Added
- 
+
  - `Equinox.CosmosStore`: Forked from `Equinox.Cosmos` to add significant new features (see Removed section for deprecation policy info).
    - Added support for accumulating events in Tip, i.e. being able to operate with a single document per stream until the events (if any) overflow a defined size threshold [#251](https://github.com/jet/equinox/pull/251) see also [#110](https://github.com/jet/equinox/pull/110)
    - Added Archive store Fallback for Event loading, enabling streams to be hot-migrated (archived to a secondary/clone, then pruned from the primary/active) between Primary and Archival stores [#247](https://github.com/jet/equinox/pull/247), [#259](https://github.com/jet/equinox/pull/259)
@@ -295,7 +299,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
    - Remove exceptions from 304/404 paths when reading Tip [#257](https://github.com/jet/equinox/pull/257)
    - Removed [warmup call](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/1436)
    - Rename `Equinox.Cosmos` DLL and namespace to `Equinox.CosmosStore` [#243](https://github.com/jet/equinox/pull/243)
-        - Rename `Equinox.Cosmos.Store` -> `Equinox.CosmosStore.Core` 
+        - Rename `Equinox.Cosmos.Store` -> `Equinox.CosmosStore.Core`
         - `Core` sub-namespace
             - Rename `Equinox.Cosmos.Core.Context` -> `Equinox.CosmosStore.Core.EventsContext`
             - Change `Equinox.Cosmos.Core.Connection` -> `Equinox.CosmosStore.Core.RetryPolicy`
@@ -511,17 +515,17 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - `SqlStreamStore`: Full support for Microsoft Sql Server, MySQL and Postgres using [SqlStreamStore](https://github.com/SQLStreamStore/SQLStreamStore) [#168](https://github.com/jet/equinox/pull/168) :pray: [@rajivhost](https://github.com/rajivhost)
-- `Cosmos`: Exposed a `Connector.CreateClient` for interop with V2 ChangeFeedProcessor and `Propulsion.Cosmos` [#171](https://github.com/jet/equinox/pull/171) 
+- `Cosmos`: Exposed a `Connector.CreateClient` for interop with V2 ChangeFeedProcessor and `Propulsion.Cosmos` [#171](https://github.com/jet/equinox/pull/171)
 - `Cosmos`: Codified `AccessStrategy.RollingState` [#178](https://github.com/jet/equinox/pull/178) :pray: [@jgardella](https://github.com/jgardella)
-- `Cosmos`: Added `eqx stats` command to count streams/docs/events in a CosmosDb Container re [#127](https://github.com/jet/equinox/issues/127) [#176](https://github.com/jet/equinox/pull/176) 
-- `MemoryStore`: Supports custom Codec logic (can use `FsCodec.Box.Codec` as default) [#173](https://github.com/jet/equinox/pull/173) 
+- `Cosmos`: Added `eqx stats` command to count streams/docs/events in a CosmosDb Container re [#127](https://github.com/jet/equinox/issues/127) [#176](https://github.com/jet/equinox/pull/176)
+- `MemoryStore`: Supports custom Codec logic (can use `FsCodec.Box.Codec` as default) [#173](https://github.com/jet/equinox/pull/173)
 - `eqx dump [store]`: Show event data from store [#177](https://github.com/jet/equinox/pull/177)
 
 ### Changed
 
 - Targeted `Destructurama.FSharp` v `1.1.1-dev-00033` [dotnet-templates#36](https://github.com/jet/dotnet-templates/issues/36)
 - Targeted `FsCodec` v `1.2.1`
-- `Cosmos`: renamed `Connector`'s `maxRetryAttemptsOnThrottledRequests` and `maxRetryWaitTimeInSeconds` to maxRetryAttemptsOnRateLimitedRequests` and `maxRetryWaitTimeOnRateLimitedRequests` and changed latter to `TimeSpan` to match V3 SDK [#171](https://github.com/jet/equinox/pull/171) 
+- `Cosmos`: renamed `Connector`'s `maxRetryAttemptsOnThrottledRequests` and `maxRetryWaitTimeInSeconds` to maxRetryAttemptsOnRateLimitedRequests` and `maxRetryWaitTimeOnRateLimitedRequests` and changed latter to `TimeSpan` to match V3 SDK [#171](https://github.com/jet/equinox/pull/171)
 - `AccessStrategy`: consistent naming for Union cases and arguments; rewrote xmldoc [#178](https://github.com/jet/equinox/pull/178) :pray: [@jgardella](https://github.com/jgardella)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Changed
 
-- Update DynamoDB dependencies to 4.x [#480](https://github.com/jet/equinox/pull/480)
+- `Equinox.DynamoStore`: Update `AWSSDK` dependencies to 4.x (knock-on effect of updating `FSharp.AWS.DynamoDB` dependency to `0.13.0-beta`) [#480](https://github.com/jet/equinox/pull/480) :pray: [njlr](https://github.com/njlr)
 
 ### Added
 

--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -405,7 +405,7 @@ module Initialization =
         let context = TableContext<Batch.Schema>(client, tableName)
         context.UpdateTableIfRequiredAsync()
 
-    /// Yields the <c>StreamsARN</c> if (but only if) it streaming is presently active
+    /// Yields the <c>StreamsARN</c> if (but only if) streaming is presently active
     let tryGetActiveStreamsArn (x: Model.TableDescription) =
         match x.StreamSpecification with
         | ss when ss <> null && ss.StreamEnabled.GetValueOrDefault(false) -> x.LatestStreamArn

--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -408,14 +408,14 @@ module Initialization =
     /// Yields the <c>StreamsARN</c> if (but only if) it streaming is presently active
     let tryGetActiveStreamsArn (x: Model.TableDescription) =
         match x.StreamSpecification with
-        | ss when ss <> null && ss.StreamEnabled -> x.LatestStreamArn
+        | ss when ss <> null && ss.StreamEnabled.GetValueOrDefault(false) -> x.LatestStreamArn
         | _ -> null
 
 type private Metrics() =
     let mutable t = 0.
     member _.Add(x: RequestMetrics) =
         for x in x.ConsumedCapacity do
-            t <- t + x.CapacityUnits
+            t <- t + x.CapacityUnits.GetValueOrDefault(0.0)
     member _.Consumed: RequestConsumption = { total = t }
 
 module private Async =

--- a/src/Equinox.DynamoStore/DynamoStore.fs
+++ b/src/Equinox.DynamoStore/DynamoStore.fs
@@ -201,7 +201,7 @@ module EncodedBody =
 [<Struct>]
 type RequestConsumption = { total: float }
 
-[<Struct; RequireQualifiedAccess>]
+[<Struct>]
 type Direction = Forward | Backward override this.ToString() = match this with Forward -> "Forward" | Backward -> "Backward"
 
 module Log =

--- a/src/Equinox.DynamoStore/Equinox.DynamoStore.fsproj
+++ b/src/Equinox.DynamoStore/Equinox.DynamoStore.fsproj
@@ -23,7 +23,7 @@
 
     <PackageReference Include="FSharp.Core" Version="6.0.7" ExcludeAssets="contentfiles" />
 
-    <PackageReference Include="FSharp.AWS.DynamoDB" Version="0.12.3-beta" />
+    <PackageReference Include="FSharp.AWS.DynamoDB" Version="0.13.0-beta" />
     <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
   </ItemGroup>
 

--- a/tools/Equinox.Tool/Equinox.Tool.fsproj
+++ b/tools/Equinox.Tool/Equinox.Tool.fsproj
@@ -34,7 +34,7 @@
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
     <!-- Required or there'll be an exception at runtime re missing support DLLs when using RBAC -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.177" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.*" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="7.0.0" />
   </ItemGroup>
@@ -45,5 +45,5 @@
       <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths -> WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
     </ItemGroup>
   </Target>
-  
+
 </Project>


### PR DESCRIPTION
This PR bumps `FSharp.AWS.DynamoDB` and `AWSSDK.SecurityToken` dependencies so that consumers can upgrade to latest versions (`4.*`) of AWSSDK packages. 

Related: https://github.com/fsprojects/FSharp.AWS.DynamoDB/issues/84