### PR TITLE
feat(MessageDb): Allows construction of MessageDbClient from NpgsqlDataSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Equinox.DynamoStore`: Update `AWSSDK` dependencies to 4.x (knock-on effect of updating `FSharp.AWS.DynamoDB` dependency to `0.13.0-beta`) [#480](https://github.com/jet/equinox/pull/480) :pray: [@njlr](https://github.com/njlr)
 - `Equinox.SqlStreamStore.MsSql`: Update `System.IdentityModel.Tokens.Jwt` to remove transitive vulnerable defaults [#489](https://github.com/jet/equinox/pull/489)
 - `Equinox.EventStore`: Correct handling for `WrongExpectedVersion` when stream empty [#493](https://github.com/jet/equinox/pull/493)
+- `Equinox.MessageDb`: Provide additional constructors that accept an `NpgsqlDataSource` [#496](https://github.com/jet/equinox/pull/496)
 
 ### Added
 

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -312,10 +312,12 @@ type MessageDbClient internal (reader, writer, ?readRetryPolicy, ?writeRetryPoli
         [<O; D(null)>]?readConnectionString: string,
         [<O; D(null)>]?readRetryPolicy, [<O; D(null)>]?writeRetryPolicy) =
 
-        let dataSource = Npgsql.NpgsqlDataSourceBuilder(connectionString).Build()
+        let buildDatasource connStr = Npgsql.NpgsqlDataSourceBuilder(connStr).Build()
+
+        let dataSource = buildDatasource connectionString
         let readDataSource =
             readConnectionString
-            |> Option.map (fun readConnectionString -> Npgsql.NpgsqlDataSourceBuilder(readConnectionString).Build())
+            |> Option.map buildDatasource
             |> Option.defaultValue dataSource
 
         let reader = MessageDbReader(readDataSource, dataSource)

--- a/src/Equinox.MessageDb/MessageDb.fs
+++ b/src/Equinox.MessageDb/MessageDb.fs
@@ -294,15 +294,32 @@ type MessageDbClient internal (reader, writer, ?readRetryPolicy, ?writeRetryPoli
     member val ReadRetryPolicy = readRetryPolicy
     member val internal Writer = writer
     member val WriteRetryPolicy = writeRetryPolicy
+
+    new(dataSource: Npgsql.NpgsqlDataSource,
+        // Can be used to divert reads to a replica
+        // Conflicts detected on write trigger a resync, reading via the `dataSource` to maximize the freshness of the data for the retry
+        [<O; D(null)>]?readDataSource: Npgsql.NpgsqlDataSource,
+        [<O; D(null)>]?readRetryPolicy, [<O; D(null)>]?writeRetryPolicy) =
+
+        let readDataSource = defaultArg readDataSource dataSource
+        let reader = MessageDbReader(readDataSource, dataSource)
+        let writer = MessageDbWriter(dataSource)
+        MessageDbClient(reader, writer, ?readRetryPolicy = readRetryPolicy, ?writeRetryPolicy = writeRetryPolicy)
+
     new(connectionString: string,
         // Can be used to divert reads to a replica
         // Conflicts detected on write trigger a resync, reading via the `connectionString` to maximize the freshness of the data for the retry
         [<O; D(null)>]?readConnectionString: string,
         [<O; D(null)>]?readRetryPolicy, [<O; D(null)>]?writeRetryPolicy) =
 
-        let readConnectionString = defaultArg readConnectionString connectionString
-        let reader = MessageDbReader(readConnectionString, connectionString)
-        let writer = MessageDbWriter(connectionString)
+        let dataSource = Npgsql.NpgsqlDataSourceBuilder(connectionString).Build()
+        let readDataSource =
+            readConnectionString
+            |> Option.map (fun readConnectionString -> Npgsql.NpgsqlDataSourceBuilder(readConnectionString).Build())
+            |> Option.defaultValue dataSource
+
+        let reader = MessageDbReader(readDataSource, dataSource)
+        let writer = MessageDbWriter(dataSource)
         MessageDbClient(reader, writer, ?readRetryPolicy = readRetryPolicy, ?writeRetryPolicy = writeRetryPolicy)
 
 type BatchOptions(getBatchSize: Func<int>, [<O; D(null)>]?batchCountLimit) =

--- a/src/Equinox.MessageDb/MessageDbClient.fs
+++ b/src/Equinox.MessageDb/MessageDbClient.fs
@@ -19,10 +19,6 @@ type MdbSyncResult = Written of int64 | ConflictUnknown
 [<AutoOpen>]
 module private NpgsqlHelpers =
 
-    let inline createConnectionAndOpen (dataSource: Npgsql.NpgsqlDataSource) ct = task {
-            let! conn = dataSource.OpenConnectionAsync(ct)
-            return conn }
-
     type NpgsqlParameterCollection with
         member p.AddParameter<'T>(parameterType: NpgsqlDbType, value: 'T voption) =
             p.AddWithValue(parameterType, match value with ValueSome v -> box v | ValueNone -> DBNull.Value) |> ignore
@@ -56,7 +52,7 @@ module private WriteMessage =
 type internal MessageDbWriter(dataSource: Npgsql.NpgsqlDataSource) =
 
     member _.WriteMessages(streamName, events: _[], version, onSync, ct) = task {
-        use! conn = createConnectionAndOpen dataSource ct
+        use! conn = dataSource.OpenConnectionAsync(ct)
         use transaction = conn.BeginTransaction()
         use batch = new NpgsqlBatch(conn, transaction)
         let toAppendCall i e =

--- a/src/Equinox.MessageDb/MessageDbClient.fs
+++ b/src/Equinox.MessageDb/MessageDbClient.fs
@@ -91,8 +91,6 @@ module private ReadStream =
 
 type internal MessageDbReader (dataSource: Npgsql.NpgsqlDataSource, leaderDataSource: Npgsql.NpgsqlDataSource) =
 
-    let selectDatasource requiresLeader = if requiresLeader then leaderDataSource else dataSource
-
     let parseRow (reader: DbDataReader): ITimelineEvent<Format> =
         let et, data, meta = reader.GetString(1), reader.GetJson(2), reader.GetJson(3)
         FsCodec.Core.TimelineEvent.Create(
@@ -102,7 +100,7 @@ type internal MessageDbReader (dataSource: Npgsql.NpgsqlDataSource, leaderDataSo
             size = et.Length + data.Length + meta.Length)
 
     member _.ReadLastEvent(streamName: string, requiresLeader, ct, ?eventType) = task {
-        let dataSource = selectDatasource requiresLeader
+        let dataSource = if requiresLeader then leaderDataSource else dataSource
         use! conn = dataSource.OpenConnectionAsync(ct)
         use cmd = ReadLast.prepareCommand conn streamName eventType
         use! reader = cmd.ExecuteReaderAsync(ct)
@@ -111,7 +109,7 @@ type internal MessageDbReader (dataSource: Npgsql.NpgsqlDataSource, leaderDataSo
         else return Array.empty }
 
     member _.ReadStream(streamName: string, fromPosition: int64, batchSize: int64, requiresLeader, ct) = task {
-        let dataSource = selectDatasource requiresLeader
+        let dataSource = if requiresLeader then leaderDataSource else dataSource
         use! conn = dataSource.OpenConnectionAsync(ct)
         use cmd = ReadStream.prepareCommand conn streamName fromPosition batchSize
         use! reader = cmd.ExecuteReaderAsync(ct)

--- a/src/Equinox.MessageDb/MessageDbClient.fs
+++ b/src/Equinox.MessageDb/MessageDbClient.fs
@@ -19,7 +19,7 @@ type MdbSyncResult = Written of int64 | ConflictUnknown
 [<AutoOpen>]
 module private NpgsqlHelpers =
 
-    let createConnectionAndOpen (dataSource: Npgsql.NpgsqlDataSource) ct = task {
+    let inline createConnectionAndOpen (dataSource: Npgsql.NpgsqlDataSource) ct = task {
             let! conn = dataSource.OpenConnectionAsync(ct)
             return conn }
 

--- a/src/Equinox.MessageDb/MessageDbClient.fs
+++ b/src/Equinox.MessageDb/MessageDbClient.fs
@@ -95,7 +95,7 @@ module private ReadStream =
 
 type internal MessageDbReader (dataSource: Npgsql.NpgsqlDataSource, leaderDataSource: Npgsql.NpgsqlDataSource) =
 
-    let connect requiresLeader = createConnectionAndOpen (if requiresLeader then leaderDataSource else dataSource)
+    let selectDatasource requiresLeader = if requiresLeader then leaderDataSource else dataSource
 
     let parseRow (reader: DbDataReader): ITimelineEvent<Format> =
         let et, data, meta = reader.GetString(1), reader.GetJson(2), reader.GetJson(3)
@@ -106,7 +106,8 @@ type internal MessageDbReader (dataSource: Npgsql.NpgsqlDataSource, leaderDataSo
             size = et.Length + data.Length + meta.Length)
 
     member _.ReadLastEvent(streamName: string, requiresLeader, ct, ?eventType) = task {
-        use! conn = connect requiresLeader ct
+        let dataSource = selectDatasource requiresLeader
+        use! conn = dataSource.OpenConnectionAsync(ct)
         use cmd = ReadLast.prepareCommand conn streamName eventType
         use! reader = cmd.ExecuteReaderAsync(ct)
 
@@ -114,7 +115,8 @@ type internal MessageDbReader (dataSource: Npgsql.NpgsqlDataSource, leaderDataSo
         else return Array.empty }
 
     member _.ReadStream(streamName: string, fromPosition: int64, batchSize: int64, requiresLeader, ct) = task {
-        use! conn = connect requiresLeader ct
+        let dataSource = selectDatasource requiresLeader
+        use! conn = dataSource.OpenConnectionAsync(ct)
         use cmd = ReadStream.prepareCommand conn streamName fromPosition batchSize
         use! reader = cmd.ExecuteReaderAsync(ct)
 

--- a/src/Equinox.MessageDb/MessageDbClient.fs
+++ b/src/Equinox.MessageDb/MessageDbClient.fs
@@ -19,10 +19,9 @@ type MdbSyncResult = Written of int64 | ConflictUnknown
 [<AutoOpen>]
 module private NpgsqlHelpers =
 
-    let createConnectionAndOpen connectionString ct = task {
-        let conn = new NpgsqlConnection(connectionString)
-        do! conn.OpenAsync(ct)
-        return conn }
+    let createConnectionAndOpen (dataSource: Npgsql.NpgsqlDataSource) ct = task {
+            let! conn = dataSource.OpenConnectionAsync(ct)
+            return conn }
 
     type NpgsqlParameterCollection with
         member p.AddParameter<'T>(parameterType: NpgsqlDbType, value: 'T voption) =
@@ -54,10 +53,10 @@ module private WriteMessage =
         cmd.Parameters.AddExpectedVersion(expectedVersion)
         cmd
 
-type internal MessageDbWriter(connectionString: string) =
+type internal MessageDbWriter(dataSource: Npgsql.NpgsqlDataSource) =
 
     member _.WriteMessages(streamName, events: _[], version, onSync, ct) = task {
-        use! conn = createConnectionAndOpen connectionString ct
+        use! conn = createConnectionAndOpen dataSource ct
         use transaction = conn.BeginTransaction()
         use batch = new NpgsqlBatch(conn, transaction)
         let toAppendCall i e =
@@ -94,9 +93,9 @@ module private ReadStream =
         cmd.Parameters.AddWithValue(NpgsqlDbType.Bigint, batchSize) |> ignore
         cmd
 
-type internal MessageDbReader (connectionString: string, leaderConnectionString: string) =
+type internal MessageDbReader (dataSource: Npgsql.NpgsqlDataSource, leaderDataSource: Npgsql.NpgsqlDataSource) =
 
-    let connect requiresLeader = createConnectionAndOpen (if requiresLeader then leaderConnectionString else connectionString)
+    let connect requiresLeader = createConnectionAndOpen (if requiresLeader then leaderDataSource else dataSource)
 
     let parseRow (reader: DbDataReader): ITimelineEvent<Format> =
         let et, data, meta = reader.GetString(1), reader.GetJson(2), reader.GetJson(3)

--- a/tests/Equinox.MessageDb.Integration/Equinox.MessageDb.Integration.fsproj
+++ b/tests/Equinox.MessageDb.Integration/Equinox.MessageDb.Integration.fsproj
@@ -23,8 +23,8 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.28" />
     <PackageReference Include="FsCheck.Xunit.v3" Version="3.3.2" />
-    <PackageReference Include="OpenTelemetry" Version="1.4.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0-beta.3" />
+    <PackageReference Include="OpenTelemetry" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="7.0.0" />
     <PackageReference Include="unquote" Version="7.0.0" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />


### PR DESCRIPTION
Enables construction of MessageDb components from an `NpgsqlDataSource`. 

Closes https://github.com/jet/equinox/issues/495